### PR TITLE
Github: Remove PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,5 @@
 
 We welcome contributions to Qt!
 
-Note that all contributions to the Qt project are exclusively handled through the [Gerrit code review system](https://codereview.qt-project.org).
-
 Read the
 [Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.


### PR DESCRIPTION
Since we migrated to Github, we no longer need to use Gerrit.

