### PR TITLE
qt-cli: Add packaging configuration file

### DIFF
--- a/qt-cli/.gitignore
+++ b/qt-cli/.gitignore
@@ -1,1 +1,1 @@
-qtcli
+dist/

--- a/qt-cli/.goreleaser.yaml
+++ b/qt-cli/.goreleaser.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+project_name: qtcli
+builds:
+  - id: qtcli
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s # strip symbol table
+      - -w # strip DWARF debugging information
+      - -X main.version={{ .Version }}
+    binary: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- .Arch }}
+    no_unique_dist_dir: true
+    ignore:
+      - goos: linux
+        goarch: arm64
+      - goos: windows
+        goarch: arm64
+
+universal_binaries:
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_darwin_fat
+    hooks:
+      post: cp {{ .Path }} {{ dir .Path }}/../{{ .Name }} # get out of sub-directory
+
+snapshot:
+  version_template: '{{ .Version }}'
+
+checksum:
+  disable: true
+
+archives:
+  - format: binary

--- a/qt-cli/Development.md
+++ b/qt-cli/Development.md
@@ -1,0 +1,53 @@
+## Build
+
+For building a native exectuable, use the `build` command.
+
+```bash
+$ go build .
+```
+
+This will generate the `qtcli` executable for your current platform and architecture.
+
+## Cross-Platform Build
+
+To build for a different platform and architecture, set `GOOS` and `GOARCH` environment variables:
+
+For example, if you run,
+
+```bash
+$ GOOS=darwin GOARCH=arm64 go build .
+$ GOOS=windows GOARCH=amd64 go build .
+```
+
+The result will be,
+
+```bash
+$ file qtcli
+qtcli: Mach-O 64-bit arm64 executable, flags:<|DYLDLINK|PIE>
+$ file qtcli.exe
+qtcli.exe: PE32+ executable (console) x86-64, for MS Windows, 15 sections
+```
+
+## Packaging
+
+This project uses `goreleaser` to simplify the deployment step. Install it with:
+
+```bash
+$ go install github.com/goreleaser/goreleaser/v2@latest
+```
+
+### Making a Snapshot
+
+To build binaries and archives for the current state of your project:
+
+```bash
+$ goreleaser --snapshot --clean --skip=publish
+```
+
+Artifacts will be saved in the `dist/` folder.
+
+If your project doesn't have a valid `Git` tag, set the `GORELEASER_CURRENT_TAG` environment variable:
+
+```bash
+$ GORELEASER_CURRENT_TAG=v1.0.0 goreleaser --snapshot --clean --skip=publish
+```

--- a/qt-cli/cmd/root.go
+++ b/qt-cli/cmd/root.go
@@ -16,7 +16,6 @@ var verbose bool
 var rootCmd = &cobra.Command{
 	Use:     "qtcli",
 	Short:   util.Msg("A CLI for creating Qt project and files"),
-	Version: "0.1",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if verbose {
 			logrus.SetLevel(logrus.DebugLevel)
@@ -32,6 +31,10 @@ func Execute() {
 	if err != nil {
 		os.Exit(1)
 	}
+}
+
+func SetVersion(v string) {
+	rootCmd.Version = v
 }
 
 func init() {

--- a/qt-cli/main.go
+++ b/qt-cli/main.go
@@ -7,6 +7,9 @@ import (
 	"qtcli/cmd"
 )
 
+var version = "dev"
+
 func main() {
+	cmd.SetVersion(version)
 	cmd.Execute()
 }


### PR DESCRIPTION
Added a `goreleaser` definition file.
Defined build configurations for Linux, Windows, and macOS, including universal binary generation for macOS.
Added `Development.md` to document the process.
