### PR TITLE
qt-core: Add new project and file creation feature

### DIFF
--- a/qt-core/package.json
+++ b/qt-core/package.json
@@ -72,6 +72,16 @@
         "command": "qt-core.registerQtByQtpaths",
         "title": "%qt-core.command.registerQtByQtpaths.title%",
         "category": "Qt"
+      },
+      {
+        "command": "qt-core.createNewFile",
+        "title": "%qt-core.command.createNewFile.title%",
+        "category": "Qt"
+      },
+      {
+        "command": "qt-core.createNewProject",
+        "title": "%qt-core.command.createNewProject.title%",
+        "category": "Qt"
       }
     ],
     "languages": [

--- a/qt-core/package.nls.json
+++ b/qt-core/package.nls.json
@@ -6,5 +6,7 @@
   "qt-core.command.setRecommendedSettings.title": "Set the recommended Qt Extension settings",
   "qt-core.command.registerQt.title": "Register Qt Installation",
   "qt-core.command.reset.title": "Reset Qt Tools Extension State (For troubleshooting)",
-  "qt-core.command.registerQtByQtpaths.title": "Register Qt (by qtpaths or qmake)"
+  "qt-core.command.registerQtByQtpaths.title": "Register Qt (by qtpaths or qmake)",
+  "qt-core.command.createNewFile.title": "Create New File",
+  "qt-core.command.createNewProject.title": "Create New Project"
 }

--- a/qt-core/src/extension.ts
+++ b/qt-core/src/extension.ts
@@ -25,6 +25,7 @@ import { EXTENSION_ID } from '@/constants';
 import { createCoreProject, CoreProjectManager } from '@/project';
 import { resetCommand } from '@/reset';
 import { registerQtByQtpaths } from '@/qtpaths';
+import { newFileCommand, newProjectCommand } from '@/qtcli/commands';
 import { checkVcpkg } from '@/vcpkg';
 
 const logger = createLogger('extension');
@@ -50,6 +51,8 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(registerSetRecommendedSettingsCommand());
   context.subscriptions.push(resetCommand());
   context.subscriptions.push(registerQtByQtpaths());
+  context.subscriptions.push(newFileCommand(context));
+  context.subscriptions.push(newProjectCommand(context));
   context.subscriptions.push(
     vscode.commands.registerCommand(`${EXTENSION_ID}.openSettings`, () => {
       telemetry.sendAction('openSettings');

--- a/qt-core/src/qtcli/commands.ts
+++ b/qt-core/src/qtcli/commands.ts
@@ -1,0 +1,100 @@
+// Copyright (C) 2024 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import { EXTENSION_ID } from '@/constants';
+import { QtcliRunner } from '@/qtcli/runner';
+import { QtcliNewNameInput } from '@/qtcli/new-name-input';
+import { QtcliExeFinder } from '@/qtcli/exe-finder';
+import {
+  QtcliAction,
+  findActiveTabUri,
+  fallbackWorkingDir,
+  logger
+} from '@/qtcli/common';
+
+let runner: QtcliRunner | undefined = undefined;
+let newProjectBaseDir: string | undefined = undefined;
+
+export function newFileCommand(context: vscode.ExtensionContext) {
+  return vscode.commands.registerCommand(
+    `${EXTENSION_ID}.createNewFile`,
+    () => {
+      void askNameAndRun(QtcliAction.NewFile, context);
+    }
+  );
+}
+
+export function newProjectCommand(context: vscode.ExtensionContext) {
+  return vscode.commands.registerCommand(
+    `${EXTENSION_ID}.createNewProject`,
+    () => {
+      void askNameAndRun(QtcliAction.NewProject, context);
+    }
+  );
+}
+
+async function askNameAndRun(
+  action: QtcliAction,
+  context: vscode.ExtensionContext
+) {
+  const exePath = await findQtcliExePath(context);
+  if (!exePath) {
+    const msg = 'Could not find qtcli executable.';
+    logger.error(msg);
+    void vscode.window.showErrorMessage(
+      msg +
+        ' ' +
+        'Please ensure that a qtcli executable is available in your PATH.'
+    );
+    return;
+  }
+
+  const input = new QtcliNewNameInput(action);
+  input.setWorkingDir(findWorkingDir(action));
+  input.onDidChangeWorkingDir((dir) => {
+    if (action === QtcliAction.NewProject) {
+      newProjectBaseDir = dir;
+    }
+  });
+  input.onDidAccept(() => {
+    const value = input.getValue().trim();
+    if (value.length === 0 || !input.hasValidInput()) {
+      return;
+    }
+
+    if (!runner) {
+      runner = new QtcliRunner();
+    }
+
+    runner.setQtcliExePath(exePath);
+    runner.setWorkingDir(input.getWorkingDir());
+    void runner.run(action, value);
+  });
+  input.show();
+}
+
+async function findQtcliExePath(context: vscode.ExtensionContext) {
+  const finder = new QtcliExeFinder();
+  finder.addPossibleDir(process.cwd());
+  finder.addPossibleDir((process.env.PATH ?? '').split(path.delimiter));
+  finder.addPossibleDir(path.join(context.extensionPath, 'res', 'qtcli'));
+
+  return finder.run();
+}
+
+function findWorkingDir(action: QtcliAction) {
+  if (action === QtcliAction.NewProject) {
+    return newProjectBaseDir ?? fallbackWorkingDir();
+  }
+
+  const activeFileUri = findActiveTabUri();
+  if (activeFileUri) {
+    return path.dirname(activeFileUri.fsPath);
+  }
+
+  const anyFolder = vscode.workspace.workspaceFolders?.[0];
+  return anyFolder ? anyFolder.uri.fsPath : fallbackWorkingDir();
+}

--- a/qt-core/src/qtcli/common.ts
+++ b/qt-core/src/qtcli/common.ts
@@ -1,0 +1,112 @@
+// Copyright (C) 2024 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as os from 'os';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { spawnSync } from 'child_process';
+
+import { createLogger, isError } from 'qt-lib';
+
+export enum QtcliAction {
+  NewFile,
+  NewProject
+}
+
+export const logger = createLogger('qtcli');
+
+export function errorString<T>(e: T) {
+  return isError(e) ? e.message : String(e);
+}
+
+export function isValidQtcliPath(qtcliPath: string): boolean {
+  const res = spawnSync(qtcliPath, ['--help'], {
+    timeout: 1000
+  });
+
+  return res.status === 0;
+}
+
+export function isValidNewName(name: string): boolean {
+  const o = name.trim();
+  if (o.length === 0) {
+    return false;
+  }
+
+  const regex = /^[a-zA-Z0-9-_]+$/;
+  return regex.test(o);
+}
+
+export function fallbackWorkingDir(): string {
+  return path.join(os.homedir(), 'Documents');
+}
+
+export async function openUri(uri: vscode.Uri) {
+  try {
+    const stats = await fs.stat(uri.fsPath);
+
+    if (stats.isFile()) {
+      void vscode.commands.executeCommand('vscode.open', uri);
+      return;
+    }
+
+    if (stats.isDirectory()) {
+      vscode.workspace.updateWorkspaceFolders(
+        vscode.workspace.workspaceFolders?.length ?? 0,
+        null,
+        { uri }
+      );
+
+      const disposable = vscode.workspace.onDidChangeWorkspaceFolders(
+        async () => {
+          const fileToOpen = await findPrimaryFileUnder(uri.fsPath);
+          if (fileToOpen) {
+            void vscode.commands.executeCommand(
+              'vscode.open',
+              vscode.Uri.file(fileToOpen)
+            );
+          }
+
+          disposable.dispose();
+        }
+      );
+    }
+  } catch (e) {
+    logger.warn('cannot open:', uri.fsPath);
+  }
+}
+
+export async function findPrimaryFileUnder(dir: string) {
+  try {
+    const patterns = [/Main.qml$/i, /main\.cpp$/i, /CMakeLists.txt$/];
+    const files = await fs.readdir(dir);
+
+    for (const pattern of patterns) {
+      for (const file of files) {
+        const filePath = path.join(dir, file);
+        if (pattern.test(file)) {
+          return filePath;
+        }
+      }
+    }
+  } catch (e) {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+export function findActiveTabUri(): vscode.Uri | undefined {
+  const tab = vscode.window.tabGroups.activeTabGroup.activeTab;
+  const input = tab?.input;
+
+  if (input instanceof vscode.TabInputText) {
+    return input.uri;
+  } else if (input instanceof vscode.TabInputCustom) {
+    // handle the case when a custom editor is used. (e.g. .qrc)
+    return input.uri;
+  }
+
+  return undefined;
+}

--- a/qt-core/src/qtcli/exe-finder.ts
+++ b/qt-core/src/qtcli/exe-finder.ts
@@ -1,0 +1,65 @@
+// Copyright (C) 2024 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+import { isValidQtcliPath, logger, errorString } from './common';
+
+export class QtcliExeFinder {
+  private readonly _dirCandidates: string[] = [];
+
+  public addPossibleDir(dirs: string | string[]) {
+    if (typeof dirs === 'string') {
+      this._dirCandidates.push(dirs);
+    } else {
+      this._dirCandidates.push(...dirs);
+    }
+  }
+
+  public async run() {
+    try {
+      const prefix = findQtcliPrefix();
+
+      for (const dir of this._dirCandidates) {
+        const fullPath = await findQtcliIn(dir, prefix);
+        if (fullPath) {
+          return fullPath;
+        }
+      }
+    } catch (e) {
+      logger.error('cannot run qtcli:', errorString(e));
+    }
+
+    return undefined;
+  }
+}
+
+function findQtcliPrefix(): string {
+  const platform = process.platform;
+
+  if (platform === 'win32') {
+    return 'qtcli_windows';
+  } else if (platform === 'darwin') {
+    return 'qtcli_macos';
+  } else if (platform === 'linux') {
+    return 'qtcli_ubuntu';
+  } else {
+    throw new Error(`Platform '${platform}' is not supported`);
+  }
+}
+
+async function findQtcliIn(dir: string, prefix: string) {
+  const files = await fs.readdir(dir, { withFileTypes: true });
+
+  for (const file of files) {
+    if (file.isFile() && file.name.startsWith(prefix)) {
+      const fullPath = path.join(dir, file.name);
+      if (isValidQtcliPath(fullPath)) {
+        return fullPath;
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/qt-core/src/qtcli/new-name-input.ts
+++ b/qt-core/src/qtcli/new-name-input.ts
@@ -1,0 +1,115 @@
+// Copyright (C) 2024 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+
+import { QtcliAction, fallbackWorkingDir, isValidNewName } from './common';
+
+export class QtcliNewNameInput {
+  private _value = '';
+  private _workingDir = fallbackWorkingDir();
+  private readonly _input: vscode.InputBox;
+  private readonly _disposables: vscode.Disposable[] = [];
+
+  public onDidAccept: vscode.Event<void>;
+  public onDidChangeWorkingDir: vscode.Event<string>;
+  private readonly _onDidAcceptEmitter: vscode.EventEmitter<void>;
+  private readonly _onDidChangeWorkingDirEmitter: vscode.EventEmitter<string>;
+
+  constructor(action: QtcliAction) {
+    this._input = vscode.window.createInputBox();
+    this._input.value = 'untitled';
+    this._input.title =
+      action === QtcliAction.NewFile ? 'New File' : 'New Project';
+    this._input.placeholder =
+      action === QtcliAction.NewFile
+        ? 'Enter a file name to create'
+        : 'Enter a project name to create';
+    this._input.buttons = [
+      {
+        iconPath: new vscode.ThemeIcon('folder'),
+        tooltip: 'Select a base directory'
+      }
+    ];
+
+    this._disposables = [
+      this._input.onDidAccept(this._onAccepted.bind(this)),
+      this._input.onDidTriggerButton(this._onButtonTriggered.bind(this)),
+      this._input.onDidChangeValue(this._updateValidationMessage.bind(this))
+    ];
+
+    this._onDidAcceptEmitter = new vscode.EventEmitter<void>();
+    this._onDidChangeWorkingDirEmitter = new vscode.EventEmitter<string>();
+    this.onDidAccept = this._onDidAcceptEmitter.event;
+    this.onDidChangeWorkingDir = this._onDidChangeWorkingDirEmitter.event;
+  }
+
+  dispose() {
+    for (const d of this._disposables) {
+      d.dispose();
+    }
+
+    this._input.dispose();
+  }
+
+  public getValue(): string {
+    return this._value;
+  }
+
+  public getWorkingDir(): string {
+    return this._workingDir;
+  }
+
+  public hasValidInput(): boolean {
+    return this._input.validationMessage === undefined;
+  }
+
+  public setWorkingDir(dir: string) {
+    this._workingDir = dir;
+  }
+
+  public show() {
+    this._updateUi();
+    this._input.show();
+  }
+
+  private _updateUi() {
+    this._input.prompt = this._workingDir;
+  }
+
+  private _onAccepted() {
+    this._value = this._input.value;
+    this._onDidAcceptEmitter.fire();
+    this._input.hide();
+  }
+
+  private async _onButtonTriggered() {
+    const options: vscode.OpenDialogOptions = {
+      canSelectMany: false,
+      canSelectFolders: true,
+      canSelectFiles: false,
+      openLabel: 'Select Directory',
+      defaultUri: vscode.Uri.file(this._workingDir)
+    };
+
+    const folderUri = await vscode.window.showOpenDialog(options);
+    if (folderUri && folderUri.length > 0) {
+      this._workingDir = folderUri[0]?.fsPath ?? '';
+      this._onDidChangeWorkingDirEmitter.fire(this._workingDir);
+    }
+
+    this.show();
+  }
+
+  private _updateValidationMessage() {
+    if (isValidNewName(this._input.value)) {
+      this._input.validationMessage = undefined;
+      return;
+    }
+
+    this._input.validationMessage = {
+      message: '',
+      severity: vscode.InputBoxValidationSeverity.Warning
+    };
+  }
+}

--- a/qt-core/src/qtcli/runner.ts
+++ b/qt-core/src/qtcli/runner.ts
@@ -1,0 +1,116 @@
+// Copyright (C) 2024 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as os from 'os';
+import * as fs from 'fs/promises';
+import * as vscode from 'vscode';
+
+import { QtcliAction, openUri, logger, errorString } from '@/qtcli/common';
+
+export class QtcliRunner {
+  private _workingDir = os.homedir();
+  private _qtcliExecPath = '';
+  private _terminal: vscode.Terminal | undefined = undefined;
+  private _fsDisposables: vscode.Disposable[] = [];
+  private _terminalDisposables: vscode.Disposable[] = [];
+
+  dispose() {
+    if (this._terminal) {
+      this._terminal.dispose();
+      this._terminal = undefined;
+
+      for (const d of this._terminalDisposables) {
+        d.dispose();
+      }
+
+      this._terminalDisposables = [];
+      this._disposeFsWatcher();
+    }
+  }
+
+  private _disposeFsWatcher() {
+    for (const d of this._fsDisposables) {
+      d.dispose();
+    }
+
+    this._fsDisposables = [];
+  }
+
+  public setWorkingDir(dir: string) {
+    if (this._workingDir !== dir) {
+      this._workingDir = dir;
+      this.dispose();
+    }
+  }
+
+  public setQtcliExePath(fullPath: string) {
+    this._qtcliExecPath = fullPath;
+  }
+
+  public async run(action: QtcliAction, arg: string) {
+    try {
+      await fs.mkdir(this._workingDir, { recursive: true });
+      this._disposeFsWatcher();
+      this._setupFsWatcher(action, arg);
+
+      if (action === QtcliAction.NewProject) {
+        this._runQtcli(['new', arg]);
+      } else {
+        this._runQtcli(['new-file', arg]);
+      }
+    } catch (e) {
+      logger.error('cannot run qtcli:', errorString(e));
+    }
+  }
+
+  private _setupFsWatcher(action: QtcliAction, arg: string) {
+    const watcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(
+        this._workingDir,
+        action === QtcliAction.NewFile ? `${arg}.*` : `${arg}/`
+      )
+    );
+
+    this._fsDisposables.push(watcher);
+    this._fsDisposables.push(
+      watcher.onDidCreate((uri) => {
+        void openUri(uri);
+        this._disposeFsWatcher();
+      })
+    );
+  }
+
+  private _runQtcli(args: string[]) {
+    this._ensureTerminalIsValid();
+
+    if (this._terminal) {
+      this._terminal.show();
+      this._terminal.sendText(`${this._qtcliExecPath} ${args.join(' ')}`);
+    }
+  }
+
+  private _ensureTerminalIsValid() {
+    if (this._terminal) {
+      return;
+    }
+
+    this._terminal = vscode.window.createTerminal({
+      name: 'qtcli',
+      cwd: this._workingDir
+    });
+
+    this._terminalDisposables.push(
+      vscode.window.onDidCloseTerminal((t) => {
+        if (t === this._terminal) {
+          this.dispose();
+        }
+      }),
+
+      vscode.window.onDidEndTerminalShellExecution((e) => {
+        if (e.terminal === this._terminal && e.exitCode === 0) {
+          this._terminal.hide();
+        }
+      })
+    );
+  }
+}


### PR DESCRIPTION
Added two commands for creating a new project and file. Included an input UI to gather a name from the user. After receiving a name, `qtcli` is executed in the terminal to get additional inputs.

The qtcli binary is searched in the current directory, system path, and the extensions's res/qtcli folder.
The qtcli binary name is expected to start with `qtcli_`, followed by the platform identifier (`windows`, `macos`, or `ubuntu`).

Task-number: VSCODEEXT-22