### PR TITLE
qt-core: Add color provider for qss files

### DIFF
--- a/qt-core/src/extension.ts
+++ b/qt-core/src/extension.ts
@@ -9,7 +9,8 @@ import {
   initLogger,
   QtInsRootConfigName,
   AdditionalQtPathsName,
-  telemetry
+  telemetry,
+  createColorProvider
 } from 'qt-lib';
 import { CoreAPIImpl } from '@/api';
 import { registerDocumentationCommands } from '@/online-docs';
@@ -61,6 +62,10 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(`${EXTENSION_ID}.registerQt`, registerQt)
   );
+  context.subscriptions.push(
+    vscode.languages.registerColorProvider('qss', createColorProvider())
+  );
+
   telemetry.sendEvent(`activated`);
 
   checkDefaultQtInsRootPath();

--- a/qt-lib/src/color-provider.ts
+++ b/qt-lib/src/color-provider.ts
@@ -3,14 +3,7 @@
 
 import * as vscode from 'vscode';
 
-export function registerColorProvider() {
-  return vscode.languages.registerColorProvider(
-    'qml',
-    createArgbHexColorProvider()
-  );
-}
-
-function createArgbHexColorProvider() {
+export function createColorProvider() {
   return {
     provideDocumentColors(document: vscode.TextDocument) {
       const regex = /#[0-9a-f]{3,8}\b/gi;

--- a/qt-lib/src/index.ts
+++ b/qt-lib/src/index.ts
@@ -5,3 +5,4 @@ export * from './core-api';
 export * from './constants';
 export * from './state';
 export * from './telemetry';
+export * from './color-provider';

--- a/qt-qml/src/extension.ts
+++ b/qt-qml/src/extension.ts
@@ -10,9 +10,9 @@ import {
   initLogger,
   telemetry,
   QtWorkspaceConfigMessage,
-  waitForQtCpp
+  waitForQtCpp,
+  createColorProvider
 } from 'qt-lib';
-import { registerColorProvider } from '@/color-provider';
 import { registerRestartQmllsCommand } from '@cmd/restart-qmlls';
 import { registerDownloadQmllsCommand } from '@cmd/download-qmlls';
 import { registerCheckQmllsUpdateCommand } from '@cmd/check-qmlls-update';
@@ -58,7 +58,7 @@ export async function activate(context: vscode.ExtensionContext) {
     registerRestartQmllsCommand(),
     registerCheckQmllsUpdateCommand(),
     registerDownloadQmllsCommand(),
-    registerColorProvider(),
+    vscode.languages.registerColorProvider('qml', createColorProvider()),
     registerResetCommand()
   );
   telemetry.sendEvent(`activated`);


### PR DESCRIPTION
Ensures the same color-editing experience like QML files. 
Supports #RGB, #RRGGBB, and #AARRGGBB color formats.

Task-number: VSCODEEXT-119
