### PR TITLE
qt-core: Fix the qtcli finder failure due to invalid folder in PATH

### DIFF
--- a/qt-core/src/qtcli/exe-finder.ts
+++ b/qt-core/src/qtcli/exe-finder.ts
@@ -50,15 +50,19 @@ function findQtcliPrefix(): string {
 }
 
 async function findQtcliIn(dir: string, prefix: string) {
-  const files = await fs.readdir(dir, { withFileTypes: true });
+  try {
+    const files = await fs.readdir(dir, { withFileTypes: true });
 
-  for (const file of files) {
-    if (file.isFile() && file.name.startsWith(prefix)) {
-      const fullPath = path.join(dir, file.name);
-      if (isValidQtcliPath(fullPath)) {
-        return fullPath;
+    for (const file of files) {
+      if (file.isFile() && file.name.startsWith(prefix)) {
+        const fullPath = path.join(dir, file.name);
+        if (isValidQtcliPath(fullPath)) {
+          return fullPath;
+        }
       }
     }
+  } catch (e) {
+    return undefined;
   }
 
   return undefined;


### PR DESCRIPTION
A non-existing folder in PATH can raise an exception during the `qtcli` binary search, causing the entire search to stop. This patch fixes that.