### PR TITLE
ci-scripts: Fix wrong `.ts` evaluation in `qt-cli`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 .eslintrc.cjs
+qt-cli/**


### PR DESCRIPTION
Since `qt-cli/src/assets/templates/common/file.ts` is not a TypeScript file, it should not be evaluated as such. The problem is introduced in https://github.com/qt-labs/vscodeext/actions/runs/12668910412/job/35305279040
