### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ src/test/util/dependencies
 .cache
 .eslintcache
 tsconfig.tsbuildinfo
+qt-core/res/qtcli/*


### PR DESCRIPTION
Since we ship `qtcli` with `qt-core`, we need to ignore the `qtcli` folder in the `qt-core/res` folder.
