### PR TITLE
qt-cli: Include more build information in binary

### DIFF
--- a/qt-cli/.goreleaser.yaml
+++ b/qt-cli/.goreleaser.yaml
@@ -2,6 +2,11 @@
 version: 2
 
 project_name: qtcli
+
+env:
+  - VERSION=1.5.0
+  - CGO_ENABLED=0
+
 builds:
   - id: qtcli
     dir: ./src
@@ -12,17 +17,18 @@ builds:
     goarch:
       - amd64
       - arm64
-    env:
-      - CGO_ENABLED=0
     ldflags:
       - -s # strip symbol table
       - -w # strip DWARF debugging information
-      - -X main.version={{ .Version }}
+      - -X main.version={{ .Env.VERSION }}
+      - -X main.timestamp={{ .Timestamp }}
+      - -X main.commit={{ .FullCommit }}
+
     binary: >-
       {{ .ProjectName }}_
       {{- .Os }}_
       {{- .Arch }}_
-      {{- .Version }}
+      {{- .Env.VERSION }}
     no_unique_dist_dir: true
     ignore:
       - goos: linux
@@ -33,12 +39,12 @@ builds:
 universal_binaries:
   - name_template: >-
       {{ .ProjectName }}_darwin_fat_
-      {{- .Version }}
+      {{- .Env.VERSION }}
     hooks:
       post: cp {{ .Path }} {{ dir .Path }}/../{{ .Name }} # get out of sub-directory
 
 snapshot:
-  version_template: '{{ .Version }}'
+  version_template: '{{ .Env.VERSION }}'
 
 checksum:
   disable: true

--- a/qt-cli/Development.md
+++ b/qt-cli/Development.md
@@ -47,9 +47,3 @@ $ goreleaser --snapshot --clean --skip=publish
 ```
 
 Artifacts will be saved in the `dist/` folder.
-
-If your project doesn't have a valid `Git` tag, set the `GORELEASER_CURRENT_TAG` environment variable:
-
-```bash
-$ GORELEASER_CURRENT_TAG=v1.0.0 goreleaser --snapshot --clean --skip=publish
-```

--- a/qt-cli/src/main.go
+++ b/qt-cli/src/main.go
@@ -4,12 +4,38 @@
 package main
 
 import (
+	"strconv"
+	"strings"
+	"time"
 	"qtcli/cmds"
 )
 
 var version = "dev"
+var timestamp = ""
+var commit = ""
 
 func main() {
-	cmds.SetVersion(version)
+	cmds.SetVersion(formatVersion(version, timestamp, commit))
 	cmds.Execute()
+}
+
+func formatVersion(version, timestamp, commit string) string {
+	info := []string{}
+	unixtime, err := strconv.ParseInt(timestamp, 10, 64)
+	if err == nil {
+		info = append(info, time.Unix(unixtime, 0).UTC().Format(time.RFC3339))
+	}
+
+	if len(commit) > 10 {
+		info = append(info, commit[:10])
+	} else if len(commit) > 0 {
+		info = append(info, commit)
+	}
+
+	details := strings.Join(info, ", ")
+	if len(details) == 0 {
+		return version
+	} else {
+		return version + " (" + details + ")"
+	}
 }


### PR DESCRIPTION
Update the build configuration file to include a version number. 
Additionally, timestamp and commit hash are now injected into binary 
to provide more detailed build information in runtime.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
