### PR TITLE
qt-core: Remove F1 key binding for help

### DIFF
--- a/qt-core/package.json
+++ b/qt-core/package.json
@@ -134,12 +134,6 @@
         }
       }
     ],
-    "keybindings": [
-      {
-        "key": "f1",
-        "command": "qt-core.documentationSearchForCurrentWord"
-      }
-    ],
     "grammars": [
       {
         "language": "qdoc",


### PR DESCRIPTION
Since the F1 key is used for `Show Command Palette` by default, it conflicts with the help command. This commit removes the F1 key binding for help.

Fixes: [VSCODEEXT-123](https://bugreports.qt.io/browse/VSCODEEXT-123)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
