### PR TITLE
Bump version to 1.3.1 & qt-core: Remove F1 key binding for help

### DIFF
--- a/qt-core/package-lock.json
+++ b/qt-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qt-core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qt-core",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "command-exists": "^1.2.9",
         "lodash": "^4.17.21",
@@ -35,15 +35,17 @@
       }
     },
     "../qt-lib": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.7",
+        "async": "^3.2.6",
         "module-alias": "^2.2.3",
         "typescript": "^5.6.3",
         "winston": "^3.15.0",
         "winston-transport-vscode": "^0.1.0"
       },
       "devDependencies": {
+        "@types/async": "^3.2.24",
         "@types/node": "^20.17.0",
         "@types/vscode": "^1.94.0",
         "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/qt-core/package.json
+++ b/qt-core/package.json
@@ -134,12 +134,6 @@
         }
       }
     ],
-    "keybindings": [
-      {
-        "key": "f1",
-        "command": "qt-core.documentationSearchForCurrentWord"
-      }
-    ],
     "grammars": [
       {
         "language": "qdoc",

--- a/qt-core/package.json
+++ b/qt-core/package.json
@@ -2,7 +2,7 @@
   "name": "qt-core",
   "displayName": "Qt Core",
   "description": "Qt Core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "homepage": "https://www.qt.io/",
   "icon": "res/icons/qt.png",
   "publisher": "theqtcompany",

--- a/qt-cpp/package-lock.json
+++ b/qt-cpp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qt-cpp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qt-cpp",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@vscode/l10n": "^0.0.16",
         "@vscode/webview-ui-toolkit": "^1.4.0",
@@ -40,15 +40,17 @@
       }
     },
     "../qt-lib": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.7",
+        "async": "^3.2.6",
         "module-alias": "^2.2.3",
         "typescript": "^5.6.3",
         "winston": "^3.15.0",
         "winston-transport-vscode": "^0.1.0"
       },
       "devDependencies": {
+        "@types/async": "^3.2.24",
         "@types/node": "^20.17.0",
         "@types/vscode": "^1.94.0",
         "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/qt-cpp/package.json
+++ b/qt-cpp/package.json
@@ -2,7 +2,7 @@
   "name": "qt-cpp",
   "displayName": "Qt C++",
   "description": "Qt C++ Support",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "homepage": "https://www.qt.io/",
   "icon": "res/icons/qt.png",
   "publisher": "theqtcompany",

--- a/qt-lib/package-lock.json
+++ b/qt-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qt-lib",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qt-lib",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.7",
         "async": "^3.2.6",

--- a/qt-lib/package.json
+++ b/qt-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qt-lib",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "out/index.js",
   "types": "out/index.d.ts",
   "files": [

--- a/qt-qml/package-lock.json
+++ b/qt-qml/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qt-qml",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qt-qml",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@vscode/l10n": "^0.0.16",
         "module-alias": "^2.2.3",
@@ -42,15 +42,17 @@
       }
     },
     "../qt-lib": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.7",
+        "async": "^3.2.6",
         "module-alias": "^2.2.3",
         "typescript": "^5.6.3",
         "winston": "^3.15.0",
         "winston-transport-vscode": "^0.1.0"
       },
       "devDependencies": {
+        "@types/async": "^3.2.24",
         "@types/node": "^20.17.0",
         "@types/vscode": "^1.94.0",
         "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/qt-qml/package.json
+++ b/qt-qml/package.json
@@ -2,7 +2,7 @@
   "name": "qt-qml",
   "displayName": "Qt Qml",
   "description": "Qt Qml Support",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "homepage": "https://www.qt.io/",
   "icon": "res/icons/qt.png",
   "publisher": "theqtcompany",

--- a/qt-ui/package-lock.json
+++ b/qt-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qt-ui",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qt-ui",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@vscode/l10n": "^0.0.16",
         "@vscode/webview-ui-toolkit": "^1.4.0",
@@ -35,15 +35,17 @@
       }
     },
     "../qt-lib": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.7",
+        "async": "^3.2.6",
         "module-alias": "^2.2.3",
         "typescript": "^5.6.3",
         "winston": "^3.15.0",
         "winston-transport-vscode": "^0.1.0"
       },
       "devDependencies": {
+        "@types/async": "^3.2.24",
         "@types/node": "^20.17.0",
         "@types/vscode": "^1.94.0",
         "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/qt-ui/package.json
+++ b/qt-ui/package.json
@@ -2,7 +2,7 @@
   "name": "qt-ui",
   "displayName": "Qt UI",
   "description": "Qt UI Support",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "homepage": "https://www.qt.io/",
   "icon": "res/icons/qt.png",
   "publisher": "theqtcompany",


### PR DESCRIPTION
- Bump version to 1.3.1
- qt-core: Remove F1 key binding for help (backport 2147c597e202fdd81570212aa1dc4caa53db2c92)
Since the F1 key is used for `Show Command Palette` by default, it
conflicts with the help command. This commit removes the F1 key binding
for help.

Fixes: [VSCODEEXT-123](https://bugreports.qt.io/browse/VSCODEEXT-123)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
