### PR TITLE
qt-core: Remove F1 key binding for help & Update CHANGELOG.md

### DIFF
--- a/qt-core/CHANGELOG.md
+++ b/qt-core/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 1.2.1 (Jan 10, 2025)
 
-The same as `1.2.0`
+🐞 **Fixed**
+
+- Revert the F1 key binding for help
 
 ## 1.2.0 (Jan 8, 2025)
 

--- a/qt-core/package.json
+++ b/qt-core/package.json
@@ -124,12 +124,6 @@
         }
       }
     ],
-    "keybindings": [
-      {
-        "key": "f1",
-        "command": "qt-core.documentationSearchForCurrentWord"
-      }
-    ],
     "grammars": [
       {
         "language": "qdoc",


### PR DESCRIPTION
- Update `CHANGELOG.md`
- qt-core: Remove F1 key binding for help (backport 2147c597e202fdd81570212aa1dc4caa53db2c92)
Since the F1 key is used for `Show Command Palette` by default, it
conflicts with the help command. This commit removes the F1 key binding
for help.
<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
