### PR TITLE
qt-cpp: Add the rest of the environment path to the path variable

### DIFF
--- a/qt-cpp/src/kit-manager.ts
+++ b/qt-cpp/src/kit-manager.ts
@@ -43,6 +43,7 @@ export const CMAKE_GLOBAL_KITS_FILEPATH = path.join(
   'cmake-tools-kits.json'
 );
 
+const envPath = '${env:PATH}';
 type Environment = Record<string, string | undefined>;
 
 interface CMakeGenerator {
@@ -357,7 +358,7 @@ export class KitManager {
       }
       tempPath.push(value);
     }
-    tempPath.push('${env:PATH}');
+    tempPath.push(envPath);
     // Remove duplicates
     const pathEnv = Array.from(new Set(tempPath)).join(path.delimiter);
     kit.environmentVariables = {
@@ -512,9 +513,7 @@ export class KitManager {
       return undefined;
     }
     const installationBinDir = path.join(installation, 'bin');
-    const QtPathAddition = [installationBinDir, '${env:PATH}'].join(
-      path.delimiter
-    );
+    const QtPathAddition = [installationBinDir, envPath].join(path.delimiter);
     return QtPathAddition;
   }
 

--- a/qt-cpp/src/kit-manager.ts
+++ b/qt-cpp/src/kit-manager.ts
@@ -510,7 +510,7 @@ export class KitManager {
 
   private static generateEnvPathForQtInstallation(installation: string) {
     if (!IsWindows) {
-      return undefined;
+      return envPath;
     }
     const installationBinDir = path.join(installation, 'bin');
     const QtPathAddition = [installationBinDir, envPath].join(path.delimiter);
@@ -544,7 +544,8 @@ export class KitManager {
     newKit.name = kitName;
     newKit.environmentVariables = {
       VSCODE_QT_INSTALLATION: installation,
-      PATH: qtPathEnv
+      // If it is just envPath, not need to set it.
+      PATH: qtPathEnv === envPath ? undefined : qtPathEnv
     };
 
     const toolchainFilePath = await promiseCmakeQtToolchainPath;


### PR DESCRIPTION
Backport 7f03010bae883c8851577ca03740ca9cf883acb9 and ba56defa3940d6e6963b52681347f2115be75af7

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
