### PR TITLE
qt-cli: Make qtcli executable name consistent across all platforms

### DIFF
--- a/.github/workflows/qtcli/action.yml
+++ b/.github/workflows/qtcli/action.yml
@@ -2,11 +2,12 @@ name: Build qtcli binaries
 
 inputs:
   working-directory:
-      description: 'Root directory of qt-cli (relative to repository root)'
-      default: '.'
-      required: false
+    description: 'Root directory of qt-cli (relative to repository root)'
+    default: '.'
+    required: false
   deploy-target:
     description: 'Folder where built binaries will be copied'
+    required: false
 
 runs:
   using: "composite"
@@ -49,6 +50,4 @@ runs:
       if: ${{ inputs.deploy-target != '' }}
       run: |
         mkdir -p ${{ inputs.deploy-target }}
-        cp ${{ inputs.working-directory }}/dist/qtcli_linux* ${{ inputs.deploy-target }}
-        cp ${{ inputs.working-directory }}/dist/qtcli_windows* ${{ inputs.deploy-target }}
-        cp ${{ inputs.working-directory }}/dist/qtcli_darwin_fat* ${{ inputs.deploy-target }}
+        cp -r ${{ inputs.working-directory }}/dist/qtcli-* ${{ inputs.deploy-target }}

--- a/qt-cli/.goreleaser.yaml
+++ b/qt-cli/.goreleaser.yaml
@@ -22,12 +22,12 @@ builds:
       - -X main.version={{ .Version }}
       - -X main.timestamp={{ .Timestamp }}
       - -X main.commit={{ .FullCommit }}
-
     binary: >-
-      {{ .ProjectName }}_
-      {{- .Os }}_
-      {{- .Arch }}_
-      {{- .Version }}
+      {{- if eq .Os "darwin" }}_intermediate/{{ end -}}
+      qtcli-
+      {{- .Os }}-
+      {{- .Arch }}-
+      {{- .Version }}/qtcli
     no_unique_dist_dir: true
     ignore:
       - goos: linux
@@ -36,11 +36,9 @@ builds:
         goarch: arm64
 
 universal_binaries:
-  - name_template: >-
-      {{ .ProjectName }}_darwin_fat_
-      {{- .Version }}
+  - name_template: qtcli
     hooks:
-      post: cp {{ .Path }} {{ dir .Path }}/../{{ .Name }} # get out of sub-directory
+      post: mv {{ .Path | dir }} dist/qtcli-darwin-fat-{{- .Version }}/
 
 snapshot:
   version_template: '{{ .Version }}'

--- a/qt-core/src/qtcli/commands.ts
+++ b/qt-core/src/qtcli/commands.ts
@@ -80,7 +80,7 @@ async function findQtcliExePath(context: vscode.ExtensionContext) {
   const finder = new QtcliExeFinder();
   finder.addPossibleDir(process.cwd());
   finder.addPossibleDir((process.env.PATH ?? '').split(path.delimiter));
-  finder.addPossibleDir(path.join(context.extensionPath, 'res', 'qtcli'));
+  finder.addDistDir(path.join(context.extensionPath, 'res', 'qtcli'));
 
   return finder.run();
 }

--- a/qt-core/src/qtcli/common.ts
+++ b/qt-core/src/qtcli/common.ts
@@ -8,13 +8,14 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { spawnSync } from 'child_process';
 
-import { createLogger, isError } from 'qt-lib';
+import { createLogger, isError, OSExeSuffix } from 'qt-lib';
 
 export enum QtcliAction {
   NewFile,
   NewProject
 }
 
+export const QtcliExeName = 'qtcli' + OSExeSuffix;
 export const logger = createLogger('qtcli');
 
 export function errorString<T>(e: T) {

--- a/qt-core/src/qtcli/exe-finder.ts
+++ b/qt-core/src/qtcli/exe-finder.ts
@@ -4,10 +4,11 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
-import { isValidQtcliPath, logger, errorString } from './common';
+import { QtcliExeName, isValidQtcliPath, logger, errorString } from './common';
 
 export class QtcliExeFinder {
   private readonly _dirCandidates: string[] = [];
+  private readonly _distDirs: string[] = [];
 
   public addPossibleDir(dirs: string | string[]) {
     if (typeof dirs === 'string') {
@@ -17,12 +18,23 @@ export class QtcliExeFinder {
     }
   }
 
+  public addDistDir(dir: string) {
+    this._distDirs.push(dir);
+  }
+
   public async run() {
     try {
-      const prefix = findQtcliPrefix();
-
       for (const dir of this._dirCandidates) {
-        const fullPath = await findQtcliIn(dir, prefix);
+        const fullPath = await findQtcliIn(dir);
+        if (fullPath) {
+          return fullPath;
+        }
+      }
+
+      const prefix = findQtcliOsPrefix();
+
+      for (const distDir of this._distDirs) {
+        const fullPath = await findQtcliInDist(distDir, prefix);
         if (fullPath) {
           return fullPath;
         }
@@ -35,27 +47,44 @@ export class QtcliExeFinder {
   }
 }
 
-function findQtcliPrefix(): string {
+function findQtcliOsPrefix(): string {
   const platform = process.platform;
 
   if (platform === 'win32') {
-    return 'qtcli_windows';
-  } else if (platform === 'darwin') {
-    return 'qtcli_darwin';
-  } else if (platform === 'linux') {
-    return 'qtcli_linux';
+    return 'qtcli-windows-';
+  } else if (platform === 'darwin' || platform === 'linux') {
+    return `qtcli-${platform}-`;
   } else {
     throw new Error(`Platform '${platform}' is not supported`);
   }
 }
 
-async function findQtcliIn(dir: string, prefix: string) {
+async function findQtcliIn(dir: string) {
   try {
     const files = await fs.readdir(dir, { withFileTypes: true });
 
     for (const file of files) {
-      if (file.isFile() && file.name.startsWith(prefix)) {
+      if (file.isFile() && file.name === QtcliExeName) {
         const fullPath = path.join(dir, file.name);
+        if (isValidQtcliPath(fullPath)) {
+          return fullPath;
+        }
+      }
+    }
+  } catch (e) {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+async function findQtcliInDist(distDir: string, prefix: string) {
+  try {
+    const entries = await fs.readdir(distDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (entry.isDirectory() && entry.name.startsWith(prefix)) {
+        const fullPath = path.join(distDir, entry.name, QtcliExeName);
         if (isValidQtcliPath(fullPath)) {
           return fullPath;
         }


### PR DESCRIPTION
Previously, the executable names varied across platforms, 
such as `qtcli_[platform]_[arch]_[version]`.

Now, the names are unified to `qtcli` for all platforms. 
This change simplifies finding qtcli from the PATH and 
reduces unnecessary details in the executable names.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
