### PR TITLE
qt-cli: Add signing action for qtcli

### DIFF
--- a/.github/actions/build-qtcli/action.yml
+++ b/.github/actions/build-qtcli/action.yml
@@ -4,10 +4,14 @@ inputs:
   working-directory:
     description: 'Root directory of qt-cli (relative to repository root)'
     default: '.'
-    required: false
+
   deploy-target:
     description: 'Folder where built binaries will be copied'
-    required: false
+
+outputs:
+  artifact-name:
+    description: 'Build artifact name'
+    value: ${{ steps.setup-env.outputs.artifact-name }}
 
 runs:
   using: "composite"
@@ -19,13 +23,15 @@ runs:
         cache: true
 
     - name: Setup build environment
+      id: setup-env
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
         V=$(head -n 1 version.txt | xargs)
         H=$(git rev-parse --short $GITHUB_SHA)
-        echo QTCLI_VERSION=$V >> $GITHUB_ENV
-        echo QTCLI_SHORT_HASH=$H >> $GITHUB_ENV
+
+        echo "QTCLI_VERSION=$V" >> $GITHUB_ENV
+        echo "artifact-name=qtcli-$V-$H" >> $GITHUB_OUTPUT
         echo "- $(go version)"
         echo "- qtcli version $V ($H)"
 
@@ -39,15 +45,18 @@ runs:
       env:
         GORELEASER_CURRENT_TAG: ${{ env.QTCLI_VERSION }}
 
-    - name: Upload artifacts
+    - name: Upload artifact
+      id: step-artifacts-upload
       uses: actions/upload-artifact@v4
       with:
-        name: qtcli-${{ env.QTCLI_VERSION }}-${{ env.QTCLI_SHORT_HASH }}
-        path: ${{ inputs.working-directory }}/dist/*
+        name: ${{ steps.setup-env.outputs.artifact-name }}
+        path: ${{ inputs.working-directory }}/dist/bin/*
 
-    - name: Copy output files
+    - name: Deploy files (unsigned)
       shell: bash
       if: ${{ inputs.deploy-target != '' }}
       run: |
         mkdir -p ${{ inputs.deploy-target }}
-        cp -r ${{ inputs.working-directory }}/dist/qtcli-* ${{ inputs.deploy-target }}
+        cp -r ${{ inputs.working-directory }}/dist/bin/qtcli-* ${{ inputs.deploy-target }}
+        echo "---------------------------------"
+        cd ${{ inputs.deploy-target }} && find . && du -h

--- a/.github/actions/build-qtcli/action.yml
+++ b/.github/actions/build-qtcli/action.yml
@@ -35,6 +35,13 @@ runs:
         echo "- $(go version)"
         echo "- qtcli version $V ($H)"
 
+    - name: Run e2e test (on ${{ runner.os }})
+      shell: bash
+      run: |
+        cd ${{ inputs.working-directory }}
+        go build -C ./src -o ../tests && \
+        go test -C ./tests/e2e -v
+
     - name: Run goreleaser
       uses: goreleaser/goreleaser-action@v6
       with:

--- a/.github/actions/sign-qtcli/action.yml
+++ b/.github/actions/sign-qtcli/action.yml
@@ -1,0 +1,77 @@
+name: Sign qtcli binaries
+
+inputs:
+  build-artifact:
+    description: 'Artifact name of built binaries'
+    required: true
+
+  worker-token:
+    description: 'Token for accessing the worker'
+    required: true
+
+  worker-owner:
+    description: 'Owner of the repository'
+    default: TheQtCompanyRnD
+
+  worker-repo:
+    description: 'Repository name of the worker'
+    default: qtcli-workflow
+
+  worker-workflow:
+    description: 'Workflow file name to use'
+    default: sign-qtcli.yml
+
+  worker-branch:
+    description: 'Branch to use'
+    default: main
+
+  deploy-target:
+    description: 'Folder where built binaries will be copied'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Trigger the worker
+      id: worker
+      uses: convictional/trigger-workflow-and-wait@v1.6.5
+      with:
+        owner: ${{ inputs.worker-owner }}
+        repo: ${{ inputs.worker-repo }}
+        github_token: ${{ inputs.worker-token }}
+        workflow_file_name: ${{ inputs.worker-workflow }}
+        ref: ${{ inputs.worker-branch }}
+        client_payload: |
+          {
+            "build-repo": "${{ github.repository }}",
+            "build-run-id": "${{ github.run_id }}",
+            "build-artifact": "${{ inputs.build-artifact }}"
+          }
+        wait_interval: 10
+        wait_workflow: true
+        trigger_workflow: true
+        propagate_failure: true
+
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.build-artifact }}-signed
+        github-token: ${{ inputs.worker-token }}
+        repository: ${{ inputs.worker-owner }}/${{ inputs.worker-repo }}
+        run-id: ${{ steps.worker.outputs.workflow_id }}
+        path: "./signed-qtcli"
+
+    - name: Upload signed qtcli
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.build-artifact }}-signed
+        path: "./signed-qtcli/*"
+
+    - name: Deploy files (signed)
+      if: ${{ inputs.deploy-target != '' }}
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.deploy-target }}
+        cp -r ./signed-qtcli/qtcli-* ${{ inputs.deploy-target }}
+        find . -type f -name "qtcli" -exec chmod 755 {} \;
+        echo "---------------------------------"
+        cd ${{ inputs.deploy-target }} && find . && du -h

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,17 +1,37 @@
 name: Build on Linux
+
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      enable-qtcli-signing:
+        description: "Enable qtcli signing (true/false)"
+        default: "false"
+        required: true
 
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # qtcli
       - name: Build qtcli
-        uses: ./.github/workflows/qtcli
+        id: build-qtcli
+        uses: ./.github/actions/build-qtcli
         with:
           working-directory: ./qt-cli
           deploy-target: ./qt-core/res/qtcli
+
+      - name: Sign qtcli
+        uses: ./.github/actions/sign-qtcli
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable-qtcli-signing == 'true' }}
+        with:
+          build-artifact: ${{ steps.build-qtcli.outputs.artifact-name }}
+          worker-token: ${{ secrets.PAT }}
+          deploy-target: ./qt-core/res/qtcli
+
+      # extensions
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/test-qtcli-all.yml
+++ b/.github/workflows/test-qtcli-all.yml
@@ -1,0 +1,32 @@
+name: Run tests on qtcli (all platforms)
+on:
+  pull_request:
+    paths:
+      - 'qt-cli/**'
+
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup environment
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: ./qt-cli/src/go.mod
+          cache-dependency-path: ./qt-cli/src/go.sum
+          cache: true
+
+      - name: Build and test
+        shell: bash
+        run: |
+          cd ./qt-cli
+          go build -C ./src -o ../tests && \
+          go test -C ./tests/e2e -v

--- a/qt-cli/.gitignore
+++ b/qt-cli/.gitignore
@@ -1,1 +1,3 @@
 dist/
+tests/qtcli
+tests/qtcli.exe

--- a/qt-cli/.goreleaser.yaml
+++ b/qt-cli/.goreleaser.yaml
@@ -24,7 +24,7 @@ builds:
       - -X main.commit={{ .FullCommit }}
     binary: >-
       {{- if eq .Os "darwin" }}_intermediate/{{ end -}}
-      qtcli-
+      bin/qtcli-
       {{- .Os }}-
       {{- .Arch }}-
       {{- .Version }}/qtcli
@@ -37,8 +37,10 @@ builds:
 
 universal_binaries:
   - name_template: qtcli
+    replace: true
     hooks:
-      post: mv {{ .Path | dir }} dist/qtcli-darwin-fat-{{- .Version }}/
+      post:
+        - mv {{ .Path | dir }} dist/bin/qtcli-darwin-all-{{- .Version }}/
 
 snapshot:
   version_template: '{{ .Version }}'

--- a/qt-cli/Development.md
+++ b/qt-cli/Development.md
@@ -70,3 +70,13 @@ After changing to the `src/` directory, run `go-licenses report` with the prepar
 $ cd src
 $ go-licenses report . --template ../others/ThirdPartyNotices.tpl --ignore qtcli > ../ThirdPartyNotices.txt
 ```
+
+### How to run end-to-end tests
+
+To run e2e tests, build `qtcli` and output it to the `tests/` directory.
+Then run the tests in the `tests/e2e` directory.
+
+```bash
+$ go build -C ./src -o ../tests
+$ go test -C ./tests/e2e -v
+```

--- a/qt-cli/src/cmds/preset_cmd.go
+++ b/qt-cli/src/cmds/preset_cmd.go
@@ -6,12 +6,10 @@ package cmds
 import (
 	"errors"
 	"fmt"
-	"qtcli/common"
 	"qtcli/formats"
 	"qtcli/prompt/comps"
 	"qtcli/runner"
 	"qtcli/util"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -29,19 +27,17 @@ var presetListCmd = &cobra.Command{
 	Short: util.Msg("List the names of all presets"),
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		if userPresets().GetCount() == 0 {
+		items := runner.Presets.User.GetAll()
+		if len(items) == 0 {
 			fmt.Println(util.Msg("<no custom preset>"))
-		} else {
-			for _, item := range userPresets().GetItems() {
-				fmt.Printf("%s -> @%s\n", item.GetName(), item.GetDescription())
-			}
 		}
 
 		if lsAllPresets {
-			all := runner.FindAllDefaultPresets()
-			for _, item := range all {
-				fmt.Printf("%s (%s)\n", item.GetName(), item.GetTypeId())
-			}
+			items = append(items, runner.Presets.Default.GetAll()...)
+		}
+
+		for _, item := range items {
+			fmt.Println(item.GetDescription())
 		}
 	},
 }
@@ -51,31 +47,13 @@ var presetCatCmd = &cobra.Command{
 	Short: util.Msg("Print the contents of the given preset"),
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		item := common.PresetData{}
 		name := args[0]
-
-		if !strings.HasPrefix(name, "@") {
-			i, err := userPresets().FindByName(name)
-			if err != nil {
-				return err
-			}
-
-			item = i
-		} else {
-			name = name[1:]
-
-			for _, p := range runner.FindAllDefaultPresets() {
-				if p.GetTemplateDir() == name {
-					item = p.ToPresetData()
-					break
-				}
-			}
+		item, err := runner.Presets.Any.FindByName(name)
+		if err != nil {
+			return err
 		}
 
-		if len(item.TemplateDir) != 0 {
-			fmt.Println(item.ToYaml())
-		}
-
+		fmt.Println(item.ToYaml())
 		return nil
 	},
 }
@@ -161,7 +139,7 @@ func getConfirm(msg string) bool {
 }
 
 func userPresets() *formats.UserPresetFile {
-	return runner.AllUserPresets
+	return runner.Presets.User.GetFile()
 }
 
 func init() {

--- a/qt-cli/src/cmds/root_cmd.go
+++ b/qt-cli/src/cmds/root_cmd.go
@@ -14,8 +14,8 @@ import (
 var verbose = false
 
 var rootCmd = &cobra.Command{
-	Use:     "qtcli",
-	Short:   util.Msg("A CLI for creating Qt project and files"),
+	Use:   "qtcli",
+	Short: util.Msg("A CLI for creating Qt project and files"),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if verbose {
 			logrus.SetLevel(logrus.DebugLevel)
@@ -41,5 +41,4 @@ func init() {
 	rootCmd.SilenceUsage = true
 	rootCmd.PersistentFlags().BoolVarP(
 		&verbose, "verbose", "v", false, util.Msg("Enable verbose output"))
-
 }

--- a/qt-cli/src/cmds/test_cmd.go
+++ b/qt-cli/src/cmds/test_cmd.go
@@ -30,16 +30,16 @@ var testPromptCmd = &cobra.Command{
 			return createNotFoundError(args[0])
 		}
 
-		name := args[0][1:]
+		name := args[0]
 
-		for _, p := range runner.FindAllDefaultPresets() {
-			if p.TemplateDir == name {
-				options, err := runner.RunPromptFromDir(name)
+		for _, p := range runner.Presets.Default.GetAll() {
+			if p.Name == name {
+				options, err := runner.RunPromptFromDir(name[1:])
 				if err != nil {
 					return err
 				}
 
-				item := p.ToPresetData()
+				item := p
 				item.Options = options
 				printPreset(item)
 				return nil
@@ -61,9 +61,9 @@ var testDefaultCmd = &cobra.Command{
 
 		name := args[0][1:]
 
-		for _, p := range runner.FindAllDefaultPresets() {
+		for _, p := range runner.Presets.Default.GetAll() {
 			if name == p.TemplateDir {
-				printPreset(p.ToPresetData())
+				printPreset(p)
 				return nil
 			}
 		}

--- a/qt-cli/src/common/preset.go
+++ b/qt-cli/src/common/preset.go
@@ -4,7 +4,9 @@
 package common
 
 import (
+	"fmt"
 	"qtcli/util"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -12,6 +14,7 @@ import (
 type Preset interface {
 	GetName() string
 	GetTypeId() TargetType
+	GetTypeName() string
 	GetDescription() string
 	GetTemplateDir() string
 	GetOptions() util.StringAnyMap
@@ -32,8 +35,16 @@ func (p PresetData) GetTypeId() TargetType {
 	return TargetTypeFromString(p.TypeName)
 }
 
+func (p PresetData) GetTypeName() string {
+	return TargetTypeToString(p.GetTypeId())
+}
+
 func (p PresetData) GetDescription() string {
-	return p.TemplateDir
+	if strings.HasPrefix(p.Name, "@") {
+		return fmt.Sprintf("[Default] %s", p.Name)
+	} else {
+		return fmt.Sprintf("%s (-> @%s)", p.Name, p.TemplateDir)
+	}
 }
 
 func (p PresetData) GetTemplateDir() string {

--- a/qt-cli/src/common/preset_manager.go
+++ b/qt-cli/src/common/preset_manager.go
@@ -1,0 +1,87 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+package common
+
+import (
+	"fmt"
+	"qtcli/util"
+)
+
+type PresetManager interface {
+	GetAll() []PresetData
+	FindByType(t TargetType) []PresetData
+	FindByName(name string) (PresetData, error)
+	FindByTypeAndName(t TargetType, name string) (PresetData, error)
+}
+
+type CompositePresetManager struct {
+	comps []PresetManager
+}
+
+func NewCompositePresetManager(comps ...PresetManager) CompositePresetManager {
+	return CompositePresetManager{comps: comps}
+}
+
+func (m CompositePresetManager) GetAll() []PresetData {
+	all := []PresetData{}
+
+	for _, c := range m.comps {
+		all = append(all, c.GetAll()...)
+	}
+
+	return all
+}
+
+func (m CompositePresetManager) GetItemsByType(t TargetType) []PresetData {
+	all := []PresetData{}
+
+	for _, c := range m.comps {
+		all = append(all, c.FindByType(t)...)
+	}
+
+	return all
+}
+
+func (m CompositePresetManager) FindByName(name string) (PresetData, error) {
+	for _, c := range m.comps {
+		preset, err := c.FindByName(name)
+		if err == nil {
+			return preset, nil
+		}
+	}
+
+	return notFoundError(name)
+}
+
+func (m CompositePresetManager) FindByTypeAndName(
+	t TargetType,
+	name string,
+) (PresetData, error) {
+	for _, c := range m.comps {
+		preset, err := FindByTypeAndName(c, t, name)
+		if err == nil {
+			return preset, nil
+		}
+	}
+
+	return notFoundError(name)
+}
+
+// helpers
+func FindByTypeAndName(
+	m PresetManager,
+	t TargetType,
+	name string,
+) (PresetData, error) {
+	candidate, err := m.FindByName(name)
+	if err == nil && candidate.GetTypeId() == t {
+		return candidate, nil
+	}
+
+	return notFoundError(name)
+}
+
+func notFoundError(name string) (PresetData, error) {
+	return PresetData{}, fmt.Errorf(util.Msg("not found, given = '%v'"), name)
+}

--- a/qt-cli/src/common/target_type.go
+++ b/qt-cli/src/common/target_type.go
@@ -5,11 +5,11 @@ package common
 
 import "strings"
 
-type TargetType string
+type TargetType int
 
 const (
-	TargetTypeFile    TargetType = "File"
-	TargetTypeProject TargetType = "Project"
+	TargetTypeFile TargetType = iota
+	TargetTypeProject
 )
 
 func TargetTypeFromString(s string) TargetType {
@@ -25,5 +25,5 @@ func TargetTypeToString(t TargetType) string {
 		return "project"
 	}
 
-	return "files"
+	return "file"
 }

--- a/qt-cli/src/formats/user_preset_file.go
+++ b/qt-cli/src/formats/user_preset_file.go
@@ -99,7 +99,7 @@ func (f *UserPresetFile) GetAllNames() []string {
 	return all
 }
 
-func (f *UserPresetFile) GetItems() []common.PresetData {
+func (f *UserPresetFile) GetAll() []common.PresetData {
 	return f.contents.Items
 }
 
@@ -196,4 +196,38 @@ func (f *UserPresetFile) Rename(from string, to string) error {
 	}
 
 	return f.Remove(from)
+}
+
+// manager
+type UserPresetManager struct {
+	file *UserPresetFile
+}
+
+func NewUserPresetManager(f *UserPresetFile) UserPresetManager {
+	return UserPresetManager{file: f}
+}
+
+func (m UserPresetManager) GetAll() []common.PresetData {
+	return m.file.GetAll()
+}
+
+func (m UserPresetManager) FindByType(
+	t common.TargetType,
+) []common.PresetData {
+	return m.file.GetItemsOfTargetType(t)
+}
+
+func (m UserPresetManager) FindByName(name string) (common.PresetData, error) {
+	return m.file.FindByName(name)
+}
+
+func (m UserPresetManager) FindByTypeAndName(
+	t common.TargetType,
+	name string,
+) (common.PresetData, error) {
+	return common.FindByTypeAndName(m, t, name)
+}
+
+func (m UserPresetManager) GetFile() *UserPresetFile {
+	return m.file
 }

--- a/qt-cli/src/generator/result.go
+++ b/qt-cli/src/generator/result.go
@@ -28,3 +28,13 @@ func (r *Result) Print(output io.Writer) {
 
 	w.Flush()
 }
+
+func (r *Result) GetOutputFilePaths() []string {
+	all := []string{}
+
+	for _, item := range *r {
+		all = append(all, item.OutputFilePath)
+	}
+
+	return all
+}

--- a/qt-cli/src/runner/default_preset.go
+++ b/qt-cli/src/runner/default_preset.go
@@ -4,7 +4,7 @@
 package runner
 
 import (
-	"fmt"
+	"errors"
 	"io/fs"
 	"path"
 	"qtcli/common"
@@ -12,99 +12,90 @@ import (
 	"qtcli/util"
 )
 
-type DefaultPresets struct {
-	Type         common.TargetType
-	TemplateDirs []string
+type DefaultPresetManager struct {
+	baseFS  fs.FS
+	presets map[common.TargetType][]common.PresetData
 }
 
-type DefaultPreset struct {
-	Name        string
-	TypeId      common.TargetType
-	TemplateDir string
-}
-
-func (p DefaultPreset) GetName() string {
-	return p.Name
-}
-
-func (p DefaultPreset) GetTypeId() common.TargetType {
-	return p.TypeId
-}
-
-func (p DefaultPreset) GetDescription() string {
-	return ""
-}
-
-func (p DefaultPreset) GetTemplateDir() string {
-	return p.TemplateDir
-}
-
-func (p DefaultPreset) GetOptions() util.StringAnyMap {
-	fullPath := path.Join(
-		p.TemplateDir,
-		common.PromptFileName)
-
-	f := formats.NewPromptFileFS(GeneratorEnv.FS, fullPath)
-	if err := f.Open(); err != nil {
-		return util.StringAnyMap{}
+func NewDefaultPresetManager(baseFS fs.FS) DefaultPresetManager {
+	presets := map[common.TargetType][]common.PresetData{
+		common.TargetTypeFile:    loadPresets(baseFS, common.TargetTypeFile),
+		common.TargetTypeProject: loadPresets(baseFS, common.TargetTypeProject),
 	}
 
-	return f.ExtractDefaults()
-}
-
-func (p DefaultPreset) ToPresetData() common.PresetData {
-	return common.PresetData{
-		Name:        p.Name,
-		TypeName:    common.TargetTypeToString(p.TypeId),
-		TemplateDir: p.TemplateDir,
-		Options:     p.GetOptions(),
+	return DefaultPresetManager{
+		baseFS:  baseFS,
+		presets: presets,
 	}
 }
 
-// helpers
-func FindAllDefaultPresets() []DefaultPreset {
-	all := []DefaultPreset{}
-	all = append(all, FindDefaultPresets(common.TargetTypeProject)...)
-	all = append(all, FindDefaultPresets(common.TargetTypeFile)...)
-
-	return all
+func (m DefaultPresetManager) GetAll() []common.PresetData {
+	return append(
+		m.FindByType(common.TargetTypeProject),
+		m.FindByType(common.TargetTypeFile)...,
+	)
 }
 
-func FindDefaultPresets(t common.TargetType) []DefaultPreset {
-	all := []DefaultPreset{}
-	names, err := findAllDefaultPresetNames(t)
+func (m DefaultPresetManager) FindByType(
+	t common.TargetType,
+) []common.PresetData {
+	presets, exists := m.presets[t]
+	if exists {
+		return presets
+	}
+
+	return []common.PresetData{}
+}
+
+func loadPresets(baseFS fs.FS, t common.TargetType) []common.PresetData {
+	all := []common.PresetData{}
+	dirs, err := findAllTemplateDirNames(baseFS, t)
 
 	if err == nil {
-		for _, name := range names {
-			all = append(all, DefaultPreset{
-				Name:        "[Default] @" + name,
-				TypeId:      t,
-				TemplateDir: name,
-			})
+		for _, dir := range dirs {
+			p := common.PresetData{
+				Name:        "@" + dir,
+				TypeName:    common.TargetTypeToString(t),
+				TemplateDir: dir,
+				Options:     readDefaultOptions(baseFS, dir),
+			}
+
+			all = append(all, p)
 		}
 	}
 
 	return all
 }
 
-func FindDefaultPresetByTemplateDir(t common.TargetType, dir string) (
-	DefaultPreset, error) {
-	presets := FindDefaultPresets(t)
+func (m DefaultPresetManager) FindByName(
+	name string,
+) (common.PresetData, error) {
+	all := m.GetAll()
 
-	for _, preset := range presets {
-		if dir == preset.TemplateDir {
+	for _, preset := range all {
+		if preset.GetName() == name {
 			return preset, nil
 		}
 	}
 
-	return DefaultPreset{},
-		fmt.Errorf(util.Msg("cannot find default preset, given = '%v'"), dir)
+	return common.PresetData{}, errors.New("not found")
 }
 
-func findAllDefaultPresetNames(t common.TargetType) ([]string, error) {
+func (m DefaultPresetManager) FindByTypeAndName(
+	t common.TargetType,
+	name string,
+) (common.PresetData, error) {
+	return common.FindByTypeAndName(m, t, name)
+}
+
+// helpers
+func findAllTemplateDirNames(
+	baseFS fs.FS,
+	t common.TargetType,
+) ([]string, error) {
 	var found []string
 
-	err := fs.WalkDir(GeneratorEnv.FS, ".",
+	err := fs.WalkDir(baseFS, ".",
 		func(walkingPath string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
@@ -112,8 +103,7 @@ func findAllDefaultPresetNames(t common.TargetType) ([]string, error) {
 
 			if d.IsDir() && walkingPath != "." {
 				fullPath := path.Join(walkingPath, common.TemplateFileName)
-				templateFile := formats.NewTemplateFileFS(
-					GeneratorEnv.FS, fullPath)
+				templateFile := formats.NewTemplateFileFS(baseFS, fullPath)
 				err := templateFile.Open()
 
 				if err == nil && templateFile.GetTargetType() == t {
@@ -125,4 +115,15 @@ func findAllDefaultPresetNames(t common.TargetType) ([]string, error) {
 		})
 
 	return found, err
+}
+
+func readDefaultOptions(baseFS fs.FS, templateDir string) util.StringAnyMap {
+	fullPath := path.Join(templateDir, common.PromptFileName)
+
+	f := formats.NewPromptFileFS(baseFS, fullPath)
+	if err := f.Open(); err != nil {
+		return util.StringAnyMap{}
+	}
+
+	return f.ExtractDefaults()
 }

--- a/qt-cli/src/runner/runner.go
+++ b/qt-cli/src/runner/runner.go
@@ -16,7 +16,12 @@ import (
 )
 
 var GeneratorEnv *generator.Env
-var AllUserPresets *formats.UserPresetFile
+
+var Presets struct {
+	Default DefaultPresetManager
+	User    formats.UserPresetManager
+	Any     common.CompositePresetManager
+}
 
 func init() {
 	baseFS, err := fs.Sub(assets.Assets, "templates")
@@ -42,5 +47,20 @@ func init() {
 		logrus.Fatal(err)
 	}
 
-	AllUserPresets = userPresets
+	// preset managers
+	userPresetManager := formats.NewUserPresetManager(userPresets)
+	defaultPresetManager := NewDefaultPresetManager(GeneratorEnv.FS)
+
+	Presets = struct {
+		Default DefaultPresetManager
+		User    formats.UserPresetManager
+		Any     common.CompositePresetManager
+	}{
+		Default: defaultPresetManager,
+		User:    userPresetManager,
+		Any: common.NewCompositePresetManager(
+			userPresetManager,
+			defaultPresetManager,
+		),
+	}
 }

--- a/qt-cli/src/runner/text_ui.go
+++ b/qt-cli/src/runner/text_ui.go
@@ -58,27 +58,14 @@ func RunFilePromptByExt(ext string) (common.Preset, error) {
 func FindPresetOrRunSelector(
 	t common.TargetType, givenPresetName string) (common.Preset, error) {
 	if len(givenPresetName) != 0 {
-		return findPresetByName(t, givenPresetName)
+		return Presets.Any.FindByTypeAndName(t, givenPresetName)
 	}
 
 	return runPresetSelector(t)
 }
 
-func findPresetByName(
-	t common.TargetType, givenPresetName string) (common.Preset, error) {
-	if strings.HasPrefix(givenPresetName, "@") {
-		return FindDefaultPresetByTemplateDir(t, givenPresetName[1:])
-	}
-
-	return AllUserPresets.Find(t, givenPresetName)
-}
-
 func runPresetSelector(t common.TargetType) (common.Preset, error) {
-	all := []common.Preset{}
-	all = append(all, toPresetList(AllUserPresets.GetItemsOfTargetType(t))...)
-	all = append(all, toPresetList(FindDefaultPresets(t))...)
-
-	items := createPickerItems(all)
+	items := createPickerItems(Presets.Any.GetItemsByType(t))
 	items = append(items, comps.NewItem(util.Msg("[Manually select features]")))
 	picked, err := comps.NewPicker().
 		Question(util.Msg("Pick a preset")).
@@ -109,8 +96,7 @@ func runPresetSelector(t common.TargetType) (common.Preset, error) {
 }
 
 func runManualConfig(t common.TargetType) (common.Preset, error) {
-	presetItems := toPresetList(FindDefaultPresets(t))
-	pickerItems := createPickerItems(presetItems)
+	pickerItems := createPickerItems(Presets.Default.FindByType(t))
 
 	result, err := comps.NewPicker().
 		Question(util.Msg("Pick an item to use:")).
@@ -145,8 +131,8 @@ func runManualConfig(t common.TargetType) (common.Preset, error) {
 
 	if len(newName) != 0 {
 		presetData.Name = newName
-		AllUserPresets.Add(presetData)
-		AllUserPresets.Save()
+		Presets.User.GetFile().Add(presetData)
+		Presets.User.GetFile().Save()
 	}
 
 	return presetData, nil
@@ -206,25 +192,14 @@ func runPresetSavePrompt() string {
 	return strings.TrimSpace(s)
 }
 
-func createPickerItems(presets []common.Preset) []comps.ListItem {
+func createPickerItems(presets []common.PresetData) []comps.ListItem {
 	items := make([]comps.ListItem, len(presets))
 
 	for i, preset := range presets {
 		items[i] = comps.
-			NewItem(preset.GetName()).
-			Description(preset.GetDescription()).
+			NewItem(preset.GetDescription()).
 			Data(preset)
 	}
 
 	return items
-}
-
-func toPresetList[T common.Preset](items []T) []common.Preset {
-	all := make([]common.Preset, len(items))
-
-	for i, item := range items {
-		all[i] = item
-	}
-
-	return all
 }

--- a/qt-cli/tests/e2e/go.mod
+++ b/qt-cli/tests/e2e/go.mod
@@ -1,0 +1,3 @@
+module qtcli-e2e
+
+go 1.23.4

--- a/qt-cli/tests/e2e/new_file_test.go
+++ b/qt-cli/tests/e2e/new_file_test.go
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+package e2e
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestNewFile(t *testing.T) {
+	name := "myfile"
+	exts := []string{"qrc", "qml", "ts", "ui"}
+
+	for _, ext := range exts {
+		checker := func(workingDir string) {
+			fileName := name + "." + ext
+			fullPath := filepath.Join(workingDir, fileName)
+			CheckFileExists(t, fullPath)
+		}
+
+		t.Run(ext, func(t *testing.T) {
+			args := []string{
+				"new-file", name,
+				"--preset", "@types/" + ext,
+			}
+
+			RunQtcli(t, checker, args...)
+		})
+	}
+}

--- a/qt-cli/tests/e2e/new_project_test.go
+++ b/qt-cli/tests/e2e/new_project_test.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+package e2e
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+type ProjectPreset struct {
+	name          string
+	expectedFiles []string
+}
+
+func TestNewProject(t *testing.T) {
+	projectName := "myapp"
+	presets := []ProjectPreset{
+		{"cpp/console", []string{"CMakeLists.txt", "main.cpp"}},
+		{"cpp/qtquick", []string{"CMakeLists.txt", "main.cpp", "Main.qml"}},
+		{"cpp/qwidget", []string{
+			"CMakeLists.txt", "main.cpp",
+			"widget.cpp", "widget.h", "widget.ui",
+		}},
+	}
+
+	for _, preset := range presets {
+		checker := func(workingDir string) {
+			projectDir := filepath.Join(workingDir, projectName)
+			CheckDirHasFiles(t, projectDir, preset.expectedFiles)
+		}
+
+		t.Run(preset.name, func(t *testing.T) {
+			args := []string{
+				"new", projectName,
+				"--preset", "@projects/" + preset.name,
+			}
+
+			RunQtcli(t, checker, args...)
+		})
+	}
+}

--- a/qt-cli/tests/e2e/utils.go
+++ b/qt-cli/tests/e2e/utils.go
@@ -1,0 +1,73 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func RunQtcli(t *testing.T, checker func(string), args ...string) {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine current workding directory")
+	}
+
+	qtcliPath := filepath.Join(cwd, "..", "qtcli")
+	tempDir, err := os.MkdirTemp(cwd, "qtcli-e2e-")
+	if err != nil {
+		t.Fatal("cannot make temporal directory to run a test")
+	}
+
+	defer os.RemoveAll(tempDir)
+	cmd := exec.Command(qtcliPath, args...)
+	cmd.Dir = tempDir
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("cannot run command: %v", err)
+	}
+
+	checker(tempDir)
+}
+
+func CheckFileExists(t *testing.T, fullPath string) {
+	t.Helper()
+	s, err := os.Stat(fullPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if s.IsDir() {
+		t.Fatalf("found a directory instead of a file: %v", fullPath)
+	}
+
+	if s.Size() == 0 {
+		t.Fatalf("found but has no content: %v", fullPath)
+	}
+}
+
+func CheckDirExists(t *testing.T, fullPath string) {
+	t.Helper()
+	s, err := os.Stat(fullPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !s.IsDir() {
+		t.Fatalf("found a file instead of a directory: %v", fullPath)
+	}
+}
+
+func CheckDirHasFiles(t *testing.T, dir string, files []string) {
+	t.Helper()
+	CheckDirExists(t, dir)
+
+	for _, file := range files {
+		CheckFileExists(t, filepath.Join(dir, file))
+	}
+}

--- a/qt-core/src/extension.ts
+++ b/qt-core/src/extension.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 import * as vscode from 'vscode';
+import { isEmpty } from 'lodash';
 
 import {
   createLogger,
@@ -90,11 +91,15 @@ export function initCoreValues() {
     QtInsRootConfigName,
     getCurrentGlobalQtInstallationRoot()
   );
+  const currentAdditionalQtPaths = getCurrentGlobalAdditionalQtPaths();
   coreAPI?.setValue(
     GlobalWorkspace,
     AdditionalQtPathsName,
-    getCurrentGlobalAdditionalQtPaths()
+    currentAdditionalQtPaths
   );
+  if (!isEmpty(currentAdditionalQtPaths)) {
+    telemetry.sendEvent('additionalQtPathsUsedGlobal');
+  }
 
   for (const project of projectManager.getProjects()) {
     project.initConfigValues();

--- a/qt-core/src/project.ts
+++ b/qt-core/src/project.ts
@@ -3,7 +3,7 @@
 
 import * as vscode from 'vscode';
 import untildify from 'untildify';
-import { isEqual } from 'lodash';
+import { isEmpty, isEqual } from 'lodash';
 
 import {
   AdditionalQtPathsName,
@@ -11,7 +11,8 @@ import {
   GlobalWorkspace,
   QtInsRootConfigName,
   QtAdditionalPath,
-  compareQtAdditionalPath
+  compareQtAdditionalPath,
+  telemetry
 } from 'qt-lib';
 import { Project, ProjectManager } from 'qt-lib';
 import { convertAdditionalQtPaths, getConfiguration } from '@/util';
@@ -107,6 +108,9 @@ export class CoreProject implements Project {
       `Setting additional Qt paths for ${folder.uri.fsPath} to: ${additionalQtPaths.join(', ')}`
     );
     logger.info('Config values initialized for:', folder.uri.fsPath);
+    if (!isEmpty(additionalQtPaths)) {
+      telemetry.sendEvent('additionalQtPathsUsedWorkspace');
+    }
   }
 
   dispose() {

--- a/qt-qml/src/qmlls.ts
+++ b/qt-qml/src/qmlls.ts
@@ -20,7 +20,8 @@ import {
   OSExeSuffix,
   QtInsRootConfigName,
   compareVersions,
-  GlobalWorkspace
+  GlobalWorkspace,
+  telemetry
 } from 'qt-lib';
 import { coreAPI, projectManager } from '@/extension';
 import { EXTENSION_ID } from '@/constants';
@@ -98,6 +99,7 @@ export async function fetchAssetAndDecide(options?: {
           return { code: DecisionCode.UserDeclined };
         }
       }
+      telemetry.sendAction('UserConsentNewerVersionOfQmlls');
       return { code: DecisionCode.NeedToUpdate, asset };
     } catch (error) {
       logger.warn(isError(error) ? error.message : String(error));
@@ -206,7 +208,7 @@ export class Qmlls {
         if (res.status !== 0) {
           throw res.error ?? new Error(res.stderr.toString());
         }
-
+        telemetry.sendAction('customQmllsUsage');
         this.startLanguageClient(customPath);
       } else {
         const installed = installer.getExpectedQmllsPath();
@@ -321,6 +323,7 @@ export class Qmlls {
         logger.info(
           `QML Language Server started for ${this._folder.name} ${qmllsPath}`
         );
+        telemetry.sendEvent('QmllsStarted');
       })
       .catch(() => {
         void vscode.window.showErrorMessage('Cannot start QML language server');

--- a/qt-ui/src/editors/ui/ui-editor.ts
+++ b/qt-ui/src/editors/ui/ui-editor.ts
@@ -3,7 +3,12 @@
 
 import * as vscode from 'vscode';
 
-import { askForKitSelection, createLogger, QtWorkspaceType } from 'qt-lib';
+import {
+  askForKitSelection,
+  createLogger,
+  QtWorkspaceType,
+  telemetry
+} from 'qt-lib';
 import { getNonce, getUri } from '@/editors/util';
 import { projectManager } from '@/extension';
 import { delay } from '@/util';
@@ -62,6 +67,7 @@ export class UIEditorProvider implements vscode.CustomTextEditorProvider {
           while (!designerServer.isClientConnected()) {
             await delay(100);
           }
+          telemetry.sendAction('openWithDesigner');
           designerServer.sendFile(document.uri.fsPath);
           logger.info('File sent to designer server: ' + document.uri.fsPath);
           break;


### PR DESCRIPTION
Add sign-qtcli GitHub action.
Update the workflow to optionally trigger the sign-qtcli action. 
Modify the qtcli build configuration to output binaries 
in the dist/bin folder for easier integration with actions.

Task-number: [VSCODEEXT-122](https://bugreports.qt.io/browse/VSCODEEXT-122)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
