### PR TITLE
qt-cli: Align preset usage by introducing preset manager

### DIFF
--- a/qt-cli/src/cmds/preset_cmd.go
+++ b/qt-cli/src/cmds/preset_cmd.go
@@ -6,12 +6,10 @@ package cmds
 import (
 	"errors"
 	"fmt"
-	"qtcli/common"
 	"qtcli/formats"
 	"qtcli/prompt/comps"
 	"qtcli/runner"
 	"qtcli/util"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -29,19 +27,17 @@ var presetListCmd = &cobra.Command{
 	Short: util.Msg("List the names of all presets"),
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		if userPresets().GetCount() == 0 {
+		items := runner.Presets.User.GetAll()
+		if len(items) == 0 {
 			fmt.Println(util.Msg("<no custom preset>"))
-		} else {
-			for _, item := range userPresets().GetItems() {
-				fmt.Printf("%s -> @%s\n", item.GetName(), item.GetDescription())
-			}
 		}
 
 		if lsAllPresets {
-			all := runner.FindAllDefaultPresets()
-			for _, item := range all {
-				fmt.Printf("%s (%s)\n", item.GetName(), item.GetTypeId())
-			}
+			items = append(items, runner.Presets.Default.GetAll()...)
+		}
+
+		for _, item := range items {
+			fmt.Println(item.GetDescription())
 		}
 	},
 }
@@ -51,31 +47,13 @@ var presetCatCmd = &cobra.Command{
 	Short: util.Msg("Print the contents of the given preset"),
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		item := common.PresetData{}
 		name := args[0]
-
-		if !strings.HasPrefix(name, "@") {
-			i, err := userPresets().FindByName(name)
-			if err != nil {
-				return err
-			}
-
-			item = i
-		} else {
-			name = name[1:]
-
-			for _, p := range runner.FindAllDefaultPresets() {
-				if p.GetTemplateDir() == name {
-					item = p.ToPresetData()
-					break
-				}
-			}
+		item, err := runner.Presets.Any.FindByName(name)
+		if err != nil {
+			return err
 		}
 
-		if len(item.TemplateDir) != 0 {
-			fmt.Println(item.ToYaml())
-		}
-
+		fmt.Println(item.ToYaml())
 		return nil
 	},
 }
@@ -161,7 +139,7 @@ func getConfirm(msg string) bool {
 }
 
 func userPresets() *formats.UserPresetFile {
-	return runner.AllUserPresets
+	return runner.Presets.User.GetFile()
 }
 
 func init() {

--- a/qt-cli/src/cmds/root_cmd.go
+++ b/qt-cli/src/cmds/root_cmd.go
@@ -14,8 +14,8 @@ import (
 var verbose = false
 
 var rootCmd = &cobra.Command{
-	Use:     "qtcli",
-	Short:   util.Msg("A CLI for creating Qt project and files"),
+	Use:   "qtcli",
+	Short: util.Msg("A CLI for creating Qt project and files"),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if verbose {
 			logrus.SetLevel(logrus.DebugLevel)
@@ -41,5 +41,4 @@ func init() {
 	rootCmd.SilenceUsage = true
 	rootCmd.PersistentFlags().BoolVarP(
 		&verbose, "verbose", "v", false, util.Msg("Enable verbose output"))
-
 }

--- a/qt-cli/src/cmds/test_cmd.go
+++ b/qt-cli/src/cmds/test_cmd.go
@@ -30,16 +30,16 @@ var testPromptCmd = &cobra.Command{
 			return createNotFoundError(args[0])
 		}
 
-		name := args[0][1:]
+		name := args[0]
 
-		for _, p := range runner.FindAllDefaultPresets() {
-			if p.TemplateDir == name {
-				options, err := runner.RunPromptFromDir(name)
+		for _, p := range runner.Presets.Default.GetAll() {
+			if p.Name == name {
+				options, err := runner.RunPromptFromDir(name[1:])
 				if err != nil {
 					return err
 				}
 
-				item := p.ToPresetData()
+				item := p
 				item.Options = options
 				printPreset(item)
 				return nil
@@ -61,9 +61,9 @@ var testDefaultCmd = &cobra.Command{
 
 		name := args[0][1:]
 
-		for _, p := range runner.FindAllDefaultPresets() {
+		for _, p := range runner.Presets.Default.GetAll() {
 			if name == p.TemplateDir {
-				printPreset(p.ToPresetData())
+				printPreset(p)
 				return nil
 			}
 		}

--- a/qt-cli/src/common/preset.go
+++ b/qt-cli/src/common/preset.go
@@ -4,7 +4,9 @@
 package common
 
 import (
+	"fmt"
 	"qtcli/util"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -12,6 +14,7 @@ import (
 type Preset interface {
 	GetName() string
 	GetTypeId() TargetType
+	GetTypeName() string
 	GetDescription() string
 	GetTemplateDir() string
 	GetOptions() util.StringAnyMap
@@ -32,8 +35,16 @@ func (p PresetData) GetTypeId() TargetType {
 	return TargetTypeFromString(p.TypeName)
 }
 
+func (p PresetData) GetTypeName() string {
+	return TargetTypeToString(p.GetTypeId())
+}
+
 func (p PresetData) GetDescription() string {
-	return p.TemplateDir
+	if strings.HasPrefix(p.Name, "@") {
+		return fmt.Sprintf("[Default] %s", p.Name)
+	} else {
+		return fmt.Sprintf("%s (-> @%s)", p.Name, p.TemplateDir)
+	}
 }
 
 func (p PresetData) GetTemplateDir() string {

--- a/qt-cli/src/common/preset_manager.go
+++ b/qt-cli/src/common/preset_manager.go
@@ -1,0 +1,87 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+package common
+
+import (
+	"fmt"
+	"qtcli/util"
+)
+
+type PresetManager interface {
+	GetAll() []PresetData
+	FindByType(t TargetType) []PresetData
+	FindByName(name string) (PresetData, error)
+	FindByTypeAndName(t TargetType, name string) (PresetData, error)
+}
+
+type CompositePresetManager struct {
+	comps []PresetManager
+}
+
+func NewCompositePresetManager(comps ...PresetManager) CompositePresetManager {
+	return CompositePresetManager{comps: comps}
+}
+
+func (m CompositePresetManager) GetAll() []PresetData {
+	all := []PresetData{}
+
+	for _, c := range m.comps {
+		all = append(all, c.GetAll()...)
+	}
+
+	return all
+}
+
+func (m CompositePresetManager) GetItemsByType(t TargetType) []PresetData {
+	all := []PresetData{}
+
+	for _, c := range m.comps {
+		all = append(all, c.FindByType(t)...)
+	}
+
+	return all
+}
+
+func (m CompositePresetManager) FindByName(name string) (PresetData, error) {
+	for _, c := range m.comps {
+		preset, err := c.FindByName(name)
+		if err == nil {
+			return preset, nil
+		}
+	}
+
+	return notFoundError(name)
+}
+
+func (m CompositePresetManager) FindByTypeAndName(
+	t TargetType,
+	name string,
+) (PresetData, error) {
+	for _, c := range m.comps {
+		preset, err := FindByTypeAndName(c, t, name)
+		if err == nil {
+			return preset, nil
+		}
+	}
+
+	return notFoundError(name)
+}
+
+// helpers
+func FindByTypeAndName(
+	m PresetManager,
+	t TargetType,
+	name string,
+) (PresetData, error) {
+	candidate, err := m.FindByName(name)
+	if err == nil && candidate.GetTypeId() == t {
+		return candidate, nil
+	}
+
+	return notFoundError(name)
+}
+
+func notFoundError(name string) (PresetData, error) {
+	return PresetData{}, fmt.Errorf(util.Msg("not found, given = '%v'"), name)
+}

--- a/qt-cli/src/common/target_type.go
+++ b/qt-cli/src/common/target_type.go
@@ -5,11 +5,11 @@ package common
 
 import "strings"
 
-type TargetType string
+type TargetType int
 
 const (
-	TargetTypeFile    TargetType = "File"
-	TargetTypeProject TargetType = "Project"
+	TargetTypeFile TargetType = iota
+	TargetTypeProject
 )
 
 func TargetTypeFromString(s string) TargetType {
@@ -25,5 +25,5 @@ func TargetTypeToString(t TargetType) string {
 		return "project"
 	}
 
-	return "files"
+	return "file"
 }

--- a/qt-cli/src/formats/user_preset_file.go
+++ b/qt-cli/src/formats/user_preset_file.go
@@ -99,7 +99,7 @@ func (f *UserPresetFile) GetAllNames() []string {
 	return all
 }
 
-func (f *UserPresetFile) GetItems() []common.PresetData {
+func (f *UserPresetFile) GetAll() []common.PresetData {
 	return f.contents.Items
 }
 
@@ -196,4 +196,38 @@ func (f *UserPresetFile) Rename(from string, to string) error {
 	}
 
 	return f.Remove(from)
+}
+
+// manager
+type UserPresetManager struct {
+	file *UserPresetFile
+}
+
+func NewUserPresetManager(f *UserPresetFile) UserPresetManager {
+	return UserPresetManager{file: f}
+}
+
+func (m UserPresetManager) GetAll() []common.PresetData {
+	return m.file.GetAll()
+}
+
+func (m UserPresetManager) FindByType(
+	t common.TargetType,
+) []common.PresetData {
+	return m.file.GetItemsOfTargetType(t)
+}
+
+func (m UserPresetManager) FindByName(name string) (common.PresetData, error) {
+	return m.file.FindByName(name)
+}
+
+func (m UserPresetManager) FindByTypeAndName(
+	t common.TargetType,
+	name string,
+) (common.PresetData, error) {
+	return common.FindByTypeAndName(m, t, name)
+}
+
+func (m UserPresetManager) GetFile() *UserPresetFile {
+	return m.file
 }

--- a/qt-cli/src/generator/result.go
+++ b/qt-cli/src/generator/result.go
@@ -28,3 +28,13 @@ func (r *Result) Print(output io.Writer) {
 
 	w.Flush()
 }
+
+func (r *Result) GetOutputFilePaths() []string {
+	all := []string{}
+
+	for _, item := range *r {
+		all = append(all, item.OutputFilePath)
+	}
+
+	return all
+}

--- a/qt-cli/src/runner/default_preset.go
+++ b/qt-cli/src/runner/default_preset.go
@@ -4,7 +4,7 @@
 package runner
 
 import (
-	"fmt"
+	"errors"
 	"io/fs"
 	"path"
 	"qtcli/common"
@@ -12,99 +12,90 @@ import (
 	"qtcli/util"
 )
 
-type DefaultPresets struct {
-	Type         common.TargetType
-	TemplateDirs []string
+type DefaultPresetManager struct {
+	baseFS  fs.FS
+	presets map[common.TargetType][]common.PresetData
 }
 
-type DefaultPreset struct {
-	Name        string
-	TypeId      common.TargetType
-	TemplateDir string
-}
-
-func (p DefaultPreset) GetName() string {
-	return p.Name
-}
-
-func (p DefaultPreset) GetTypeId() common.TargetType {
-	return p.TypeId
-}
-
-func (p DefaultPreset) GetDescription() string {
-	return ""
-}
-
-func (p DefaultPreset) GetTemplateDir() string {
-	return p.TemplateDir
-}
-
-func (p DefaultPreset) GetOptions() util.StringAnyMap {
-	fullPath := path.Join(
-		p.TemplateDir,
-		common.PromptFileName)
-
-	f := formats.NewPromptFileFS(GeneratorEnv.FS, fullPath)
-	if err := f.Open(); err != nil {
-		return util.StringAnyMap{}
+func NewDefaultPresetManager(baseFS fs.FS) DefaultPresetManager {
+	presets := map[common.TargetType][]common.PresetData{
+		common.TargetTypeFile:    loadPresets(baseFS, common.TargetTypeFile),
+		common.TargetTypeProject: loadPresets(baseFS, common.TargetTypeProject),
 	}
 
-	return f.ExtractDefaults()
-}
-
-func (p DefaultPreset) ToPresetData() common.PresetData {
-	return common.PresetData{
-		Name:        p.Name,
-		TypeName:    common.TargetTypeToString(p.TypeId),
-		TemplateDir: p.TemplateDir,
-		Options:     p.GetOptions(),
+	return DefaultPresetManager{
+		baseFS:  baseFS,
+		presets: presets,
 	}
 }
 
-// helpers
-func FindAllDefaultPresets() []DefaultPreset {
-	all := []DefaultPreset{}
-	all = append(all, FindDefaultPresets(common.TargetTypeProject)...)
-	all = append(all, FindDefaultPresets(common.TargetTypeFile)...)
-
-	return all
+func (m DefaultPresetManager) GetAll() []common.PresetData {
+	return append(
+		m.FindByType(common.TargetTypeProject),
+		m.FindByType(common.TargetTypeFile)...,
+	)
 }
 
-func FindDefaultPresets(t common.TargetType) []DefaultPreset {
-	all := []DefaultPreset{}
-	names, err := findAllDefaultPresetNames(t)
+func (m DefaultPresetManager) FindByType(
+	t common.TargetType,
+) []common.PresetData {
+	presets, exists := m.presets[t]
+	if exists {
+		return presets
+	}
+
+	return []common.PresetData{}
+}
+
+func loadPresets(baseFS fs.FS, t common.TargetType) []common.PresetData {
+	all := []common.PresetData{}
+	dirs, err := findAllTemplateDirNames(baseFS, t)
 
 	if err == nil {
-		for _, name := range names {
-			all = append(all, DefaultPreset{
-				Name:        "[Default] @" + name,
-				TypeId:      t,
-				TemplateDir: name,
-			})
+		for _, dir := range dirs {
+			p := common.PresetData{
+				Name:        "@" + dir,
+				TypeName:    common.TargetTypeToString(t),
+				TemplateDir: dir,
+				Options:     readDefaultOptions(baseFS, dir),
+			}
+
+			all = append(all, p)
 		}
 	}
 
 	return all
 }
 
-func FindDefaultPresetByTemplateDir(t common.TargetType, dir string) (
-	DefaultPreset, error) {
-	presets := FindDefaultPresets(t)
+func (m DefaultPresetManager) FindByName(
+	name string,
+) (common.PresetData, error) {
+	all := m.GetAll()
 
-	for _, preset := range presets {
-		if dir == preset.TemplateDir {
+	for _, preset := range all {
+		if preset.GetName() == name {
 			return preset, nil
 		}
 	}
 
-	return DefaultPreset{},
-		fmt.Errorf(util.Msg("cannot find default preset, given = '%v'"), dir)
+	return common.PresetData{}, errors.New("not found")
 }
 
-func findAllDefaultPresetNames(t common.TargetType) ([]string, error) {
+func (m DefaultPresetManager) FindByTypeAndName(
+	t common.TargetType,
+	name string,
+) (common.PresetData, error) {
+	return common.FindByTypeAndName(m, t, name)
+}
+
+// helpers
+func findAllTemplateDirNames(
+	baseFS fs.FS,
+	t common.TargetType,
+) ([]string, error) {
 	var found []string
 
-	err := fs.WalkDir(GeneratorEnv.FS, ".",
+	err := fs.WalkDir(baseFS, ".",
 		func(walkingPath string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
@@ -112,8 +103,7 @@ func findAllDefaultPresetNames(t common.TargetType) ([]string, error) {
 
 			if d.IsDir() && walkingPath != "." {
 				fullPath := path.Join(walkingPath, common.TemplateFileName)
-				templateFile := formats.NewTemplateFileFS(
-					GeneratorEnv.FS, fullPath)
+				templateFile := formats.NewTemplateFileFS(baseFS, fullPath)
 				err := templateFile.Open()
 
 				if err == nil && templateFile.GetTargetType() == t {
@@ -125,4 +115,15 @@ func findAllDefaultPresetNames(t common.TargetType) ([]string, error) {
 		})
 
 	return found, err
+}
+
+func readDefaultOptions(baseFS fs.FS, templateDir string) util.StringAnyMap {
+	fullPath := path.Join(templateDir, common.PromptFileName)
+
+	f := formats.NewPromptFileFS(baseFS, fullPath)
+	if err := f.Open(); err != nil {
+		return util.StringAnyMap{}
+	}
+
+	return f.ExtractDefaults()
 }

--- a/qt-cli/src/runner/runner.go
+++ b/qt-cli/src/runner/runner.go
@@ -16,7 +16,12 @@ import (
 )
 
 var GeneratorEnv *generator.Env
-var AllUserPresets *formats.UserPresetFile
+
+var Presets struct {
+	Default DefaultPresetManager
+	User    formats.UserPresetManager
+	Any     common.CompositePresetManager
+}
 
 func init() {
 	baseFS, err := fs.Sub(assets.Assets, "templates")
@@ -42,5 +47,20 @@ func init() {
 		logrus.Fatal(err)
 	}
 
-	AllUserPresets = userPresets
+	// preset managers
+	userPresetManager := formats.NewUserPresetManager(userPresets)
+	defaultPresetManager := NewDefaultPresetManager(GeneratorEnv.FS)
+
+	Presets = struct {
+		Default DefaultPresetManager
+		User    formats.UserPresetManager
+		Any     common.CompositePresetManager
+	}{
+		Default: defaultPresetManager,
+		User:    userPresetManager,
+		Any: common.NewCompositePresetManager(
+			userPresetManager,
+			defaultPresetManager,
+		),
+	}
 }

--- a/qt-cli/src/runner/text_ui.go
+++ b/qt-cli/src/runner/text_ui.go
@@ -58,27 +58,14 @@ func RunFilePromptByExt(ext string) (common.Preset, error) {
 func FindPresetOrRunSelector(
 	t common.TargetType, givenPresetName string) (common.Preset, error) {
 	if len(givenPresetName) != 0 {
-		return findPresetByName(t, givenPresetName)
+		return Presets.Any.FindByTypeAndName(t, givenPresetName)
 	}
 
 	return runPresetSelector(t)
 }
 
-func findPresetByName(
-	t common.TargetType, givenPresetName string) (common.Preset, error) {
-	if strings.HasPrefix(givenPresetName, "@") {
-		return FindDefaultPresetByTemplateDir(t, givenPresetName[1:])
-	}
-
-	return AllUserPresets.Find(t, givenPresetName)
-}
-
 func runPresetSelector(t common.TargetType) (common.Preset, error) {
-	all := []common.Preset{}
-	all = append(all, toPresetList(AllUserPresets.GetItemsOfTargetType(t))...)
-	all = append(all, toPresetList(FindDefaultPresets(t))...)
-
-	items := createPickerItems(all)
+	items := createPickerItems(Presets.Any.GetItemsByType(t))
 	items = append(items, comps.NewItem(util.Msg("[Manually select features]")))
 	picked, err := comps.NewPicker().
 		Question(util.Msg("Pick a preset")).
@@ -109,8 +96,7 @@ func runPresetSelector(t common.TargetType) (common.Preset, error) {
 }
 
 func runManualConfig(t common.TargetType) (common.Preset, error) {
-	presetItems := toPresetList(FindDefaultPresets(t))
-	pickerItems := createPickerItems(presetItems)
+	pickerItems := createPickerItems(Presets.Default.FindByType(t))
 
 	result, err := comps.NewPicker().
 		Question(util.Msg("Pick an item to use:")).
@@ -145,8 +131,8 @@ func runManualConfig(t common.TargetType) (common.Preset, error) {
 
 	if len(newName) != 0 {
 		presetData.Name = newName
-		AllUserPresets.Add(presetData)
-		AllUserPresets.Save()
+		Presets.User.GetFile().Add(presetData)
+		Presets.User.GetFile().Save()
 	}
 
 	return presetData, nil
@@ -206,25 +192,14 @@ func runPresetSavePrompt() string {
 	return strings.TrimSpace(s)
 }
 
-func createPickerItems(presets []common.Preset) []comps.ListItem {
+func createPickerItems(presets []common.PresetData) []comps.ListItem {
 	items := make([]comps.ListItem, len(presets))
 
 	for i, preset := range presets {
 		items[i] = comps.
-			NewItem(preset.GetName()).
-			Description(preset.GetDescription()).
+			NewItem(preset.GetDescription()).
 			Data(preset)
 	}
 
 	return items
-}
-
-func toPresetList[T common.Preset](items []T) []common.Preset {
-	all := make([]common.Preset, len(items))
-
-	for i, item := range items {
-		all[i] = item
-	}
-
-	return all
 }


### PR DESCRIPTION
Aligned the usage of default and user presets,
which previously had diffrent usage patterns.
Introduced a composite preset manager to handle cases requiring both presets.
Removed redundant structures and functions to simplify the code.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
