### PR TITLE
qt-cli: Add end-to-end tests

### DIFF
--- a/qt-cli/.gitignore
+++ b/qt-cli/.gitignore
@@ -1,1 +1,3 @@
 dist/
+tests/qtcli
+tests/qtcli.exe

--- a/qt-cli/Development.md
+++ b/qt-cli/Development.md
@@ -70,3 +70,13 @@ After changing to the `src/` directory, run `go-licenses report` with the prepar
 $ cd src
 $ go-licenses report . --template ../others/ThirdPartyNotices.tpl --ignore qtcli > ../ThirdPartyNotices.txt
 ```
+
+### How to run end-to-end tests
+
+To run e2e tests, build `qtcli` and output it to the `tests/` directory.
+Then run the tests in the `tests/e2e` directory.
+
+```bash
+$ go build -C ./src -o ../tests
+$ go test -C ./tests/e2e -v
+```

--- a/qt-cli/tests/e2e/go.mod
+++ b/qt-cli/tests/e2e/go.mod
@@ -1,0 +1,3 @@
+module qtcli-e2e
+
+go 1.23.4

--- a/qt-cli/tests/e2e/new_file_test.go
+++ b/qt-cli/tests/e2e/new_file_test.go
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+package e2e
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestNewFile(t *testing.T) {
+	name := "myfile"
+	exts := []string{"qrc", "qml", "ts", "ui"}
+
+	for _, ext := range exts {
+		checker := func(workingDir string) {
+			fileName := name + "." + ext
+			fullPath := filepath.Join(workingDir, fileName)
+			CheckFileExists(t, fullPath)
+		}
+
+		t.Run(ext, func(t *testing.T) {
+			args := []string{
+				"new-file", name,
+				"--preset", "@types/" + ext,
+			}
+
+			RunQtcli(t, checker, args...)
+		})
+	}
+}

--- a/qt-cli/tests/e2e/new_project_test.go
+++ b/qt-cli/tests/e2e/new_project_test.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+package e2e
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+type ProjectPreset struct {
+	name          string
+	expectedFiles []string
+}
+
+func TestNewProject(t *testing.T) {
+	projectName := "myapp"
+	presets := []ProjectPreset{
+		{"cpp/console", []string{"CMakeLists.txt", "main.cpp"}},
+		{"cpp/qtquick", []string{"CMakeLists.txt", "main.cpp", "Main.qml"}},
+		{"cpp/qwidget", []string{
+			"CMakeLists.txt", "main.cpp",
+			"widget.cpp", "widget.h", "widget.ui",
+		}},
+	}
+
+	for _, preset := range presets {
+		checker := func(workingDir string) {
+			projectDir := filepath.Join(workingDir, projectName)
+			CheckDirHasFiles(t, projectDir, preset.expectedFiles)
+		}
+
+		t.Run(preset.name, func(t *testing.T) {
+			args := []string{
+				"new", projectName,
+				"--preset", "@projects/" + preset.name,
+			}
+
+			RunQtcli(t, checker, args...)
+		})
+	}
+}

--- a/qt-cli/tests/e2e/utils.go
+++ b/qt-cli/tests/e2e/utils.go
@@ -1,0 +1,73 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func RunQtcli(t *testing.T, checker func(string), args ...string) {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine current workding directory")
+	}
+
+	qtcliPath := filepath.Join(cwd, "..", "qtcli")
+	tempDir, err := os.MkdirTemp(cwd, "qtcli-e2e-")
+	if err != nil {
+		t.Fatal("cannot make temporal directory to run a test")
+	}
+
+	defer os.RemoveAll(tempDir)
+	cmd := exec.Command(qtcliPath, args...)
+	cmd.Dir = tempDir
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("cannot run command: %v", err)
+	}
+
+	checker(tempDir)
+}
+
+func CheckFileExists(t *testing.T, fullPath string) {
+	t.Helper()
+	s, err := os.Stat(fullPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if s.IsDir() {
+		t.Fatalf("found a directory instead of a file: %v", fullPath)
+	}
+
+	if s.Size() == 0 {
+		t.Fatalf("found but has no content: %v", fullPath)
+	}
+}
+
+func CheckDirExists(t *testing.T, fullPath string) {
+	t.Helper()
+	s, err := os.Stat(fullPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !s.IsDir() {
+		t.Fatalf("found a file instead of a directory: %v", fullPath)
+	}
+}
+
+func CheckDirHasFiles(t *testing.T, dir string, files []string) {
+	t.Helper()
+	CheckDirExists(t, dir)
+
+	for _, file := range files {
+		CheckFileExists(t, filepath.Join(dir, file))
+	}
+}


### PR DESCRIPTION
Added e2e tests for creating a new file and project. 
The tests expect the `qtcli` binary to be located under the `tests/` directory. 
The documentation and .gitignore have been updated accordingly.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
