### PR TITLE
qt-cli: Include qtcli tests in the workflow

### DIFF
--- a/.github/workflows/qtcli/action.yml
+++ b/.github/workflows/qtcli/action.yml
@@ -29,6 +29,13 @@ runs:
         echo "- $(go version)"
         echo "- qtcli version $V ($H)"
 
+    - name: Run e2e test (on ${{ runner.os }})
+      shell: bash
+      run: |
+        cd ${{ inputs.working-directory }}
+        go build -C ./src -o ../tests && \
+        go test -C ./tests/e2e -v
+
     - name: Run goreleaser
       uses: goreleaser/goreleaser-action@v6
       with:

--- a/.github/workflows/test-qtcli-all.yml
+++ b/.github/workflows/test-qtcli-all.yml
@@ -1,0 +1,32 @@
+name: Run tests on qtcli (all platforms)
+on:
+  pull_request:
+    paths:
+      - 'qt-cli/**'
+
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup environment
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: ./qt-cli/src/go.mod
+          cache-dependency-path: ./qt-cli/src/go.sum
+          cache: true
+
+      - name: Build and test
+        shell: bash
+        run: |
+          cd ./qt-cli
+          go build -C ./src -o ../tests && \
+          go test -C ./tests/e2e -v


### PR DESCRIPTION
Added end-to-end tests to the qtcli build action.
Added a new workflow to run end-to-end tests across multiple platforms.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
