### PR TITLE
qt-cli: Add signing action for qtcli

### DIFF
--- a/.github/actions/build-qtcli/action.yml
+++ b/.github/actions/build-qtcli/action.yml
@@ -4,10 +4,14 @@ inputs:
   working-directory:
     description: 'Root directory of qt-cli (relative to repository root)'
     default: '.'
-    required: false
+
   deploy-target:
     description: 'Folder where built binaries will be copied'
-    required: false
+
+outputs:
+  artifact-name:
+    description: 'Build artifact name'
+    value: ${{ steps.setup-env.outputs.artifact-name }}
 
 runs:
   using: "composite"
@@ -19,13 +23,15 @@ runs:
         cache: true
 
     - name: Setup build environment
+      id: setup-env
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
         V=$(head -n 1 version.txt | xargs)
         H=$(git rev-parse --short $GITHUB_SHA)
-        echo QTCLI_VERSION=$V >> $GITHUB_ENV
-        echo QTCLI_SHORT_HASH=$H >> $GITHUB_ENV
+
+        echo "QTCLI_VERSION=$V" >> $GITHUB_ENV
+        echo "artifact-name=qtcli-$V-$H" >> $GITHUB_OUTPUT
         echo "- $(go version)"
         echo "- qtcli version $V ($H)"
 
@@ -46,15 +52,18 @@ runs:
       env:
         GORELEASER_CURRENT_TAG: ${{ env.QTCLI_VERSION }}
 
-    - name: Upload artifacts
+    - name: Upload artifact
+      id: step-artifacts-upload
       uses: actions/upload-artifact@v4
       with:
-        name: qtcli-${{ env.QTCLI_VERSION }}-${{ env.QTCLI_SHORT_HASH }}
-        path: ${{ inputs.working-directory }}/dist/*
+        name: ${{ steps.setup-env.outputs.artifact-name }}
+        path: ${{ inputs.working-directory }}/dist/bin/*
 
-    - name: Copy output files
+    - name: Deploy files (unsigned)
       shell: bash
       if: ${{ inputs.deploy-target != '' }}
       run: |
         mkdir -p ${{ inputs.deploy-target }}
-        cp -r ${{ inputs.working-directory }}/dist/qtcli-* ${{ inputs.deploy-target }}
+        cp -r ${{ inputs.working-directory }}/dist/bin/qtcli-* ${{ inputs.deploy-target }}
+        echo "---------------------------------"
+        cd ${{ inputs.deploy-target }} && find . && du -h

--- a/.github/actions/sign-qtcli/action.yml
+++ b/.github/actions/sign-qtcli/action.yml
@@ -1,0 +1,77 @@
+name: Sign qtcli binaries
+
+inputs:
+  build-artifact:
+    description: 'Artifact name of built binaries'
+    required: true
+
+  worker-token:
+    description: 'Token for accessing the worker'
+    required: true
+
+  worker-owner:
+    description: 'Owner of the repository'
+    default: TheQtCompanyRnD
+
+  worker-repo:
+    description: 'Repository name of the worker'
+    default: qtcli-workflow
+
+  worker-workflow:
+    description: 'Workflow file name to use'
+    default: sign-qtcli.yml
+
+  worker-branch:
+    description: 'Branch to use'
+    default: main
+
+  deploy-target:
+    description: 'Folder where built binaries will be copied'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Trigger the worker
+      id: worker
+      uses: convictional/trigger-workflow-and-wait@v1.6.5
+      with:
+        owner: ${{ inputs.worker-owner }}
+        repo: ${{ inputs.worker-repo }}
+        github_token: ${{ inputs.worker-token }}
+        workflow_file_name: ${{ inputs.worker-workflow }}
+        ref: ${{ inputs.worker-branch }}
+        client_payload: |
+          {
+            "build-repo": "${{ github.repository }}",
+            "build-run-id": "${{ github.run_id }}",
+            "build-artifact": "${{ inputs.build-artifact }}"
+          }
+        wait_interval: 10
+        wait_workflow: true
+        trigger_workflow: true
+        propagate_failure: true
+
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.build-artifact }}-signed
+        github-token: ${{ inputs.worker-token }}
+        repository: ${{ inputs.worker-owner }}/${{ inputs.worker-repo }}
+        run-id: ${{ steps.worker.outputs.workflow_id }}
+        path: "./signed-qtcli"
+
+    - name: Upload signed qtcli
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.build-artifact }}-signed
+        path: "./signed-qtcli/*"
+
+    - name: Deploy files (signed)
+      if: ${{ inputs.deploy-target != '' }}
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.deploy-target }}
+        cp -r ./signed-qtcli/qtcli-* ${{ inputs.deploy-target }}
+        find . -type f -name "qtcli" -exec chmod 755 {} \;
+        echo "---------------------------------"
+        cd ${{ inputs.deploy-target }} && find . && du -h

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,17 +1,37 @@
 name: Build on Linux
+
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      enable-qtcli-signing:
+        description: "Enable qtcli signing (true/false)"
+        default: "false"
+        required: true
 
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # qtcli
       - name: Build qtcli
-        uses: ./.github/workflows/qtcli
+        id: build-qtcli
+        uses: ./.github/actions/build-qtcli
         with:
           working-directory: ./qt-cli
           deploy-target: ./qt-core/res/qtcli
+
+      - name: Sign qtcli
+        uses: ./.github/actions/sign-qtcli
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable-qtcli-signing == 'true' }}
+        with:
+          build-artifact: ${{ steps.build-qtcli.outputs.artifact-name }}
+          worker-token: ${{ secrets.PAT }}
+          deploy-target: ./qt-core/res/qtcli
+
+      # extensions
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/qt-cli/.goreleaser.yaml
+++ b/qt-cli/.goreleaser.yaml
@@ -24,7 +24,7 @@ builds:
       - -X main.commit={{ .FullCommit }}
     binary: >-
       {{- if eq .Os "darwin" }}_intermediate/{{ end -}}
-      qtcli-
+      bin/qtcli-
       {{- .Os }}-
       {{- .Arch }}-
       {{- .Version }}/qtcli
@@ -37,8 +37,10 @@ builds:
 
 universal_binaries:
   - name_template: qtcli
+    replace: true
     hooks:
-      post: mv {{ .Path | dir }} dist/qtcli-darwin-fat-{{- .Version }}/
+      post:
+        - mv {{ .Path | dir }} dist/bin/qtcli-darwin-all-{{- .Version }}/
 
 snapshot:
   version_template: '{{ .Version }}'


### PR DESCRIPTION
Add sign-qtcli GitHub action.
Update the workflow to optionally trigger the sign-qtcli action. 
Modify the qtcli build configuration to output binaries 
in the dist/bin folder for easier integration with actions.

Task-number: [VSCODEEXT-122](https://bugreports.qt.io/browse/VSCODEEXT-122)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
