### PR TITLE
qt-cli: Reduce consecutive empty lines to a single line

### DIFF
--- a/qt-cli/src/generator/generator.go
+++ b/qt-cli/src/generator/generator.go
@@ -10,6 +10,7 @@ import (
 	"qtcli/common"
 	"qtcli/formats"
 	"qtcli/util"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -226,5 +227,12 @@ func (g *Generator) evalWhenCondition(file formats.TemplateItem) (bool, error) {
 }
 
 func polishOutput(contents string) string {
-	return strings.TrimLeft(contents, " \t\r\n")
+	tooManyLinesWin := regexp.MustCompile(`(\r\n){3,}`)
+	tooManyLinesUnix := regexp.MustCompile(`\n{3,}`)
+
+	v := strings.TrimLeft(contents, " \t\r\n")
+	v = tooManyLinesWin.ReplaceAllString(v, "\r\n\r\n")
+	v = tooManyLinesUnix.ReplaceAllString(v, "\n\n")
+
+	return v
 }


### PR DESCRIPTION
Before saving the generated output to a file, 
consecutive empty lines (more than one) will be reduced to a single empty line.

This is because managing line breaks in templates can be tricky, 
often resulting in unintended multiple empty lines. 
This change simplifies the template creation process by eliminating that concern.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
