### PR TITLE
qt-qml: Add `-d` option to specify kit documentation path

### DIFF
--- a/qt-lib/src/util.ts
+++ b/qt-lib/src/util.ts
@@ -237,6 +237,18 @@ export async function waitForQtCpp() {
   }
 }
 
+export function findQtPathsInKitDir(dir: string): string | undefined {
+  const exeNames = [`qtpaths${OSExeSuffix}`, `qtpaths6${OSExeSuffix}`];
+
+  for (const exeName of exeNames) {
+    const exePath = path.join(dir, 'bin', exeName);
+    if (fsSync.existsSync(exePath)) {
+      return exePath;
+    }
+  }
+  return undefined;
+}
+
 class FileWriter {
   private readonly files = new Map<
     string,

--- a/qt-qml/package.json
+++ b/qt-qml/package.json
@@ -142,6 +142,12 @@
           "description": "Use custom QML Language Server arguments instead of the default ones",
           "scope": "machine-overridable"
         },
+        "qt-qml.qmlls.customDocsPath": {
+          "type": "string",
+          "default": "",
+          "description": "Specify the documentation path for QML Language Server",
+          "scope": "machine-overridable"
+        },
         "qt-qml.qmlls.additionalImportPaths": {
           "type": "array",
           "items": {

--- a/qt-qml/src/project.ts
+++ b/qt-qml/src/project.ts
@@ -4,7 +4,12 @@
 import * as vscode from 'vscode';
 import path from 'path';
 
-import { Project, ProjectManager, createLogger } from 'qt-lib';
+import {
+  Project,
+  ProjectManager,
+  createLogger,
+  findQtPathsInKitDir
+} from 'qt-lib';
 import { Qmlls } from '@/qmlls';
 import { coreAPI } from '@/extension';
 
@@ -93,11 +98,29 @@ export class QMLProject implements Project {
     this.qtpathsExe = coreAPI?.getValue<string>(this.folder, 'selectedQtPaths');
     this.buildDir = coreAPI?.getValue<string>(this.folder, 'buildDir');
   }
+  getDocsPathFromKitDir(kitDir: string) {
+    const qtpaths = findQtPathsInKitDir(kitDir);
+    if (!qtpaths) {
+      logger.error(`Cannot find qtpaths in: ${this.kitPath}`);
+      return undefined;
+    }
+    const qtInfo = coreAPI?.getQtInfoFromPath(qtpaths);
+    if (!qtInfo) {
+      logger.error('Cannot find qtInfo');
+      return undefined;
+    }
+    return qtInfo.get('QT_INSTALL_DOCS');
+  }
 
   updateQmllsParams() {
     this.qmlls.clearImportPaths();
     if (this.kitPath) {
       this.qmlls.addImportPath(path.join(this.kitPath, 'qml'));
+      const docsPath = this.getDocsPathFromKitDir(this.kitPath);
+      if (docsPath) {
+        logger.info('Setting docs path:', docsPath);
+        this.qmlls.docsPath = docsPath;
+      }
     } else if (this.qtpathsExe) {
       const info = coreAPI?.getQtInfoFromPath(this.qtpathsExe);
       if (!info) {
@@ -108,6 +131,11 @@ export class QMLProject implements Project {
         throw new Error('Could not find QT_INSTALL_QML');
       }
       this.qmlls.addImportPath(qmlImportPath);
+      const docsPath = info.get('QT_INSTALL_DOCS');
+      if (docsPath) {
+        logger.info('Setting docs path:', docsPath);
+        this.qmlls.docsPath = docsPath;
+      }
     }
   }
   set buildDir(buildDir: string | undefined) {

--- a/qt-qml/src/qmlls.ts
+++ b/qt-qml/src/qmlls.ts
@@ -119,6 +119,7 @@ export async function fetchAssetAndDecide(options?: {
 }
 
 export class Qmlls {
+  private _docsPath: string | undefined;
   private readonly _disposables: vscode.Disposable[] = [];
   private readonly _importPaths = new Set<string>();
   private _client: LanguageClient | undefined;
@@ -149,6 +150,14 @@ export class Qmlls {
 
   addImportPath(importPath: string) {
     this._importPaths.add(importPath);
+  }
+
+  get docsPath() {
+    return this._docsPath;
+  }
+
+  set docsPath(docsPath: string | undefined) {
+    this._docsPath = docsPath;
   }
 
   removeImportPath(importPath: string) {
@@ -282,6 +291,18 @@ export class Qmlls {
         'additionalImportPaths',
         []
       );
+
+      let docsPath = configs.get<string>('customDocsPath', '');
+      if (docsPath) {
+        // If qt-qml.qmlls.customDocsPath is set, use it instead of the path from the kit
+        docsPath = untildify(docsPath);
+      } else {
+        docsPath = this.docsPath ?? '';
+      }
+
+      if (docsPath) {
+        args.push(`-d${docsPath}`);
+      }
 
       const toImportParam = (p: string) => {
         return `-I${p}`;


### PR DESCRIPTION
* Add `findQtPathsInKitDir()` to get Qt paths in the kit directory
* Add `qt-qml.qmlls.customDocsPath` setting to specify kit documentation path
* Add `-d` option to specify kit documentation path
* Use `QT_INSTALL_DOCS` from `qtpaths` as default documentation path

When `qt-qml.qmlls.customDocsPath` is specified, it overrides the default in either the selected kit or qtpaths.

Fixes: [VSCODEEXT-137](https://bugreports.qt.io/browse/VSCODEEXT-137)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
