### PR TITLE
 Introduce qt-qml.qmlls.useNoCMakeCalls option

### DIFF
--- a/qt-qml/package.json
+++ b/qt-qml/package.json
@@ -148,6 +148,12 @@
           "description": "Use the QML_IMPORT_PATH environment variable to look for QML Modules. When set to true, the \"-E\" command argument will be added when starting qmlls",
           "scope": "machine-overridable"
         },
+        "qt-qml.qmlls.useNoCMakeCalls": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use --no-cmake-calls option when starting QML Language Server",
+          "scope": "machine-overridable"
+        },
         "qt-qml.doNotAskForQmllsDownload": {
           "type": "boolean",
           "default": false,

--- a/qt-qml/package.json
+++ b/qt-qml/package.json
@@ -100,13 +100,13 @@
         "qt-qml.qmlls.enabled": {
           "type": "boolean",
           "default": true,
-          "description": "Run qmlls when activating an extension",
+          "description": "Run QML Language Server when activating an extension",
           "scope": "machine-overridable"
         },
         "qt-qml.qmlls.verboseOutput": {
           "type": "boolean",
           "default": false,
-          "description": "Run qmlls with --verbose option",
+          "description": "Run QML Language Server with --verbose option",
           "scope": "machine-overridable"
         },
         "qt-qml.qmlls.traceLsp": {
@@ -130,7 +130,7 @@
         "qt-qml.qmlls.customExePath": {
           "type": "string",
           "default": "",
-          "description": "Specify the custom qmlls executable path",
+          "description": "Specify the custom QML Language Server executable path",
           "scope": "machine-overridable"
         },
         "qt-qml.qmlls.additionalImportPaths": {
@@ -139,13 +139,13 @@
             "type": "string"
           },
           "default": [],
-          "description": "Look for QML modules in the specified directories. Each entry will be added via the \"-I\" command argument when starting qmlls",
+          "description": "Look for QML modules in the specified directories. Each entry will be added via the \"-I\" command argument when starting QML Language Server",
           "scope": "machine-overridable"
         },
         "qt-qml.qmlls.useQmlImportPathEnvVar": {
           "type": "boolean",
           "default": false,
-          "description": "Use the QML_IMPORT_PATH environment variable to look for QML Modules. When set to true, the \"-E\" command argument will be added when starting qmlls",
+          "description": "Use the QML_IMPORT_PATH environment variable to look for QML Modules. When set to true, the \"-E\" command argument will be added when starting QML Language Server",
           "scope": "machine-overridable"
         },
         "qt-qml.qmlls.useNoCMakeCalls": {
@@ -157,7 +157,7 @@
         "qt-qml.doNotAskForQmllsDownload": {
           "type": "boolean",
           "default": false,
-          "description": "Do not ask for downloading qmlls",
+          "description": "Do not ask for downloading QML Language Server",
           "scope": "machine"
         }
       }

--- a/qt-qml/src/qmlls.ts
+++ b/qt-qml/src/qmlls.ts
@@ -291,6 +291,11 @@ export class Qmlls {
       args.push(toImportParam(importPath))
     );
 
+    const useNoCMakeCalls = configs.get<boolean>('useNoCMakeCalls', false);
+    if (useNoCMakeCalls) {
+      args.push('--no-cmake-calls');
+    }
+
     logger.info('Starting QML Language Server with:', args.join(';'));
     const serverOptions: ServerOptions = {
       command: qmllsPath,


### PR DESCRIPTION
* Add option to use `--no-cmake-calls` when starting QML Language Server
* Use `QML Language Server` instead of `qmlls` in description

https://doc.qt.io/qt-6/qtqml-tooling-qmlls.html#disabling-automatic-cmake-builds

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
