### PR TITLE
qt-qml: Add custom arguments support for QML Language Server

### DIFF
--- a/qt-qml/package.json
+++ b/qt-qml/package.json
@@ -133,6 +133,15 @@
           "description": "Specify the custom QML Language Server executable path",
           "scope": "machine-overridable"
         },
+        "qt-qml.qmlls.customArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Use custom QML Language Server arguments instead of the default ones",
+          "scope": "machine-overridable"
+        },
         "qt-qml.qmlls.additionalImportPaths": {
           "type": "array",
           "items": {

--- a/qt-qml/src/qmlls.ts
+++ b/qt-qml/src/qmlls.ts
@@ -257,43 +257,48 @@ export class Qmlls {
         `QML Language Server - ${this._folder.name}`
       );
     }
-    const args: string[] = [];
-    if (verboseOutput) {
-      args.push('--verbose');
-    }
+    let args: string[] = [];
+    const customArgs = configs.get<string[]>('customArgs', []);
+    if (customArgs.length > 0) {
+      args = customArgs;
+    } else {
+      if (verboseOutput) {
+        args.push('--verbose');
+      }
 
-    const useQmlImportPathEnvVar = configs.get<boolean>(
-      'useQmlImportPathEnvVar',
-      false
-    );
-    if (useQmlImportPathEnvVar) {
-      args.push('-E');
-    }
+      const useQmlImportPathEnvVar = configs.get<boolean>(
+        'useQmlImportPathEnvVar',
+        false
+      );
+      if (useQmlImportPathEnvVar) {
+        args.push('-E');
+      }
 
-    if (this._buildDir) {
-      args.push(`-b${this._buildDir}`);
-    }
+      if (this._buildDir) {
+        args.push(`-b${this._buildDir}`);
+      }
 
-    const additionalImportPaths = configs.get<string[]>(
-      'additionalImportPaths',
-      []
-    );
+      const additionalImportPaths = configs.get<string[]>(
+        'additionalImportPaths',
+        []
+      );
 
-    const toImportParam = (p: string) => {
-      return `-I${p}`;
-    };
+      const toImportParam = (p: string) => {
+        return `-I${p}`;
+      };
 
-    additionalImportPaths.forEach((importPath) => {
-      args.push(toImportParam(importPath));
-    });
+      additionalImportPaths.forEach((importPath) => {
+        args.push(toImportParam(importPath));
+      });
 
-    this._importPaths.forEach((importPath) =>
-      args.push(toImportParam(importPath))
-    );
+      this._importPaths.forEach((importPath) =>
+        args.push(toImportParam(importPath))
+      );
 
-    const useNoCMakeCalls = configs.get<boolean>('useNoCMakeCalls', false);
-    if (useNoCMakeCalls) {
-      args.push('--no-cmake-calls');
+      const useNoCMakeCalls = configs.get<boolean>('useNoCMakeCalls', false);
+      if (useNoCMakeCalls) {
+        args.push('--no-cmake-calls');
+      }
     }
 
     logger.info('Starting QML Language Server with:', args.join(';'));


### PR DESCRIPTION
* Introduce `qt-qml.qmlls.customArgs` setting to allow users to pass custom arguments to the QML Language Server.

When the `qt-qml.qmlls.customArgs` setting is set, the extension will use the custom arguments instead of the default ones.

Fixes: [VSCODEEXT-140](https://bugreports.qt.io/browse/VSCODEEXT-140)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
