### PR TITLE
qt-cli: Fix incorrect method name

### DIFF
--- a/qt-cli/src/common/preset_manager.go
+++ b/qt-cli/src/common/preset_manager.go
@@ -33,7 +33,7 @@ func (m CompositePresetManager) GetAll() []PresetData {
 	return all
 }
 
-func (m CompositePresetManager) GetItemsByType(t TargetType) []PresetData {
+func (m CompositePresetManager) FindByType(t TargetType) []PresetData {
 	all := []PresetData{}
 
 	for _, c := range m.comps {

--- a/qt-cli/src/runner/text_ui.go
+++ b/qt-cli/src/runner/text_ui.go
@@ -65,7 +65,7 @@ func FindPresetOrRunSelector(
 }
 
 func runPresetSelector(t common.TargetType) (common.Preset, error) {
-	items := createPickerItems(Presets.Any.GetItemsByType(t))
+	items := createPickerItems(Presets.Any.FindByType(t))
 	items = append(items, comps.NewItem(util.Msg("[Manually select features]")))
 	picked, err := comps.NewPicker().
 		Question(util.Msg("Pick a preset")).


### PR DESCRIPTION
Rename a method to ensure CompisitePresetManager 
correctly implements the PresetManager interface.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
