### PR TITLE
qt-ui: Fix switching between customWidgetsDesignerExePath and kit paths

### DIFF
--- a/qt-ui/src/project.ts
+++ b/qt-ui/src/project.ts
@@ -54,41 +54,57 @@ export class UIProject implements Project {
         );
       }
     }
-    const eventHandler = vscode.workspace.onDidChangeConfiguration((event) => {
-      if (
-        affectsConfig(
-          event,
-          CONF_CUSTOM_WIDGETS_DESIGNER_EXE_PATH,
-          this._folder
-        )
-      ) {
-        this._customWidgetsDesignerExePath = this.getQtCustomDesignerPath();
-        logger.info(
-          `new ${CONF_CUSTOM_WIDGETS_DESIGNER_EXE_PATH}:`,
-          this._customWidgetsDesignerExePath
-        );
+    const eventHandler = vscode.workspace.onDidChangeConfiguration(
+      async (event) => {
         if (
-          this._customWidgetsDesignerExePath &&
-          UIProject.checkCustomDesignerExePath(
-            this._customWidgetsDesignerExePath
+          affectsConfig(
+            event,
+            CONF_CUSTOM_WIDGETS_DESIGNER_EXE_PATH,
+            this._folder
           )
         ) {
-          this.designerClient = new DesignerClient(
-            this._customWidgetsDesignerExePath,
-            this._designerServer.getPort()
+          this._customWidgetsDesignerExePath = this.getQtCustomDesignerPath();
+          logger.info(
+            `new ${CONF_CUSTOM_WIDGETS_DESIGNER_EXE_PATH}:`,
+            this._customWidgetsDesignerExePath
           );
-        } else {
-          // That means the user has removed the path.
-          // So, we need to detach the client.
-          if (this._designerClient) {
+          if (
+            this._customWidgetsDesignerExePath &&
+            UIProject.checkCustomDesignerExePath(
+              this._customWidgetsDesignerExePath
+            )
+          ) {
             this.designerClient = new DesignerClient(
-              this.getQtCustomDesignerPath(),
+              this._customWidgetsDesignerExePath,
               this._designerServer.getPort()
             );
+          } else {
+            // That means the user has removed the path.
+            // So, we need to detach the client and get the designer from qtpaths
+            // or bin dir.
+            if (this._designerClient) {
+              if (this._binDir) {
+                this.designerClient = await this.getNewDesignerClient(
+                  this._binDir
+                );
+              } else if (this._qtpathsExe) {
+                const designer = await locateDesignerFromQtPaths(
+                  this._qtpathsExe
+                );
+                if (designer) {
+                  this.designerClient = new DesignerClient(
+                    designer,
+                    this.designerServer.getPort()
+                  );
+                }
+              } else {
+                this.designerClient = undefined;
+              }
+            }
           }
         }
       }
-    });
+    );
     this._disposables.push(eventHandler);
   }
   getQtCustomDesignerPath() {
@@ -132,18 +148,21 @@ export class UIProject implements Project {
         );
       }
     };
-    if (qtpathsExe) {
-      void locateDesignerFromQtPaths(qtpathsExe).then(setDesignerClient);
-    } else {
-      this.designerClient = undefined;
+
+    if (!this._customWidgetsDesignerExePath) {
+      if (qtpathsExe) {
+        void locateDesignerFromQtPaths(qtpathsExe).then(setDesignerClient);
+      } else {
+        this.designerClient = undefined;
+      }
     }
     this._qtpathsExe = qtpathsExe;
   }
 
   async setBinDir(binDir: string | undefined) {
     if (binDir !== this._binDir) {
+      this._binDir = binDir;
       if (!this._customWidgetsDesignerExePath) {
-        this._binDir = binDir;
         if (binDir) {
           this.designerClient = await this.getNewDesignerClient(binDir);
         } else {


### PR DESCRIPTION
When `qt-ui.customWidgetsDesignerExePath` is provided by the user, it was not used. The below gerrit patch caused this problem. This commit fixes that.

There was also a bug when `qt-ui.customWidgetsDesignerExePath` is removed from the settings, the extension was not switching back to the anymore. This commit fixes that as well.

https://codereview.qt-project.org/c/%7Bgraveyard%7D/qt-labs/vscodeext/+/609633

Fixes: [VSCODEEXT-141](https://bugreports.qt.io/browse/VSCODEEXT-141)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
