### PR TITLE
qt-lib: Align user home and user local dir with the cmake extension

### DIFF
--- a/qt-core/src/installation-root.ts
+++ b/qt-core/src/installation-root.ts
@@ -81,6 +81,9 @@ export function checkDefaultQtInsRootPath() {
     throw new Error(errorMessage);
   }
   const defaultQtInsRootName = 'Qt';
+  if (!Home) {
+    throw new Error('Home is undefined');
+  }
   const unixDefaultPaths = [
     path.join(Home, defaultQtInsRootName),
     path.join(Home, 'dev', defaultQtInsRootName),

--- a/qt-cpp/src/commands/register-qt-path.ts
+++ b/qt-cpp/src/commands/register-qt-path.ts
@@ -79,6 +79,9 @@ export async function getSelectedKit(
     folder !== undefined
       ? KitManager.getCMakeWorkspaceKitsFilepath(folder)
       : '';
+  if (!CMAKE_GLOBAL_KITS_FILEPATH) {
+    throw new Error('CMAKE_GLOBAL_KITS_FILEPATH is undefined.');
+  }
   const kitFiles = [workspaceFolderKitsPath, CMAKE_GLOBAL_KITS_FILEPATH];
   if (addtionalKits) {
     kitFiles.push(...addtionalKits);

--- a/qt-cpp/src/kit-manager.ts
+++ b/qt-cpp/src/kit-manager.ts
@@ -37,11 +37,22 @@ import { QtVersionFromKit } from '@util/util';
 const logger = createLogger('kit-manager');
 
 export const CMakeDefaultGenerator = 'Ninja';
-const CMakeToolsDir = path.join(UserLocalDir, 'CMakeTools');
-export const CMAKE_GLOBAL_KITS_FILEPATH = path.join(
-  CMakeToolsDir,
-  'cmake-tools-kits.json'
-);
+const CMakeToolsDir = cmakeToolsDir();
+export const CMAKE_GLOBAL_KITS_FILEPATH = cmakeGlobalKitsFilepath();
+
+function cmakeGlobalKitsFilepath() {
+  if (!CMakeToolsDir) {
+    return undefined;
+  }
+  return path.join(CMakeToolsDir, 'cmake-tools-kits.json');
+}
+
+function cmakeToolsDir() {
+  if (!UserLocalDir) {
+    return undefined;
+  }
+  return path.join(UserLocalDir, 'CMakeTools');
+}
 
 const envPath = '${env:PATH}';
 type Environment = Record<string, string | undefined>;
@@ -469,6 +480,9 @@ export class KitManager {
     const cmakeKitsFile = workspaceFolder
       ? path.join(workspaceFolder.uri.fsPath, '.vscode', 'cmake-kits.json')
       : CMAKE_GLOBAL_KITS_FILEPATH;
+    if (cmakeKitsFile === undefined) {
+      throw new Error('CMake tools directory not found');
+    }
     const currentKits = await KitManager.parseCMakeKitsFile(cmakeKitsFile);
     const newKits = currentKits.filter((kit) => {
       // filter kits if previousQtKits contains the kit with the same name
@@ -492,6 +506,9 @@ export class KitManager {
   }
 
   private static async loadCMakeKitsFileJSON(): Promise<Kit[]> {
+    if (CMAKE_GLOBAL_KITS_FILEPATH === undefined) {
+      throw new Error('CMake tools directory not found');
+    }
     if (!fsSync.existsSync(CMAKE_GLOBAL_KITS_FILEPATH)) {
       return [];
     }
@@ -694,6 +711,9 @@ export class KitManager {
     const cmakeKitsFile = workspaceFolder
       ? path.join(workspaceFolder.uri.fsPath, '.vscode', 'cmake-kits.json')
       : CMAKE_GLOBAL_KITS_FILEPATH;
+    if (cmakeKitsFile === undefined) {
+      throw new Error('CMake tools directory not found');
+    }
     const currentKits = await KitManager.parseCMakeKitsFile(cmakeKitsFile);
     const newKits = currentKits.filter((kit) => {
       // Filter kits if previousQtKits contains the kit with the same name

--- a/qt-lib/src/util.ts
+++ b/qt-lib/src/util.ts
@@ -11,7 +11,7 @@ import * as async from 'async';
 import { QtInfo } from './core-api';
 import { telemetry } from './telemetry';
 
-export const Home = os.homedir();
+export const Home = userHome();
 export const IsWindows = process.platform === 'win32';
 export const IsMacOS = process.platform === 'darwin';
 export const IsLinux = process.platform === 'linux';
@@ -22,12 +22,40 @@ export const Isx86 = os.arch() === 'x86' || os.arch() === 'ia32';
 export const Isx64 = os.arch() === 'x64';
 
 export const OSExeSuffix = IsWindows ? '.exe' : '';
-export const UserLocalDir = IsWindows
-  ? (process.env.LOCALAPPDATA ?? '')
-  : path.join(Home, '.local/share');
+export const UserLocalDir = userLocalDir();
 
 export async function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function userLocalDir() {
+  if (process.platform === 'win32') {
+    return localAppData();
+  } else {
+    const xdg_dir = process.env.XDG_DATA_HOME;
+    if (xdg_dir) {
+      return xdg_dir;
+    }
+    if (Home) {
+      return path.join(Home, '.local/share');
+    }
+    return undefined;
+  }
+
+  function localAppData() {
+    return process.env.LOCALAPPDATA;
+  }
+}
+
+function userHome() {
+  if (process.platform === 'win32') {
+    return path.join(
+      process.env.HOMEDRIVE ?? 'C:',
+      process.env.HOMEPATH ?? 'Users\\Public'
+    );
+  } else {
+    return process.env.HOME ?? process.env.PROFILE ?? os.homedir();
+  }
 }
 
 export async function exists(filePath: string) {

--- a/qt-qml/src/installer.ts
+++ b/qt-qml/src/installer.ts
@@ -15,7 +15,7 @@ import { setDoNotAskForDownloadingQmlls } from '@/qmlls';
 const ReleaseInfoUrl = 'https://qtccache.qt.io/QMLLS/LatestRelease';
 const ReleaseInfoTimeout = 10 * 1000;
 const DownloadDir = os.tmpdir();
-const InstallDir = path.join(UserLocalDir, 'qmlls');
+const InstallDir = installerDir();
 const ExtractDir = path.join(InstallDir, 'files');
 const QmllsExePath = path.join(InstallDir, 'files', 'qmlls' + OSExeSuffix);
 const ReleaseJsonPath = path.join(InstallDir, 'release.json');
@@ -28,6 +28,12 @@ interface Asset {
   created_at: string;
 }
 
+function installerDir() {
+  if (!UserLocalDir) {
+    throw new Error('Cannot determine the user local directory');
+  }
+  return path.join(UserLocalDir, 'qmlls');
+}
 export interface AssetWithTag extends Asset {
   tag_name: string;
 }


### PR DESCRIPTION
When we use a hardcoded path for the user home and user local dir, it
causes issues when the user has a different home directory. This change
aligns the user home and user local dir with the cmake extension.

Also, if vscode is installed via a package manager like snap, the cmake
extension generates  `cmake-tools-kits.json` file in the snap directory
, but the Qt extension generates it in the user local dir. This causes
users to not see the kits.

Fixes: [VSCODEEXT-146](https://bugreports.qt.io/browse/VSCODEEXT-146)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
