### PR TITLE
qt-qml: Add QML Debug Adapter part(1/x)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1402,6 +1402,7 @@
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
       "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "date-fns": "^2.30.0",

--- a/qt-core/package-lock.json
+++ b/qt-core/package-lock.json
@@ -47,6 +47,8 @@
         "winston-transport-vscode": "^0.1.0"
       },
       "devDependencies": {
+        "@eslint/eslintrc": "^3.3.0",
+        "@eslint/js": "^9.21.0",
         "@types/async": "^3.2.24",
         "@types/node": "^20.17.0",
         "@types/vscode": "^1.94.0",

--- a/qt-qml/ThirdPartyNotices.txt
+++ b/qt-qml/ThirdPartyNotices.txt
@@ -383,6 +383,44 @@ https://github.com/DefinitelyTyped/DefinitelyTyped#readme
 
 ---------------------------------------------------------
 
+debugadapter 1.68.0 - MIT
+https://github.com/microsoft/vscode-debugadapter-node#readme
+
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+debugprotocol 1.68.0 - MIT
+https://github.com/microsoft/vscode-debugadapter-node#readme
+
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 extension-telemetry 0.9.7 - MIT
 https://github.com/Microsoft/vscode-extension-telemetry#readme
 
@@ -466,6 +504,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+async-mutex 0.5.0 - MIT
+https://github.com/DirtyHairy/async-mutex#readme
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Christian Speckner <cnspeckn@googlemail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 ---------------------------------------------------------
 
@@ -874,6 +941,35 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------------------------
 
+fast-xml-parser 5.0.8 - MIT
+https://github.com/NaturalIntelligence/fast-xml-parser#readme
+
+MIT License
+
+Copyright (c) 2017 Amit Kumar Gupta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 fecha 4.2.3 - MIT
 git+https://taylorhakes@github.com/taylorhakes/fecha#readme
 
@@ -929,6 +1025,23 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+get-port 7.1.0 - MIT
+https://github.com/sindresorhus/get-port#readme
+
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------------------------
 
@@ -1238,6 +1351,118 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------------------------
 
+promise-duplex 8.0.0 - MIT
+https://github.com/dex4er/js-promise-duplex#readme
+
+MIT License
+
+Copyright (c) 2017-2024 Piotr Roszatycki <piotr.roszatycki@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+promise-readable 8.0.1 - MIT
+https://github.com/dex4er/js-promise-readable#readme
+
+MIT License
+
+Copyright (c) 2017-2024 Piotr Roszatycki <piotr.roszatycki@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+promise-socket 8.0.0 - MIT
+https://github.com/dex4er/js-promise-socket#readme
+
+MIT License
+
+Copyright (c) 2017-2024 Piotr Roszatycki <piotr.roszatycki@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+promise-writable 8.0.0 - MIT
+https://github.com/dex4er/js-promise-writable#readme
+
+MIT License
+
+Copyright (c) 2017-2024 Piotr Roszatycki <piotr.roszatycki@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 readable-stream 3.6.2 - MIT
 https://github.com/nodejs/readable-stream#readme
 
@@ -1536,6 +1761,35 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 """
 
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+strnum 2.0.5 - MIT
+https://github.com/NaturalIntelligence/strnum#readme
+
+MIT License
+
+Copyright (c) 2021 Natural Intelligence
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ---------------------------------------------------------
 

--- a/qt-qml/package-lock.json
+++ b/qt-qml/package-lock.json
@@ -8,8 +8,14 @@
       "name": "qt-qml",
       "version": "1.5.0",
       "dependencies": {
+        "@vscode/debugadapter": "^1.68.0",
+        "@vscode/debugprotocol": "^1.68.0",
         "@vscode/l10n": "^0.0.16",
+        "async-mutex": "^0.5.0",
+        "fast-xml-parser": "^5.0.8",
+        "get-port": "^7.1.0",
         "module-alias": "^2.2.3",
+        "promise-socket": "^8.0.0",
         "qt-lib": "file:../qt-lib",
         "typescript": "^5.6.3",
         "untildify": "^5.0.0",
@@ -1272,6 +1278,24 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@vscode/debugadapter": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.68.0.tgz",
+      "integrity": "sha512-D6gk5Fw2y4FV8oYmltoXpj+VAZexxJFopN/mcZ6YcgzQE9dgq2L45Aj3GLxScJOD6GeLILcxJIaA8l3v11esGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/debugprotocol": "1.68.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@vscode/debugprotocol": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
+      "integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg==",
+      "license": "MIT"
+    },
     "node_modules/@vscode/l10n": {
       "version": "0.0.16",
       "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.16.tgz",
@@ -1737,6 +1761,15 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/asynckit": {
@@ -3107,6 +3140,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.0.8.tgz",
+      "integrity": "sha512-qY8NiI5L8ff00F2giyICiJxSSKHO52tC36LJqx2JtvGyAd5ZfehC/l4iUVVHpmpIa6sM9N5mneSLHQG2INGoHA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -3312,6 +3363,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
+      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stdin": {
@@ -5325,6 +5388,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/promise-duplex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/promise-duplex/-/promise-duplex-8.0.0.tgz",
+      "integrity": "sha512-JlrnT6KZMRD+t4cxP7gh/dlGP2pl01/jTPg3pTLvFLBTdHTbTTdc+g25q0qswC3ziO9RAr3L1b2n/++4y23GQg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-readable": "^8.0.1",
+        "promise-writable": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/promise-readable": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/promise-readable/-/promise-readable-8.0.1.tgz",
+      "integrity": "sha512-peVAz+49xRooF1Om2wYSOluKpOApnpiJVOKgQ6IR/ZAWo15tBa4ZtcKKSTAytRiNJVlkvil9NoFhqihY4Sl1Fw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/promise-socket": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/promise-socket/-/promise-socket-8.0.0.tgz",
+      "integrity": "sha512-5Qb5719QcOm3/zrt0DLiAsJXutv2vb4HRxCiOVro1eyAOMak6vF2gTIoB6f0M1mnKMCsXW1SC/O+4G3P6p7kbw==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-duplex": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/promise-writable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/promise-writable/-/promise-writable-8.0.0.tgz",
+      "integrity": "sha512-Qn7/5tE42fjLUWevPm/SFmVz26tRdhmxmPXgOJSeIwLnkI2V4u0/t+CrRXb8ic1Jy9qqvOHVYm+sAIgel++eVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/pseudo-localization": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/pseudo-localization/-/pseudo-localization-2.4.0.tgz",
@@ -6195,6 +6301,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.0.5.tgz",
+      "integrity": "sha512-YAT3K/sgpCUxhxNMrrdhtod3jckkpYwH6JAuwmUdXZsmzH1wUyzTMrrK2wYCEEqlKwrWDd35NeuUkbBy/1iK+Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -6419,7 +6537,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
       "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tunnel": {

--- a/qt-qml/package.json
+++ b/qt-qml/package.json
@@ -176,7 +176,144 @@
           "scope": "machine"
         }
       }
-    }
+    },
+    "breakpoints": [
+      {
+        "language": "qml"
+      }
+    ],
+    "debuggers": [
+      {
+        "type": "qml",
+        "label": "QML debugger",
+        "runtime": "node",
+        "configurationAttributes": {
+          "attach": {
+            "required": [
+              "host",
+              "port"
+            ],
+            "properties": {
+              "host": {
+                "type": "string",
+                "description": "Hostname (or IP address) of the target program's debug service",
+                "default": "localhost"
+              },
+              "port": {
+                "type": [
+                  "number",
+                  "string"
+                ],
+                "description": "Port of the target program's debug service"
+              },
+              "buildDirs": {
+                "type": "array",
+                "description": "List of build directories to include in the debugger. This variable is useful when the build directory is not in the workspace.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "initialConfigurations": [
+          {
+            "type": "qml",
+            "request": "attach",
+            "name": "Attach to QML debugger",
+            "host": "localhost",
+            "port": "^\"Custom port or \\${command:qt-qml.debugPort} for compound usage\""
+          }
+        ],
+        "configurationSnippets": [
+          {
+            "label": "%qt-qml.debug.qmlDebugging.label%",
+            "description": "%qt-qml.debug.qmlDebugging.description%",
+            "body": {
+              "name": "%qt-qml.debug.qmlDebugging.label%",
+              "type": "qml",
+              "request": "attach",
+              "host": "localhost",
+              "port": "^\"Custom port or \\${command:qt-qml.debugPort} for compound usage\""
+            }
+          },
+          {
+            "label": "%qt-qml.debug.cppdbg.label%",
+            "description": "%qt-qml.debug.cppdbg.description%",
+            "body": {
+              "name": "%qt-qml.debug.cppdbg.label%",
+              "type": "cppdbg",
+              "request": "launch",
+              "program": "^\"\\${command:cmake.launchTargetPath}\"",
+              "stopAtEntry": false,
+              "cwd": "^\"\\${workspaceFolder}\"",
+              "visualizerFile": "^\"\\${command:qt-cpp.natvis}\"",
+              "showDisplayString": true,
+              "args": [
+                "^\"-qmljsdebugger=host:localhost,port:\\${command:qt-qml.debugPort},block,services:DebugMessages,QmlDebugger,V8Debugger\""
+              ],
+              "linux": {
+                "MIMode": "gdb",
+                "miDebuggerPath": "/usr/bin/gdb"
+              },
+              "osx": {
+                "MIMode": "lldb"
+              },
+              "windows": {
+                "environment": [
+                  {
+                    "name": "PATH",
+                    "value": "^\"\\${env:PATH};\\${command:qt-cpp.qtDir}\""
+                  },
+                  {
+                    "name": "QT_QPA_PLATFORM_PLUGIN_PATH",
+                    "value": "^\"\\${command:qt-cpp.QT_QPA_PLATFORM_PLUGIN_PATH}\""
+                  },
+                  {
+                    "name": "QML_IMPORT_PATH",
+                    "value": "^\"\\${command:qt-cpp.QML_IMPORT_PATH}\""
+                  }
+                ],
+                "MIMode": "gdb",
+                "miDebuggerPath": "^\"\\${command:qt-cpp.minGWgdb}\""
+              }
+            }
+          },
+          {
+            "label": "%qt-qml.debug.cppvsdbg.label%",
+            "description": "%qt-qml.debug.cppvsdbg.description%",
+            "body": {
+              "name": "%qt-qml.debug.cppvsdbg.label%",
+              "type": "cppvsdbg",
+              "request": "launch",
+              "program": "^\"\\${command:cmake.launchTargetPath}\"",
+              "stopAtEntry": false,
+              "cwd": "^\"\\${workspaceFolder}\"",
+              "visualizerFile": "^\"\\${command:qt-cpp.natvis}\"",
+              "args": [
+                "^\"-qmljsdebugger=host:localhost,port:\\${command:qt-qml.debugPort},block,services:DebugMessages,QmlDebugger,V8Debugger\""
+              ],
+              "windows": {
+                "environment": [
+                  {
+                    "name": "PATH",
+                    "value": "^\"\\${env:PATH};\\${command:qt-cpp.qtDir}\""
+                  },
+                  {
+                    "name": "QT_QPA_PLATFORM_PLUGIN_PATH",
+                    "value": "^\"\\${command:qt-cpp.QT_QPA_PLATFORM_PLUGIN_PATH}\""
+                  },
+                  {
+                    "name": "QML_IMPORT_PATH",
+                    "value": "^\"\\${command:qt-cpp.QML_IMPORT_PATH}\""
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ]
   },
   "taskDefinitions": [
     {
@@ -221,8 +358,14 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
+    "@vscode/debugadapter": "^1.68.0",
+    "@vscode/debugprotocol": "^1.68.0",
     "@vscode/l10n": "^0.0.16",
+    "async-mutex": "^0.5.0",
+    "fast-xml-parser": "^5.0.8",
+    "get-port": "^7.1.0",
     "module-alias": "^2.2.3",
+    "promise-socket": "^8.0.0",
     "qt-lib": "file:../qt-lib",
     "typescript": "^5.6.3",
     "untildify": "^5.0.0",

--- a/qt-qml/package.nls.json
+++ b/qt-qml/package.nls.json
@@ -1,5 +1,11 @@
 {
   "qt-qml.command.restartQmlls.title": "Restart QML language server",
   "qt-qml.command.checkQmllsUpdate.title": "Check for QML language server update",
-  "qt-qml.command.downloadQmlls.title": "Download the most recent QML language server"
+  "qt-qml.command.downloadQmlls.title": "Download the most recent QML language server",
+  "qt-qml.debug.qmlDebugging.label": "Qt: QML: Attach by port",
+  "qt-qml.debug.qmlDebugging.description": "Launch a QML application with the QML debugger",
+  "qt-qml.debug.cppdbg.label": "Qt: Debug with cppdbg and QML debugger",
+  "qt-qml.debug.cppdbg.description": "Launch a QML application with C++ debugger and attach with QML debugger",
+  "qt-qml.debug.cppvsdbg.label": "Qt: Debug with cppdbg and QML debugger (Windows)",
+  "qt-qml.debug.cppvsdbg.description": "Launch a QML application with Visual Studio Debugger and attach with QML debugger"
 }

--- a/qt-qml/src/commands/debug.ts
+++ b/qt-qml/src/commands/debug.ts
@@ -1,0 +1,21 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+
+import { EXTENSION_ID } from '@/constants';
+import { compoundPort } from '@/tasks/acquire-port';
+
+// This function is used when a compound launch is used. The main idea is to
+// return the same port number for the first and second call.
+export function registerDebugPort() {
+  return vscode.commands.registerCommand(`${EXTENSION_ID}.debugPort`, () => {
+    if (compoundPort === undefined) {
+      void vscode.window.showErrorMessage(
+        'Use "${command:qt-qml.debugPort}" with a compound launch and "preLaunchTask": "Qt: Acquire Port"'
+      );
+      return;
+    }
+    return compoundPort;
+  });
+}

--- a/qt-qml/src/debug/datastream.ts
+++ b/qt-qml/src/debug/datastream.ts
@@ -1,0 +1,309 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+// Replacement of QDataStream
+export class DataStream {
+  private _data = Buffer.alloc(0);
+  private readOffset = 0;
+  private writeOffset = 0;
+
+  constructor(data?: Buffer) {
+    if (data) {
+      this.data = data;
+    } else {
+      this.data = Buffer.alloc(0);
+    }
+  }
+  get data() {
+    return this._data.subarray(0, this.writeOffset);
+  }
+  set data(data: Buffer) {
+    this._data = data;
+    this.writeOffset = 0;
+    this.readOffset = 0;
+  }
+  writeInt8(value: number) {
+    const newValueSize = 1;
+    this.ensureCapacity(this.writeOffset + newValueSize);
+    this._data.writeInt8(value, this.writeOffset);
+    this.writeOffset += newValueSize;
+  }
+  writeInt16LE(value: number) {
+    const newValueSize = 2;
+    this.ensureCapacity(this.writeOffset + newValueSize);
+    this._data.writeInt16LE(value, this.writeOffset);
+    this.writeOffset += newValueSize;
+  }
+  writeInt16BE(value: number) {
+    const newValueSize = 2;
+    this.ensureCapacity(this.writeOffset + newValueSize);
+    this._data.writeInt16BE(value, this.writeOffset);
+    this.writeOffset += newValueSize;
+  }
+  writeInt32LE(value: number) {
+    const newValueSize = 4;
+    this.ensureCapacity(this.writeOffset + newValueSize);
+    this._data.writeInt32LE(value, this.writeOffset);
+    this.writeOffset += newValueSize;
+  }
+  writeUInt32LE(value: number) {
+    const newValueSize = 4;
+    this.ensureCapacity(this.writeOffset + newValueSize);
+    this._data.writeUInt32LE(value, this.writeOffset);
+    this.writeOffset += newValueSize;
+  }
+  writeInt32BE(value: number) {
+    const newValueSize = 4;
+    this.ensureCapacity(this.writeOffset + newValueSize);
+    this._data.writeInt32BE(value, this.writeOffset);
+    this.writeOffset += newValueSize;
+  }
+  writeUInt32BE(value: number) {
+    const newValueSize = 4;
+    this.ensureCapacity(this.writeOffset + newValueSize);
+    this._data.writeUInt32BE(value, this.writeOffset);
+    this.writeOffset += newValueSize;
+  }
+  writeInt64LE(value: bigint) {
+    const newValueSize = 8;
+    this.ensureCapacity(this.writeOffset + newValueSize);
+    this._data.writeBigInt64LE(value, this.writeOffset);
+    this.writeOffset += newValueSize;
+  }
+  writeInt64BE(value: bigint) {
+    const newValueSize = 8;
+    this.ensureCapacity(this.writeOffset + newValueSize);
+    this._data.writeBigInt64BE(value, this.writeOffset);
+    this.writeOffset += newValueSize;
+  }
+  writeFloatLE(value: number) {
+    const newValueSize = 4;
+    this.ensureCapacity(this.writeOffset + newValueSize);
+    this._data.writeFloatLE(value, this.writeOffset);
+    this.writeOffset += newValueSize;
+  }
+  writeFloatBE(value: number) {
+    const newValueSize = 4;
+    this.ensureCapacity(this.writeOffset + newValueSize);
+    this._data.writeFloatBE(value, this.writeOffset);
+    this.writeOffset += newValueSize;
+  }
+  writeDoubleLE(value: number) {
+    const newValueSize = 8;
+    this.ensureCapacity(this.writeOffset + newValueSize);
+    this._data.writeDoubleLE(value, this.writeOffset);
+    this.writeOffset += newValueSize;
+  }
+  writeDoubleBE(value: number) {
+    const newValueSize = 8;
+    this.ensureCapacity(this.writeOffset + newValueSize);
+    this._data.writeDoubleBE(value, this.writeOffset);
+    this.writeOffset += newValueSize;
+  }
+  writeStringUTF8(value: string) {
+    if (value === '') {
+      this.writeUInt32BE(0xffffffff);
+    }
+    const newValueSize = Buffer.byteLength(value, 'utf8');
+    this.ensureCapacity(this.writeOffset + newValueSize + 4);
+    this.writeUInt32BE(newValueSize);
+    this._data.write(value, this.writeOffset, 'utf8');
+    this.writeOffset += newValueSize;
+  }
+  writeBoolean(value: boolean) {
+    this.writeInt8(value ? 1 : 0);
+  }
+  writeJsonUTF8(value: object) {
+    const str = JSON.stringify(value);
+    if (str === '') {
+      this.writeStringUTF8('');
+      return;
+    }
+    this.writeStringUTF8(str);
+  }
+  getSize(): number {
+    return this.writeOffset;
+  }
+  writeSubDataStream(subPacket: DataStream) {
+    this.ensureCapacity(this.writeOffset + subPacket.getSize() + 4);
+    this.writeUInt32BE(subPacket.getSize());
+    subPacket.data.copy(this._data, this.writeOffset);
+    this.writeOffset += subPacket.getSize();
+  }
+  writeBuffer(buffer: Buffer) {
+    this.ensureCapacity(this.writeOffset + buffer.byteLength);
+    buffer.copy(this._data, this.writeOffset);
+    this.writeOffset += buffer.byteLength;
+  }
+
+  writeStringUTF16(value: string) {
+    const newValueSize = Buffer.byteLength(value, 'ucs-2');
+    this.ensureCapacity(this.writeOffset + newValueSize + 4);
+    this.writeUInt32BE(newValueSize);
+    const stringBuffer = Buffer.from(value, 'ucs-2').swap16();
+    stringBuffer.copy(this._data, this.writeOffset);
+    this.writeOffset += newValueSize;
+  }
+
+  writeArray<T>(container: T[], writeFunc: (value: T) => void) {
+    this.writeUInt32BE(container.length);
+    for (const key of container) {
+      writeFunc.call(this, key);
+    }
+  }
+  readInt8(): number {
+    const value = this._data.readInt8(this.readOffset);
+    this.readOffset += 1;
+    return value;
+  }
+  readInt16LE(): number {
+    const value = this._data.readInt16LE(this.readOffset);
+    this.readOffset += 2;
+    return value;
+  }
+  readInt16BE(): number {
+    const value = this._data.readInt16BE(this.readOffset);
+    this.readOffset += 2;
+    return value;
+  }
+  readInt32LE(): number {
+    const value = this._data.readInt32LE(this.readOffset);
+    this.readOffset += 4;
+    return value;
+  }
+  atEnd(): boolean {
+    return this.readOffset >= this._data.byteLength;
+  }
+  readInt32BE(): number {
+    const value = this._data.readInt32BE(this.readOffset);
+    this.readOffset += 4;
+    return value;
+  }
+  readUInt32LE(): number {
+    const value = this._data.readUInt32LE(this.readOffset);
+    this.readOffset += 4;
+    return value;
+  }
+  readUInt32BE(): number {
+    const value = this._data.readUInt32BE(this.readOffset);
+    this.readOffset += 4;
+    return value;
+  }
+  readInt64LE(): bigint {
+    const value = this._data.readBigInt64LE(this.readOffset);
+    this.readOffset += 8;
+    return value;
+  }
+  readInt64BE(): bigint {
+    const value = this._data.readBigInt64BE(this.readOffset);
+    this.readOffset += 8;
+    return value;
+  }
+  readFloatLE(): number {
+    const value = this._data.readFloatLE(this.readOffset);
+    this.readOffset += 4;
+    return value;
+  }
+  readFloatBE(): number {
+    const value = this._data.readFloatBE(this.readOffset);
+    this.readOffset += 4;
+    return value;
+  }
+  readDoubleLE(): number {
+    const value = this._data.readDoubleLE(this.readOffset);
+    this.readOffset += 8;
+    return value;
+  }
+  readArray<ValueType>(readFunc: () => ValueType): ValueType[] {
+    const length = this.readUInt32BE();
+    const values = new Array<ValueType>();
+    for (let i = 0; i < length; i++) {
+      values.push(readFunc.call(this));
+    }
+    return values;
+  }
+  readArrayString(): string[] {
+    return this.readArray(() => this.readStringUTF16LE());
+  }
+  readArrayDouble(): number[] {
+    return this.readArray(() => this.readDoubleLE());
+  }
+  readDoubleBE(): number {
+    const value = this._data.readDoubleBE(this.readOffset);
+    this.readOffset += 8;
+    return value;
+  }
+  readStringUTF8(): string {
+    const length = this.readUInt32BE();
+    if (length === 0xffffffff) {
+      return '';
+    }
+    const value = this._data.toString(
+      'utf8',
+      this.readOffset,
+      this.readOffset + length
+    );
+    this.readOffset += length;
+    return value;
+  }
+  readStringUTF16LE(): string {
+    const length = this.readUInt32BE();
+    if (length === 0xffffffff) {
+      return '';
+    }
+    const valueBuffer = this._data.subarray(
+      this.readOffset,
+      this.readOffset + length
+    );
+    const value = valueBuffer.swap16().toString('ucs-2');
+    this.readOffset += length;
+    return value;
+  }
+  readStringUTF16BE(): string {
+    const length = this.readUInt32BE();
+    if (length === 0xffffffff) {
+      return '';
+    }
+    const bytesLen = length * 2;
+    const value = this._data.toString(
+      'ucs-2',
+      this.readOffset,
+      this.readOffset + bytesLen
+    );
+    this.readOffset += length;
+    return value;
+  }
+  readJsonUTF8(): object {
+    const str = this.readStringUTF8();
+    if (str === '') {
+      return {};
+    }
+    return JSON.parse(str) as object;
+  }
+  readSubDataStream(): DataStream {
+    const size = this.readUInt32BE();
+    const subPacket = new DataStream(
+      this._data.subarray(this.readOffset, this.readOffset + size)
+    );
+    this.readOffset += size;
+    return subPacket;
+  }
+  resize(newSize: number) {
+    const newData = Buffer.alloc(newSize);
+    this._data.copy(newData);
+    this._data = newData;
+  }
+  ensureCapacity(capacity: number) {
+    const increaseFactor = 2;
+    if (this._data.byteLength === 0) {
+      this.resize(10);
+    }
+    if (this._data.byteLength < capacity) {
+      let newSize = this._data.byteLength * increaseFactor;
+      while (newSize < capacity) {
+        newSize *= increaseFactor;
+      }
+      this.resize(newSize);
+    }
+  }
+}

--- a/qt-qml/src/debug/debug-adapter.ts
+++ b/qt-qml/src/debug/debug-adapter.ts
@@ -1,0 +1,414 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+import {
+  InitializedEvent,
+  LoggingDebugSession,
+  TerminatedEvent,
+  Thread
+} from '@vscode/debugadapter';
+import { DebugProtocol } from '@vscode/debugprotocol';
+import { Mutex } from 'async-mutex';
+import path from 'path';
+
+import { createLogger, delay, telemetry } from 'qt-lib';
+import {
+  QmlDebugConnectionState,
+  Server,
+  ServerScheme
+} from '@debug/debug-connection';
+import { QmlEngine, StepAction } from '@debug/qml-engine';
+import { projectManager } from '@/extension';
+
+const logger = createLogger('project');
+
+export function registerQmlDebugAdapterFactory() {
+  return vscode.debug.registerDebugAdapterDescriptorFactory(
+    'qml',
+    new QmlDebugAdapterFactory()
+  );
+}
+
+export enum BreakpointState {
+  BreakpointNew,
+  BreakpointInsertionRequested, //!< Inferior was told about bp, not ack'ed.
+  BreakpointInsertionProceeding,
+  BreakpointInserted,
+  BreakpointUpdateRequested,
+  BreakpointUpdateProceeding,
+  BreakpointRemoveRequested,
+  BreakpointRemoveProceeding,
+  BreakpointDead
+}
+
+interface QmlDebugSessionAttachArguments
+  extends DebugProtocol.AttachRequestArguments {
+  host: string;
+  port: number | string;
+  buildDirs: string[] | undefined;
+}
+
+export interface QmlBreakpoint {
+  id?: number;
+  filename: string;
+  line: number;
+  state: BreakpointState;
+}
+
+export class QmlDebugSession extends LoggingDebugSession {
+  private readonly _mutex = new Mutex();
+  private _qmlEngine: QmlEngine | undefined;
+  private readonly _breakpoints = new Map<string, QmlBreakpoint[]>();
+  public constructor(session: vscode.DebugSession) {
+    super();
+
+    logger.info('Creating debug session for session:', session.id);
+  }
+  findBreakpoint(filename: string, line: number): QmlBreakpoint | undefined {
+    const breakpoints = this._breakpoints.get(filename);
+    if (!breakpoints) {
+      return undefined;
+    }
+    for (const breakpoint of breakpoints) {
+      if (breakpoint.line === line) {
+        return breakpoint;
+      }
+    }
+    return undefined;
+  }
+  // eslint-disable-next-line @typescript-eslint/require-await
+  protected override async disconnectRequest(
+    response: DebugProtocol.DisconnectResponse,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _args: DebugProtocol.DisconnectArguments,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _request?: DebugProtocol.Request
+  ): Promise<void> {
+    try {
+      if (!this._qmlEngine) {
+        throw new Error('QML engine not initialized');
+      }
+      logger.info('Disconnect request:');
+      this._qmlEngine.closeConnection();
+      this._qmlEngine.notifyInferiorExited();
+      this.sendResponse(response);
+    } catch (err) {
+      this.sendError(response, 1, err as string);
+    }
+  }
+  protected override async setBreakPointsRequest(
+    response: DebugProtocol.SetBreakpointsResponse,
+    args: DebugProtocol.SetBreakpointsArguments,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _request?: DebugProtocol.Request
+  ): Promise<void> {
+    try {
+      await this.waitUntilDebuggerIsReady();
+      await this._mutex.waitForUnlock();
+      const release = await this._mutex.acquire();
+      logger.info('Func: setBreakPointsRequest: Begin');
+      if (this._qmlEngine === undefined) {
+        throw new Error('QML engine not initialized');
+      }
+      if (!args.source.path) {
+        throw new Error('Source path is not defined');
+      }
+      const breakpointstoRemove: QmlBreakpoint[] = [];
+      const breakpointsToAdd: QmlBreakpoint[] = [];
+      const sourceBreakpoints = args.breakpoints ?? [];
+      // check if current breakpoints are the same as the new ones
+      for (const sourceBreakpoint of sourceBreakpoints) {
+        const found = this.findBreakpoint(
+          args.source.path,
+          sourceBreakpoint.line
+        );
+        if (!found) {
+          const newBreakpoint: QmlBreakpoint = {
+            filename: path.basename(args.source.path),
+            line: sourceBreakpoint.line,
+            state: BreakpointState.BreakpointNew
+          };
+          const currentSourceBreakpoints = this._breakpoints.get(
+            args.source.path
+          );
+          if (currentSourceBreakpoints) {
+            currentSourceBreakpoints.push(newBreakpoint);
+          } else {
+            this._breakpoints.set(args.source.path, [newBreakpoint]);
+          }
+          breakpointsToAdd.push(newBreakpoint);
+        }
+      }
+      for (const breakpoint of this._breakpoints.get(args.source.path) ?? []) {
+        const found = sourceBreakpoints.find(
+          (sourceBreakpoint) => sourceBreakpoint.line === breakpoint.line
+        );
+        if (!found) {
+          breakpointstoRemove.push(breakpoint);
+        }
+      }
+
+      for (const breakpoint of breakpointstoRemove) {
+        const breakpoints = this._breakpoints.get(args.source.path);
+        if (!breakpoints) {
+          continue;
+        }
+        const index = breakpoints.indexOf(breakpoint);
+        breakpoints.splice(index, 1);
+        this._qmlEngine.clearBreakpoint(breakpoint);
+      }
+
+      for (const breakpoint of breakpointsToAdd) {
+        breakpoint.state = BreakpointState.BreakpointInsertionRequested;
+        const breakpontId =
+          await this._qmlEngine.tryClaimBreakpoint(breakpoint);
+        if (breakpontId) {
+          breakpoint.id = breakpontId;
+          breakpoint.state = BreakpointState.BreakpointInserted;
+        }
+      }
+
+      response.body = {
+        breakpoints: []
+      };
+      const currentBreakpoints = this._breakpoints.get(args.source.path);
+      if (currentBreakpoints) {
+        // We have to sort the breakpoints by line number. Otherwise, an
+        // undefined behavior can occur.
+        const sortedCurrentBreakpoints = currentBreakpoints.sort(
+          (a, b) => a.line - b.line
+        );
+        for (const breakpoint of sortedCurrentBreakpoints) {
+          if (
+            breakpoint.state === BreakpointState.BreakpointInsertionRequested
+          ) {
+            continue;
+          }
+          if (breakpoint.id === undefined) {
+            throw new Error('Breakpoint ID is undefined');
+          }
+          response.body.breakpoints.push({
+            id: breakpoint.id,
+            line: breakpoint.line,
+            verified: true
+          });
+        }
+      }
+      logger.info('setBreakPointsRequest response:', JSON.stringify(response));
+      this.sendResponse(response);
+      release();
+    } catch (err) {
+      this.sendError(response, 1, err as string);
+    }
+  }
+  async waitUntilDebuggerIsReady() {
+    if (!this._qmlEngine) {
+      throw new Error('QML engine not initialized');
+    }
+    while (
+      this._qmlEngine.connectionState !== QmlDebugConnectionState.Connected
+    ) {
+      await delay(1000);
+    }
+  }
+  protected override initializeRequest(
+    response: DebugProtocol.InitializeResponse,
+    args: DebugProtocol.InitializeRequestArguments
+  ) {
+    logger.info('Initialize request:', JSON.stringify(args));
+    response.body = {};
+    this.sendResponse(response);
+  }
+  protected override threadsRequest(
+    response: DebugProtocol.ThreadsResponse,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _request?: DebugProtocol.Request
+  ) {
+    logger.info('threadsRequest');
+    if (!this._qmlEngine) {
+      throw new Error('QML engine not initialized');
+    }
+    response.body = {
+      threads: [new Thread(this._qmlEngine.mainQmlThreadId, 'Main Thread')]
+    };
+    this.sendResponse(response);
+  }
+  protected override async stackTraceRequest(
+    response: DebugProtocol.StackTraceResponse,
+    args: DebugProtocol.StackTraceArguments,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _request?: DebugProtocol.Request
+  ) {
+    try {
+      if (!this._qmlEngine) {
+        throw new Error('QML engine not initialized');
+      }
+      logger.info('Stack trace request:', JSON.stringify(args));
+      const { stackFrames, length } = await this._qmlEngine.backtrace(args);
+      response.body = {
+        stackFrames: stackFrames
+      };
+      response.body.totalFrames = length;
+      response.success = true;
+      this.sendResponse(response);
+    } catch (err) {
+      this.sendError(response, 1, err as string);
+    }
+  }
+  protected override async continueRequest(
+    response: DebugProtocol.ContinueResponse,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _args: DebugProtocol.ContinueArguments,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _request?: DebugProtocol.Request
+  ) {
+    try {
+      if (!this._qmlEngine) {
+        throw new Error('QML engine not initialized');
+      }
+      const result = await this._qmlEngine.continueDebugging(
+        StepAction.Continue
+      );
+      if (!result.success) {
+        response.success = false;
+      }
+      this.sendResponse(response);
+    } catch (err) {
+      this.sendError(response, 1, err as string);
+    }
+  }
+  protected override async stepInRequest(
+    response: DebugProtocol.StepInResponse,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _args: DebugProtocol.StepInArguments,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _request?: DebugProtocol.Request
+  ) {
+    try {
+      if (!this._qmlEngine) {
+        throw new Error('QML engine not initialized');
+      }
+      const result = await this._qmlEngine.continueDebugging(StepAction.StepIn);
+      if (!result.success) {
+        response.success = false;
+      }
+      this.sendResponse(response);
+    } catch (err) {
+      this.sendError(response, 1, err as string);
+    }
+  }
+  protected override async stepOutRequest(
+    response: DebugProtocol.StepOutResponse,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _args: DebugProtocol.StepOutArguments,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _request?: DebugProtocol.Request
+  ) {
+    try {
+      if (!this._qmlEngine) {
+        throw new Error('QML engine not initialized');
+      }
+      const result = await this._qmlEngine.continueDebugging(
+        StepAction.StepOut
+      );
+      if (!result.success) {
+        response.success = false;
+      }
+      this.sendResponse(response);
+    } catch (err) {
+      this.sendError(response, 1, err as string);
+    }
+  }
+  protected override async nextRequest(
+    response: DebugProtocol.NextResponse,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _args: DebugProtocol.NextArguments,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _request?: DebugProtocol.Request
+  ) {
+    try {
+      if (!this._qmlEngine) {
+        throw new Error('QML engine not initialized');
+      }
+
+      const result = await this._qmlEngine.continueDebugging(StepAction.Next);
+      if (!result.success) {
+        response.success = false;
+      }
+      this.sendResponse(response);
+    } catch (err) {
+      this.sendError(response, 1, err as string);
+    }
+  }
+  private sendError(
+    response: DebugProtocol.Response,
+    number: number,
+    err: string
+  ) {
+    logger.error('Error:', err);
+    this.sendErrorResponse(response, {
+      id: number,
+      format: 'QML Debug: ' + err,
+      showUser: true
+    });
+    this.sendEvent(new TerminatedEvent());
+  }
+
+  protected override attachRequest(
+    response: DebugProtocol.AttachResponse,
+    args: QmlDebugSessionAttachArguments,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _request?: DebugProtocol.Request
+  ) {
+    try {
+      telemetry.sendAction('QMLDebugAttach');
+      logger.info('Attach request:', args.host, args.port.toString());
+      if (typeof args.port === 'string') {
+        args.port = parseInt(args.port, 10);
+      }
+      const server: Server = {
+        host: args.host,
+        port: args.port,
+        scheme: ServerScheme.Tcp
+      };
+      this._qmlEngine = new QmlEngine(this);
+      this._qmlEngine.server = server;
+      this._qmlEngine.buildDirs = args.buildDirs ?? [];
+      this._qmlEngine.onShutdownEngine = () => {
+        this.sendEvent(new TerminatedEvent());
+      };
+
+      // If there is multi-workspace usage, we skip this step because we don't
+      // know which build dir to use.
+      // TODO: We can get the selected workspace from the CMake extension.
+      const buildDirs = projectManager.getBuildDirs();
+      if (buildDirs.length === 1 && buildDirs[0] !== undefined) {
+        this._qmlEngine.buildDirs.push(buildDirs[0]);
+      }
+      this._qmlEngine.start();
+
+      this.sendResponse(response);
+      this.sendEvent(new InitializedEvent());
+    } catch (err) {
+      this.sendError(response, 1, err as string);
+    }
+  }
+}
+
+export class QmlDebugAdapterFactory
+  implements vscode.DebugAdapterDescriptorFactory
+{
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  public createDebugAdapterDescriptor(
+    session: vscode.DebugSession,
+    executable: vscode.DebugAdapterExecutable | undefined
+  ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+    logger.info('Creating debug adapter for session:', session.id);
+    logger.info('Executable:', executable?.command ?? 'undefined');
+
+    return new vscode.DebugAdapterInlineImplementation(
+      new QmlDebugSession(session)
+    );
+  }
+}

--- a/qt-qml/src/debug/debug-connection.ts
+++ b/qt-qml/src/debug/debug-connection.ts
@@ -1,0 +1,628 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+import { Socket } from 'net';
+
+import { createLogger } from 'qt-lib';
+import { Packet, PacketProtocol } from '@debug/packet';
+import { Timer } from '@debug/timer';
+
+const logger = createLogger('project');
+
+export enum ServerScheme {
+  Tcp = 'tcp',
+  // eslint-disable-next-line @typescript-eslint/no-shadow
+  Socket = 'unix'
+}
+
+export enum SocketState {
+  UnconnectedState = 0,
+  HostLookupState = 1,
+  ConnectingState = 2,
+  ConnectedState = 3,
+  BoundState = 4,
+  ListeningState = 5,
+  ClosingState = 6
+}
+
+export enum QmlDebugConnectionState {
+  NotConnected,
+  Unavailable,
+  Enabled,
+  Connected
+}
+
+export interface Server {
+  host: string;
+  port: number;
+  scheme: ServerScheme;
+}
+
+const serverId = 'QDeclarativeDebugServer';
+const clientId = 'QDeclarativeDebugClient';
+const protocolVersion = 1;
+
+export class QmlDebugConnectionManager {
+  private readonly _connectionTimer: Timer = new Timer();
+  private _server: Server | undefined;
+  private _connection: QmlDebugConnection | undefined;
+  private _retryInterval = 400; // 200ms??
+  private _maximumRetries = 50; // 10??
+  private _numRetries = 0;
+  private readonly _connectionClosed = new vscode.EventEmitter<void>();
+  private readonly _connectionFailed = new vscode.EventEmitter<void>();
+
+  get connection() {
+    return this._connection;
+  }
+  get retryInterval() {
+    return this._retryInterval;
+  }
+  set retryInterval(value: number) {
+    this._retryInterval = value;
+  }
+  set maximumRetries(value: number) {
+    this._maximumRetries = value;
+  }
+  get maximumRetries() {
+    return this._maximumRetries;
+  }
+  dispose() {
+    if (this._connection) {
+      this._connection.dispose();
+    }
+  }
+  disconnectToConnection() {
+    if (this._connection) {
+      this._connection.disconnect();
+    }
+  }
+  isConnected() {
+    if (!this._connection) {
+      return false;
+    }
+    return this._connection.isConnected();
+  }
+
+  connectToServer(server: Server) {
+    if (this._server !== server) {
+      this._server = server;
+      // destroyConnection(); // TODO: Implement
+      // stopConnectionTimer(); // TODO: Implement
+    }
+    if (this._server.scheme === ServerScheme.Tcp) {
+      this.connectToTcpServer();
+    } else {
+      throw new Error('Not implemented');
+    }
+  }
+  connectToTcpServer() {
+    if (!this._server) {
+      throw new Error('Server not set');
+    }
+    if (!this._connection) {
+      this.createConnection();
+    }
+    const onTimeout = () => {
+      if (this.isConnected()) {
+        return;
+      }
+      if (++this._numRetries < this.maximumRetries) {
+        if (!this._connection) {
+          // If the previous connection failed, recreate it.
+
+          // Assign _connection explicitly to avoid TS error
+          // TODO: Remove the below line and find a better way to handle this
+          // Because _connection is already assigned in createConnection()
+          this._connection = new QmlDebugConnection();
+          this.createConnection();
+          if (!this._server) {
+            throw new Error('Server not set');
+          }
+          this._connection.connectToHost(this._server.host, this._server.port);
+        } else if (
+          this._numRetries < this._maximumRetries &&
+          this._connection.socketState() !== SocketState.ConnectedState
+        ) {
+          // If we don't get connected in the first retry interval, drop the socket and try
+          // with a new one. On some operating systems (macOS) the very first connection to a
+          // TCP server takes a very long time to get established and this helps.
+          // On other operating systems (windows) every connection takes forever to get
+          // established. So, after tearing down and rebuilding the socket twice, just
+          // keep trying with the same one.
+          if (!this._server) {
+            throw new Error('Server not set');
+          }
+          this._connection.connectToHost(this._server.host, this._server.port);
+        } // Else leave it alone and wait for hello.
+      } else {
+        // On final timeout, clear the connection.
+        this.stopConnectionTimer();
+        this.destroyConnection();
+        this._connectionFailed.fire();
+      }
+    };
+    this._connectionTimer.onTimeout(() => {
+      onTimeout();
+    });
+    this._connectionTimer.start(this._retryInterval);
+
+    if (this._connection) {
+      this._connection.connectToHost(this._server.host, this._server.port);
+    }
+  }
+  stopConnectionTimer() {
+    this._connectionTimer.stop();
+  }
+  destroyConnection() {
+    if (this._connection) {
+      this._connection.disconnect();
+      this._connection = undefined;
+      this._connectionTimer.stop();
+      this._connectionTimer.disconnect();
+      // destroyClients(); TODO: Needs this?
+      this._numRetries = 0;
+    }
+  }
+  createConnection() {
+    this._connection = new QmlDebugConnection();
+    this.createClients();
+    this.connectConnectionSignals();
+  }
+  createClients() {
+    void this;
+  }
+  connectConnectionSignals() {
+    if (!this._connection) {
+      throw new Error('Connection not set');
+    }
+    this._connection.onConnected(() => {
+      this.qmlDebugConnectionOpened();
+    });
+    this._connection.onDisconnected(() => {
+      this.qmlDebugConnectionClosed();
+    });
+  }
+  qmlDebugConnectionOpened() {
+    if (this._connection?.isConnected()) {
+      return;
+    }
+    logger.info('Connection opened');
+    this.stopConnectionTimer();
+  }
+  qmlDebugConnectionClosed() {
+    if (!this._connection?.isConnected()) {
+      return;
+    }
+    logger.info('Connection closed');
+    // this.destroyConnection(); // TODO: Implement
+    this._connectionClosed.fire();
+  }
+  qmlDebugConnectionFailed() {
+    if (this._connection) {
+      return;
+    }
+    logger.error('Connection failed');
+    this._connectionFailed.fire();
+  }
+}
+
+export class QmlDebugConnection {
+  private readonly _serverPlugins = new Map<string, number>();
+  private _device: Socket | undefined;
+  private _protocol: PacketProtocol | undefined;
+  private static readonly minStreamVersion = 12;
+  private _currentDataStreamVersion = QmlDebugConnection.minStreamVersion;
+  private readonly _maximumDataStreamVersion = 23; // Qt_DefaultCompiledVersion??
+  private readonly _connected = new vscode.EventEmitter<void>();
+  private readonly _disconnected = new vscode.EventEmitter<void>();
+  private readonly _connectionFailed = new vscode.EventEmitter<void>();
+  private _gotHello = false;
+  private readonly _plugins = new Map<string, QmlDebugClient>();
+  get gotHello() {
+    return this._gotHello;
+  }
+  disconnect() {
+    this._disconnected.dispose();
+    this._connectionFailed.dispose();
+  }
+  get onConnected() {
+    return this._connected.event;
+  }
+  get onDisconnected() {
+    return this._disconnected.event;
+  }
+  get onConnectionFailed() {
+    return this._connectionFailed.event;
+  }
+  serviceVersion(serviceName: string) {
+    const version = this._serverPlugins.get(serviceName);
+    if (version) {
+      return version;
+    }
+    return -1;
+  }
+  socketState() {
+    if (!this._device) {
+      return SocketState.UnconnectedState;
+    }
+    if (this._device.readyState === 'open') {
+      return SocketState.ConnectedState;
+    }
+    if (
+      this._device.connecting ||
+      this._device.readyState === 'opening' ||
+      this._device.pending
+    ) {
+      return SocketState.ConnectingState;
+    }
+    if (this._device.destroyed || this._device.closed) {
+      return SocketState.UnconnectedState;
+    }
+    throw new Error('Unknown socket state');
+  }
+  socketDisconnected() {
+    if (this.gotHello) {
+      this._gotHello = false;
+      for (const p of this._plugins.values()) {
+        p.stateChanged(QmlDebugConnectionState.Unavailable);
+      }
+      this._disconnected.fire();
+    } else if (this._device) {
+      this._connectionFailed.fire();
+    }
+
+    if (this._protocol) {
+      this._protocol.disconnect();
+      // d->protocol->deleteLater(); // Do we need this?
+      this._protocol = undefined;
+    }
+    if (this._device) {
+      // TODO: Do we need this?
+      // Don't allow any "connected()" or "disconnected()" signals to be triggered anymore.
+      // As the protocol is gone this would lead to crashes.
+      // d->device->disconnect();
+      this._device.destroy();
+      // Don't immediately delete it as it may do some cleanup on returning from a signal.
+      // d->device->deleteLater();
+      this._device = undefined;
+    }
+  }
+  close() {
+    if (this._device && this._device.readyState === 'open') {
+      this._device.destroy();
+    }
+  }
+  dispose() {
+    this.socketDisconnected();
+    this.disconnect();
+  }
+  isConnected() {
+    return this.gotHello;
+  }
+  isConnecting() {
+    return !this.gotHello && this._device;
+  }
+
+  connectToHost(host: string | undefined, port: number) {
+    this.socketDisconnected();
+    this._device = new Socket();
+    this._protocol = new PacketProtocol(this._device);
+    this._protocol.onReadyRead(() => {
+      this.protocolReadyRead();
+    });
+    this._device.on('error', (error: Error) => {
+      logger.error('Cannot connect to host:' + error.stack);
+      this.socketDisconnected();
+    });
+    this._device.on('connect', () => {
+      logger.info('Connected to host');
+      void this.socketConnected();
+    });
+    this._device.on('close', () => {
+      logger.info('Socket closed');
+      this.socketDisconnected();
+    });
+    this._device.connect(port, host ? host : 'localhost');
+  }
+  async socketConnected() {
+    const packet = new Packet();
+    packet.writeStringUTF16(serverId);
+    packet.writeInt32BE(0); // OP
+    packet.writeInt32BE(1); // Version
+    const plugins = Array.from(this._plugins.keys());
+    packet.writeArray(plugins, (plugin) => {
+      packet.writeStringUTF16(plugin);
+    });
+    packet.writeInt32BE(QmlDebugConnection.minStreamVersion);
+    packet.writeBoolean(true); // We accept multiple messages per packet
+    if (!this._protocol) {
+      throw new Error('Protocol not set');
+    }
+    await this._protocol.send(packet.data);
+  }
+  protocolReadyRead() {
+    if (!this._protocol) {
+      throw new Error('Protocol not set');
+    }
+    if (!this._gotHello) {
+      const pack = this._protocol.read();
+      const name = pack.readStringUTF16LE();
+      let validHello = false;
+      if (name === clientId) {
+        const op = pack.readInt32BE();
+        if (op == 0) {
+          const version = pack.readInt32BE();
+          if (version == protocolVersion) {
+            const pluginNames = pack.readArrayString();
+            const pluginNamesSize = pluginNames.length;
+            const pluginVersions = pack.readArrayDouble();
+            const pluginVersionsSize = pluginVersions.length;
+            for (let i = 0; i < pluginNamesSize; i++) {
+              let pluginVersion = 1.0;
+              if (i < pluginVersionsSize) {
+                const temp = pluginVersions[i];
+                if (!temp) {
+                  throw new Error('Plugin version is not a number');
+                }
+                pluginVersion = temp;
+              }
+              const tempPluginName = pluginNames[i];
+              if (!tempPluginName) {
+                throw new Error('Plugin name is not a string');
+              }
+              this._serverPlugins.set(tempPluginName, pluginVersion);
+            }
+            if (!pack.atEnd()) {
+              this._currentDataStreamVersion = pack.readInt32BE();
+              if (
+                this._currentDataStreamVersion > this._maximumDataStreamVersion
+              ) {
+                logger.warn('Server returned invalid data stream version!');
+              }
+              validHello = true;
+            }
+          }
+        }
+      }
+
+      if (!validHello) {
+        logger.warn('QML Debug Client: Invalid hello message');
+        this.close();
+        return;
+      }
+      this._gotHello = true;
+      for (const [key, value] of this._plugins) {
+        let newState = QmlDebugConnectionState.Unavailable;
+        if (this._serverPlugins.has(key)) {
+          newState = QmlDebugConnectionState.Enabled;
+        }
+        value.stateChanged(newState);
+      }
+      this._connected.fire();
+    }
+    while (this._protocol.packetsAvailable()) {
+      const pack = this._protocol.read();
+      const name = pack.readStringUTF16LE();
+
+      if (name === clientId) {
+        const op = pack.readInt32BE();
+        if (op === 1) {
+          // Service Discovery
+          const oldServerPlugins = new Map(this._serverPlugins);
+          this._serverPlugins.clear();
+
+          const pluginNames = pack.readArrayString();
+          let pluginVersions: number[] | undefined;
+          if (!pack.atEnd()) {
+            pluginVersions = pack.readArrayDouble();
+          }
+          const pluginNamesSize = pluginNames.length;
+          const pluginVersionsSize = pluginVersions ? pluginVersions.length : 0;
+          for (let i = 0; i < pluginNamesSize; i++) {
+            let pluginVersion = 1.0;
+            if (pluginVersions && i < pluginVersionsSize) {
+              const temp = pluginVersions[i];
+              if (!temp) {
+                throw new Error('Plugin version is not a number');
+              }
+              pluginVersion = temp;
+            }
+            const tempPluginName = pluginNames[i];
+            if (!tempPluginName) {
+              throw new Error('Plugin name is not a string');
+            }
+            this._serverPlugins.set(tempPluginName, pluginVersion);
+          }
+          for (const [pluginName, plugin] of this._plugins) {
+            let newState = QmlDebugConnectionState.Unavailable;
+            if (this._serverPlugins.has(pluginName)) {
+              newState = QmlDebugConnectionState.Enabled;
+            }
+
+            if (
+              oldServerPlugins.has(pluginName) !=
+              this._serverPlugins.has(pluginName)
+            ) {
+              plugin.stateChanged(newState);
+            }
+          }
+        } else {
+          logger.warn('QML Debug Client: Unknown control message id' + op);
+        }
+      } else {
+        const client = this._plugins.get(name);
+        if (!client) {
+          logger.warn(
+            'QML Debug Client: Message received for missing plugin' + name
+          );
+        } else {
+          while (!pack.atEnd()) {
+            const subPacket = pack.readSubDataStream();
+            client.messageReceived(subPacket);
+          }
+        }
+      }
+    }
+  }
+  async sendMessage(name: string, message: Packet) {
+    if (!this.gotHello || !this._plugins.has(name)) {
+      return false;
+    }
+    const packet = new Packet();
+    packet.writeStringUTF16(name);
+    packet.writeSubDataStream(message);
+    await this._protocol?.send(packet.data);
+    // TODO: Needs to flush the data?
+    return true;
+  }
+  async addClient(name: string, client: QmlDebugClient) {
+    if (this._plugins.has(name)) {
+      return false;
+    }
+    this._plugins.set(name, client);
+    await this.advertisePlugins();
+    return true;
+  }
+  async removeClient(name: string) {
+    if (!this._plugins.has(name)) {
+      return false;
+    }
+    this._plugins.delete(name);
+    await this.advertisePlugins();
+    return true;
+  }
+  async advertisePlugins() {
+    if (!this.gotHello) {
+      return;
+    }
+    const packet = new Packet();
+    packet.writeStringUTF16(serverId);
+    packet.writeInt32BE(1); // Version
+    const plugins = Array.from(this._plugins.keys());
+    for (const plugin of plugins) {
+      packet.writeStringUTF16(plugin);
+    }
+    packet.writeInt32BE(QmlDebugConnection.minStreamVersion);
+    packet.writeBoolean(true);
+    await this._protocol?.send(packet.data);
+  }
+  getClient(name: string) {
+    return this._plugins.get(name);
+  }
+}
+
+export interface IQmlDebugClient {
+  messageReceived(packet: Packet): void;
+  stateChanged(state: QmlDebugConnectionState): void;
+}
+export class QmlDebugClient {
+  constructor(
+    private readonly _name: string,
+    private readonly _connection: QmlDebugConnection
+  ) {
+    void this._connection.addClient(this._name, this);
+  }
+  serviceVersion() {
+    return this._connection.serviceVersion(this.name);
+  }
+  get name() {
+    return this._name;
+  }
+  get connection() {
+    return this._connection;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  messageReceived(_packet: Packet): void {
+    void this;
+    throw new Error('Method not implemented.');
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  stateChanged(_state: QmlDebugConnectionState) {
+    void this;
+    throw new Error('Method not implemented.');
+  }
+  getState(): QmlDebugConnectionState {
+    if (!this.connection.isConnected()) {
+      return QmlDebugConnectionState.NotConnected;
+    }
+    if (this.connection.serviceVersion(this.name) !== -1) {
+      return QmlDebugConnectionState.Enabled;
+    }
+    return QmlDebugConnectionState.Unavailable;
+  }
+  async sendMessage(message: Packet) {
+    if (this.getState() !== QmlDebugConnectionState.Enabled) {
+      return;
+    }
+    await this.connection.sendMessage(this.name, message);
+  }
+}
+
+interface DebugContextInfo {
+  line: number;
+  file: string;
+  function: string;
+  category?: string;
+  timestamp: bigint;
+}
+
+export interface IMessageType {
+  type: number;
+  message: string;
+  info: DebugContextInfo;
+}
+
+export class DebugMessageClient
+  extends QmlDebugClient
+  implements IQmlDebugClient
+{
+  // signals:
+  private readonly _newState =
+    new vscode.EventEmitter<QmlDebugConnectionState>();
+  private readonly _message = new vscode.EventEmitter<IMessageType>();
+
+  constructor(connection: QmlDebugConnection) {
+    super('DebugMessages', connection);
+  }
+  get newState() {
+    return this._newState.event;
+  }
+  get message() {
+    return this._message.event;
+  }
+  override messageReceived(ds: Packet): void {
+    const command = ds.readStringUTF8();
+    if (command !== 'MESSAGE') {
+      return;
+    }
+    const type = ds.readInt32BE();
+    const debugMessage = ds.readStringUTF8();
+    const file = ds.readStringUTF8();
+    const line = ds.readInt32BE();
+    const functionName = ds.readStringUTF8();
+    const info: DebugContextInfo = {
+      line: line,
+      file: file,
+      function: functionName,
+      timestamp: BigInt(-1)
+    };
+    if (!ds.atEnd()) {
+      info.category = ds.readStringUTF8();
+      if (!ds.atEnd()) {
+        info.timestamp = ds.readInt64BE();
+      }
+    }
+    this._message.fire({
+      type: type,
+      message: debugMessage,
+      info: info
+    });
+  }
+  override stateChanged(_state: QmlDebugConnectionState) {
+    void this;
+    logger.info('DebugMessages: stateChanged:' + _state);
+  }
+}

--- a/qt-qml/src/debug/debugger-command.ts
+++ b/qt-qml/src/debug/debugger-command.ts
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+export class DebuggerCommand {
+  private _func: string;
+  private _args: object | null = null;
+  constructor(func: string) {
+    this._func = func;
+  }
+  set function(func: string) {
+    this._func = func;
+  }
+  get function() {
+    return this._func;
+  }
+  arg<T>(name: string, value: T) {
+    if (this._args === null) {
+      this._args = {};
+    }
+    this._args = addtoJson(this._args, name, value);
+    return this;
+  }
+  get args() {
+    // return _args as JSON value
+    return this._args;
+  }
+}
+
+// addToJsonObject equivalent
+// Add key value pair to json
+function addtoJson<T>(args: object, key: string, value: T) {
+  // Add key value pair to json
+  const newJson = { ...args, [key]: value };
+  return newJson;
+}

--- a/qt-qml/src/debug/file-finder.ts
+++ b/qt-qml/src/debug/file-finder.ts
@@ -1,0 +1,149 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+
+import { QRCParser } from '@debug/qrc-parser';
+
+export class FileFinder {
+  private readonly _qrcParser: QRCParser;
+  private readonly _cache: Map<string, string>;
+  private allFiles: vscode.Uri[] = [];
+  private _buildDirs: string[] = [];
+  constructor() {
+    this._qrcParser = new QRCParser();
+    this._cache = new Map();
+    this.allFiles = [];
+  }
+
+  set buildDirs(dirs: string[]) {
+    this._buildDirs = dirs;
+  }
+  get buildDirs() {
+    return this._buildDirs;
+  }
+
+  async findFile(fileUrl: string) {
+    if (fileUrl.startsWith('qrc') || fileUrl.startsWith(':')) {
+      return this.findInQrcFiles(fileUrl, this._buildDirs);
+    }
+    return this.checkProjectFiles(fileUrl);
+  }
+  async findInQrcFiles(fileUrl: string, additionalFolders: string[] = []) {
+    const fileUrlParts = fileUrl.split(':');
+    const fileUrlPath = fileUrlParts[1];
+    if (fileUrlParts.length !== 2 || !fileUrlPath) {
+      throw new Error('Invalid file URL');
+    }
+    const filePath = this._cache.get(fileUrlPath);
+    if (filePath) {
+      return filePath;
+    }
+    const allQrcFiles = await vscode.workspace.findFiles('**/*.qrc');
+    for (const folder of additionalFolders) {
+      const pattern = new vscode.RelativePattern(folder, '**/*.qrc');
+      const additionalQrcFiles = await vscode.workspace.findFiles(pattern);
+      allQrcFiles.push(...additionalQrcFiles);
+    }
+    // parse all qrc files asynchrounously
+    const parsePromises = allQrcFiles.map((file) =>
+      this._qrcParser.parseQRCFile(file.fsPath)
+    );
+    const parsedQrcFiles = await Promise.all(parsePromises);
+    this._cache.clear();
+    for (const parsedQrcFile of parsedQrcFiles) {
+      for (const [alias, path] of parsedQrcFile) {
+        this._cache.set(alias, path);
+      }
+    }
+    return this._cache.get(fileUrlPath);
+  }
+  async checkProjectFiles(originalPath: string) {
+    // Filter .qml and .js files
+    // Rewrite again becuase new files may be added or removed
+    this.allFiles = await vscode.workspace.findFiles('**/*.{qml,js}');
+    const matches: string[] = [];
+    const lastSegment = originalPath.split('/').pop();
+    if (!lastSegment) {
+      throw new Error('Invalid path');
+    }
+    const files = this.filesWithSameFileName(lastSegment);
+    matches.push(...files.map((file) => file.fsPath));
+    const matchedFilePaths = FileFinder.bestMatches(matches, originalPath);
+    if (matchedFilePaths.length === 0) {
+      return undefined;
+    }
+    const hits: string[] = [];
+    for (const matchedFilePath of matchedFilePaths) {
+      if (FileFinder.checkPath(matchedFilePath)) {
+        hits.push(matchedFilePath);
+      }
+    }
+    // return the first hit
+    return hits[0];
+  }
+  filesWithSameFileName(fileName: string) {
+    return this.allFiles.filter((file) => file.fsPath.endsWith(fileName));
+  }
+
+  static commonPostFixLength(
+    candidatePath: string,
+    filePathToFind: string
+  ): number {
+    let rank = 0;
+    let a = candidatePath.length;
+    let b = filePathToFind.length;
+
+    while (
+      --a >= 0 &&
+      --b >= 0 &&
+      candidatePath.charAt(a) === filePathToFind.charAt(b)
+    ) {
+      rank++;
+    }
+
+    return rank;
+  }
+  static checkPath(candidate: string) {
+    // check if the file exists
+    if (fs.existsSync(candidate)) {
+      return true;
+    }
+    return false;
+  }
+
+  static bestMatches(filePaths: string[], filePathToFind: string): string[] {
+    if (filePaths.length === 0) {
+      return [];
+    }
+
+    if (filePaths.length === 1) {
+      console.debug(
+        `FileInProjectFinder: found ${filePaths[0]} in project files`
+      );
+      return filePaths;
+    }
+
+    let bestRank = -1;
+    let bestFilePaths: string[] = [];
+
+    for (const fp of filePaths) {
+      const currentRank = FileFinder.commonPostFixLength(fp, filePathToFind);
+      if (currentRank < bestRank) {
+        continue;
+      }
+      if (currentRank > bestRank) {
+        bestRank = currentRank;
+        bestFilePaths = [];
+      }
+      bestFilePaths.push(fp);
+    }
+
+    if (bestFilePaths.length === 0) {
+      throw new Error('No best file paths found');
+    }
+
+    return bestFilePaths;
+  }
+}

--- a/qt-qml/src/debug/packet.ts
+++ b/qt-qml/src/debug/packet.ts
@@ -1,0 +1,168 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+import { PromiseSocket } from 'promise-socket';
+import { Socket } from 'net';
+
+import { DataStream } from '@debug/datastream';
+import { createLogger } from 'qt-lib';
+
+type PacketSocket = PromiseSocket<Socket>;
+
+const logger = createLogger('PacketProtocol');
+
+export class Packet extends DataStream {}
+
+export class PacketProtocol {
+  private readonly _dev: PacketSocket;
+  private readonly _readyRead = new vscode.EventEmitter<void>();
+  private readonly _protocolError = new vscode.EventEmitter<void>();
+  private readonly _packets = new Array<Packet>();
+  private _sendingPackets = new Array<number>();
+  private readonly _bytesWritten = new vscode.EventEmitter<number>();
+  private static readonly notInProgress = -1;
+  private _inProgressSize = PacketProtocol.notInProgress;
+  private _inProgress = Buffer.alloc(0);
+  constructor(socket: Socket) {
+    socket.on('readable', () => {
+      this.readyToRead();
+    });
+    socket.readable;
+    socket.on('close', () => {
+      this.aboutToClose();
+    });
+    this.onBytesWritten((bytes) => {
+      this.bytesWritten(bytes);
+    });
+    this._dev = new PromiseSocket(socket);
+  }
+  packetsAvailable(): boolean {
+    return this._packets.length > 0;
+  }
+  aboutToClose() {
+    this._inProgress = Buffer.alloc(0);
+    this._sendingPackets = [];
+    this._inProgressSize = PacketProtocol.notInProgress;
+  }
+  readyToRead() {
+    const dev = this._dev.socket;
+    const int32SIZE = 4;
+    // Maybe while (true)??
+    while (this._dev.socket.readable) {
+      // Need to get trailing data
+      if (PacketProtocol.notInProgress == this._inProgressSize) {
+        // We need a size header of sizeof(qint32)
+        if (int32SIZE > dev.readableLength) {
+          return;
+        }
+        // Read size header
+        const inProgressSizeLE: Buffer | null = dev.read(
+          int32SIZE
+        ) as Buffer | null;
+        if (inProgressSizeLE === null) {
+          this.fail();
+          logger.error('Cannot read size header');
+          return;
+        }
+        this._inProgressSize = inProgressSizeLE.readInt32LE();
+        // Check sizing constraints
+        if (this._inProgressSize < int32SIZE) {
+          logger.error('Packet size is too small');
+          return;
+        }
+        this._inProgressSize -= int32SIZE;
+      } else {
+        const temp = dev.read(
+          this._inProgressSize - this._inProgress.length
+        ) as Buffer | null;
+        if (temp === null) {
+          logger.error('Cannot read packet');
+          return;
+        }
+        this._inProgress = Buffer.concat([this._inProgress, temp]);
+        if (this._inProgressSize === this._inProgress.length) {
+          // Packet has arrived!
+          this._packets.push(new Packet(this._inProgress));
+          this._inProgressSize = PacketProtocol.notInProgress;
+          this._inProgress = Buffer.alloc(0);
+
+          this.readyRead();
+        } else {
+          return;
+        }
+      }
+    }
+  }
+  read() {
+    const first = this._packets.shift();
+    if (first) {
+      return first;
+    }
+    return new Packet();
+  }
+  fail() {
+    this._dev.socket.removeAllListeners();
+    this._bytesWritten.dispose();
+    this._protocolError.fire();
+  }
+  disconnect() {
+    this._readyRead.dispose();
+    this._protocolError.dispose();
+  }
+  readyRead() {
+    this._readyRead.fire();
+  }
+  get onReadyRead() {
+    return this._readyRead.event;
+  }
+  async send(buffer: Buffer) {
+    // return if the size is more than max int32 - 4
+    const maxSendSize = 0x7fffffff - 4;
+    if (buffer.length > maxSendSize) {
+      throw new Error('Packet is too large');
+    }
+    if (this._dev.socket.destroyed) {
+      return;
+    }
+    if (buffer.length === 0) {
+      return; // We don't send empty packets
+    }
+    const sendSize = buffer.length + 4;
+    this._sendingPackets.push(sendSize);
+    let tempBuffer = Buffer.alloc(4);
+    tempBuffer.writeInt32LE(sendSize);
+    tempBuffer = Buffer.concat([tempBuffer, buffer]);
+    await this.waitUntilWritten(tempBuffer);
+    this._bytesWritten.fire(sendSize);
+  }
+  get onBytesWritten() {
+    return this._bytesWritten.event;
+  }
+
+  bytesWritten(bytes: number) {
+    if (this._sendingPackets.length === 0) {
+      throw new Error('No packets to send');
+    }
+    while (bytes) {
+      if (!this._sendingPackets[0]) {
+        return;
+      }
+      if (this._sendingPackets[0] > bytes) {
+        this._sendingPackets[0] -= bytes;
+        bytes = 0;
+      } else {
+        bytes -= this._sendingPackets[0];
+        this._sendingPackets.shift();
+      }
+    }
+  }
+
+  private async waitUntilWritten(buffer: Buffer) {
+    let written = 0;
+    while (written < buffer.length) {
+      written = await this._dev.write(buffer);
+      buffer = buffer.subarray(written);
+    }
+  }
+}

--- a/qt-qml/src/debug/qml-engine.ts
+++ b/qt-qml/src/debug/qml-engine.ts
@@ -1,0 +1,864 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import path from 'path';
+import { DebugProtocol } from '@vscode/debugprotocol';
+import { Source, StackFrame, StoppedEvent } from '@vscode/debugadapter';
+
+import {
+  QmlDebugClient,
+  IQmlDebugClient,
+  QmlDebugConnection,
+  Server,
+  DebugMessageClient,
+  IMessageType,
+  QmlDebugConnectionState
+} from '@debug/debug-connection';
+import { Timer } from '@debug/timer';
+import { createLogger } from 'qt-lib';
+import {
+  BreakpointState,
+  QmlBreakpoint,
+  QmlDebugSession
+} from '@debug/debug-adapter';
+import {
+  BACKTRACE,
+  BREAKONSIGNAL,
+  BREAKPOINT,
+  CLEARBREAKPOINT,
+  COLUMN,
+  CONDITION,
+  CONNECT,
+  CONTINEDEBUGGING,
+  DISCONNECT,
+  ENABLED,
+  EVENT,
+  IGNORECOUNT,
+  IN,
+  INTERRUPT,
+  LINE,
+  NEXT,
+  OUT,
+  SCRIPTREGEXP,
+  SETBREAKPOINT,
+  STEPACTION,
+  TARGET,
+  TYPE,
+  V8DEBUG,
+  V8MESSAGE,
+  V8REQUEST,
+  VERSION
+} from '@debug/qmlv8debuggerclientconstants';
+import { Packet } from '@debug/packet';
+import { DebuggerCommand } from '@debug/debugger-command';
+import { FileFinder } from '@debug/file-finder';
+import { QmlEngineUI } from '@debug/ui';
+
+const logger = createLogger('qml-engine');
+
+export enum DebuggerState {
+  DebuggerNotReady, // Debugger not started
+
+  EngineSetupRequested, // Engine starts
+  EngineSetupFailed,
+
+  EngineRunRequested,
+  EngineRunFailed,
+
+  InferiorUnrunnable, // Used in the core dump adapter
+
+  InferiorRunRequested, // Debuggee requested to run
+  InferiorRunOk, // Debuggee running
+  InferiorRunFailed, // Debuggee not running
+
+  InferiorStopRequested, // Debuggee running, stop requested
+  InferiorStopOk, // Debuggee stopped
+  InferiorStopFailed, // Debuggee not stopped, will kill debugger
+
+  InferiorShutdownRequested,
+  InferiorShutdownFinished,
+
+  EngineShutdownRequested,
+  EngineShutdownFinished,
+
+  DebuggerFinished
+}
+
+export enum DebuggerStartMode {
+  NoStartMode,
+  StartInternal, // Start current start project's binary
+  StartExternal, // Start binary found in file system
+  AttachToLocalProcess, // Attach to running local process by process id
+  AttachToCrashedProcess, // Attach to crashed process by process id
+  AttachToCore, // Attach to a core file
+  AttachToRemoteServer, // Attach to a running gdbserver
+  AttachToRemoteProcess, // Attach to a running remote process
+  AttachToQmlServer, // Attach to a running QmlServer
+  StartRemoteProcess // Start and attach to a remote process
+}
+
+enum QtMsgType {
+  QtDebugMsg,
+  QtInfoMsg,
+  QtWarningMsg,
+  QtCriticalMsg,
+  QtFatalMsg
+}
+
+export enum StepAction {
+  Continue,
+  StepIn,
+  StepOut,
+  Next
+}
+
+interface QmlMessage {
+  type: string;
+  seq: number;
+}
+
+interface IQmlEvent extends QmlMessage {
+  event: string;
+  body: IResponseBodyBreak;
+}
+
+interface IResponseBodyBreak {
+  invocationText: string;
+  sourceLineText: string;
+  script: string;
+  breakpoints: number[];
+  sourceLine: number;
+}
+
+interface QmlResponse<QmlResponseBody> extends QmlMessage {
+  type: 'response';
+  request_seq: number;
+  command: string;
+  success: boolean;
+  running: boolean;
+  body: QmlResponseBody;
+}
+
+interface QmlResponseBodySetBreakpoint {
+  type: string;
+  breakpoint: number;
+  line?: number;
+  actual_locations?: number[];
+}
+
+interface QmlSetBreakpointResponse
+  extends QmlResponse<QmlResponseBodySetBreakpoint> {
+  command: 'breakpoint';
+}
+
+interface QmlVariable {
+  handle: number;
+  name?: string;
+  type: string;
+  value: unknown;
+  ref?: number;
+  properties?: QmlVariable[];
+}
+
+interface QmlScope {
+  frameIndex: number;
+  index: number;
+  type: number;
+  object?: QmlVariable;
+}
+
+interface QmlFrame {
+  index: number;
+  func: string;
+  script: string;
+  line: number;
+  debuggerFrame: boolean;
+  scopes: QmlScope[];
+}
+
+interface QmlBacktrace {
+  fromFrame: number;
+  toFrame: number;
+  frames: QmlFrame[];
+}
+
+export interface QmlContinueResponse extends QmlResponse<undefined> {
+  command: 'continue';
+}
+
+interface QmlBacktraceResponse extends QmlResponse<QmlBacktrace> {
+  command: 'backtrace';
+}
+
+export class QmlEngine extends QmlDebugClient implements IQmlDebugClient {
+  private readonly _ui: QmlEngineUI | undefined;
+  private _buildDirs: string[] = [];
+  private _connectionState = QmlDebugConnectionState.Unavailable;
+  private readonly _callbackForToken = new Map<
+    number,
+    // TODO: Get rid of unknown
+    unknown
+  >();
+  private readonly _breakpointsSync = new Map<number, QmlBreakpoint>();
+  private readonly _breakpointsTemp = new Array<string>();
+  readonly mainQmlThreadId = 1;
+  private _sendBuffer: Packet[] = [];
+  private _sequence = -1;
+  private readonly _msgClient: DebugMessageClient | undefined;
+  private readonly _startMode: DebuggerStartMode =
+    DebuggerStartMode.AttachToQmlServer;
+  private _server: Server | undefined;
+  private _isDying = false;
+  private _state = DebuggerState.DebuggerNotReady;
+  private _retryOnConnectFail = false;
+  private _automaticConnect = false;
+  private readonly _session: QmlDebugSession;
+  private _onShutdownEngine: (() => void) | undefined;
+  private readonly _connectionTimer: Timer = new Timer();
+  constructor(session: QmlDebugSession) {
+    super('V8Debugger', new QmlDebugConnection());
+    this._ui = new QmlEngineUI();
+    this._session = session;
+    this._connectionTimer.setInterval(4000);
+    this._connectionTimer.setSingleShot(true);
+    this._connectionTimer.onTimeout(() => {
+      this.checkConnectionState();
+    });
+    this.connection.onConnectionFailed(() => {
+      this.connectionFailed();
+    });
+    this.connection.onConnected(() => {
+      this._connectionTimer.stop();
+      this.connectionEstablished();
+    });
+    this.connection.onDisconnected(() => {
+      this.disconnected();
+    });
+    this._msgClient = new DebugMessageClient(this.connection);
+    this._msgClient.newState((state: QmlDebugConnectionState) => {
+      if (!this._msgClient) {
+        throw new Error('Message client is not set');
+      }
+      this.logServiceStateChange(
+        this._msgClient.name,
+        this._msgClient.serviceVersion(),
+        state
+      );
+    });
+    this._msgClient.message((message: IMessageType) => {
+      QmlEngine.appendDebugOutput(message);
+    });
+  }
+  set onShutdownEngine(cb: () => void) {
+    this._onShutdownEngine = cb;
+  }
+
+  get ui() {
+    if (!this._ui) {
+      throw new Error('UI is not set');
+    }
+    return this._ui;
+  }
+
+  set buildDirs(dirs: string[]) {
+    this._buildDirs = dirs;
+  }
+  get buildDirs() {
+    return this._buildDirs;
+  }
+
+  get connectionState() {
+    return this._connectionState;
+  }
+  override stateChanged(state: QmlDebugConnectionState): void {
+    this._connectionState = state;
+    logger.info(
+      this.name,
+      this.serviceVersion() as unknown as string,
+      QmlDebugConnectionState[state]
+    );
+    if (state === QmlDebugConnectionState.Enabled) {
+      const cb = () => {
+        void this.flushSendBuffer();
+        const jsonParameters = {
+          redundantRefs: false,
+          namesAsObjects: false
+        };
+        const msg = new Packet();
+        msg.writeJsonUTF8(jsonParameters);
+        this.runDirectCommand(CONNECT, msg.data);
+        this.runCommand(new DebuggerCommand(VERSION));
+      };
+      Timer.singleShot(0, cb);
+    }
+  }
+  runCommand<T>(command: DebuggerCommand, cb?: (response: T) => void) {
+    ++this._sequence;
+    const object = {
+      type: 'request',
+      command: command.function,
+      seq: this._sequence,
+      arguments: command.args
+    };
+    if (cb) {
+      this._callbackForToken.set(this._sequence, cb);
+    }
+    const msg = new Packet();
+    msg.writeJsonUTF8(object);
+    this.runDirectCommand(V8REQUEST, msg.data);
+    return this._sequence;
+  }
+  async tryClaimBreakpoint(bp: QmlBreakpoint) {
+    return this.requestBreakpointInsertion(bp);
+  }
+  async requestBreakpointInsertion(bp: QmlBreakpoint) {
+    return this.insertBreakpoint(bp);
+  }
+  async insertBreakpoint(bp: QmlBreakpoint) {
+    const response = await this.setBreakpoint(
+      SCRIPTREGEXP,
+      bp.filename,
+      true,
+      bp.line,
+      0,
+      '',
+      0
+    );
+    const breakpointId = response.body.breakpoint;
+    if (breakpointId) {
+      this._breakpointsSync.set(breakpointId, bp);
+    }
+    return breakpointId;
+  }
+
+  clearBreakpoint(bp: QmlBreakpoint) {
+    //    { "seq"       : <number>,
+    //      "type"      : "request",
+    //      "command"   : "clearbreakpoint",
+    //      "arguments" : { "breakpoint" : <number of the break point to clear>
+    //                    }
+    //    }
+    if (bp.state !== BreakpointState.BreakpointInserted) {
+      return undefined;
+    }
+    if (bp.id === undefined) {
+      throw new Error('Breakpoint ID is not set');
+    }
+
+    const cmd = new DebuggerCommand(CLEARBREAKPOINT);
+    cmd.arg(BREAKPOINT, bp.id);
+    return this.runCommand(cmd);
+  }
+
+  async setBreakpoint(
+    type: string,
+    target: string,
+    enabled: boolean,
+    line: number,
+    column: number,
+    condition: string,
+    ignoreCount: number
+  ) {
+    //    { "seq"       : <number>,
+    //      "type"      : "request",
+    //      "command"   : "setbreakpoint",
+    //      "arguments" : { "type"        : <"function" or "script" or "scriptId" or "scriptRegExp">
+    //                      "target"      : <function expression or script identification>
+    //                      "line"        : <line in script or function>
+    //                      "column"      : <character position within the line>
+    //                      "enabled"     : <initial enabled state. True or false, default is true>
+    //                      "condition"   : <string with break point condition>
+    //                      "ignoreCount" : <number specifying the number of break point hits to ignore, default value is 0>
+    //                    }
+    //    }
+
+    const cmd = new DebuggerCommand(SETBREAKPOINT);
+    cmd.arg(TYPE, type);
+    cmd.arg(ENABLED, enabled);
+    if (type === SCRIPTREGEXP) {
+      // TODO: Use target file instead here
+      cmd.arg(TARGET, target);
+    } else {
+      cmd.arg(TARGET, target);
+    }
+    if (line) {
+      cmd.arg(LINE, line - 1);
+    }
+    if (column) {
+      cmd.arg(COLUMN, column - 1);
+    }
+    if (condition) {
+      cmd.arg(CONDITION, condition);
+    }
+    cmd.arg(IGNORECOUNT, ignoreCount);
+    const task = new Promise<QmlSetBreakpointResponse>((resolve) => {
+      this.runCommand(cmd, (debuggerResponse: QmlSetBreakpointResponse) => {
+        QmlEngine.handleResponse(debuggerResponse, resolve);
+      });
+    });
+    return task;
+  }
+
+  async backtrace(args: DebugProtocol.StackTraceArguments) {
+    //    { "seq"       : <number>,
+    //      "type"      : "request",
+    //      "command"   : "backtrace",
+    //      "arguments" : { "fromFrame" : <number>
+    //                      "toFrame" : <number>
+    //                      "bottom" : <boolean, set to true if the bottom of the
+    //                          stack is requested>
+    //                    }
+    //    }
+
+    const cmd = new DebuggerCommand(BACKTRACE);
+    // wait until the backtrace response is received
+    const task = new Promise<QmlBacktraceResponse>((resolve) => {
+      this.runCommand(cmd, (debuggerResponse: QmlBacktraceResponse) => {
+        QmlEngine.handleResponse(debuggerResponse, resolve);
+      });
+    });
+    const result = await task;
+    const backtrace = result.body;
+    const fileFinder = new FileFinder();
+    fileFinder.buildDirs = this.buildDirs;
+    let frameCount = 0;
+    const stackFrames = await Promise.all(
+      backtrace.frames
+        .filter((_value, index) => {
+          if (args.startFrame !== undefined) {
+            if (index < args.startFrame) {
+              return false;
+            }
+          }
+
+          if (args.levels !== undefined) {
+            if (frameCount >= args.levels) {
+              return false;
+            }
+            frameCount++;
+          }
+
+          return true;
+        })
+        .map(async (frame) => {
+          const physicalPath = await fileFinder.findFile(frame.script);
+          if (!physicalPath) {
+            throw new Error('Cannot find physical path for:' + frame.script);
+          }
+          const parsedPath = path.parse(physicalPath);
+          return new StackFrame(
+            frame.index,
+            frame.func,
+            new Source(parsedPath.base, physicalPath),
+            frame.line + 1
+          );
+        })
+    );
+    const length = backtrace.frames.length;
+    return { stackFrames, length };
+  }
+  static handleResponse<T>(response: T, resolve: (response: T) => void) {
+    resolve(response);
+  }
+  override messageReceived(packet: Packet): void {
+    const command = packet.readStringUTF8();
+    if (command !== V8DEBUG) {
+      logger.error('Unexpected header:', command);
+      return;
+    }
+    const type = packet.readStringUTF8();
+    logger.info('Received message:', type);
+    if (type == CONNECT) {
+      this.stateChanged(QmlDebugConnectionState.Connected);
+      logger.info(`${V8DEBUG} debugging session started`);
+    } else if (type == INTERRUPT) {
+      logger.info('Debug break requested');
+    } else if (type == BREAKONSIGNAL) {
+      logger.info('Break on signal handler requested');
+    } else if (type == V8MESSAGE) {
+      logger.info('V8 message received');
+      this.analyzeV8Message(packet);
+    }
+  }
+  async continueDebugging(action: StepAction) {
+    //    { "seq"       : <number>,
+    //      "type"      : "request",
+    //      "command"   : "continue",
+    //      "arguments" : { "stepaction" : <"in", "next" or "out">,
+    //                      "stepcount"  : <number of steps (default 1)>
+    //                    }
+    //    }
+    const cmd = new DebuggerCommand(CONTINEDEBUGGING);
+
+    if (action === StepAction.StepIn) {
+      cmd.arg(STEPACTION, IN);
+    } else if (action === StepAction.StepOut) {
+      cmd.arg(STEPACTION, OUT);
+    } else if (action === StepAction.Next) {
+      cmd.arg(STEPACTION, NEXT);
+    }
+
+    const task = new Promise<QmlContinueResponse>((resolve) => {
+      this.runCommand(cmd, (debuggerResponse: QmlContinueResponse) => {
+        QmlEngine.handleResponse(debuggerResponse, resolve);
+        this.notifyInferiorRunOk();
+      });
+    });
+    return task;
+  }
+  analyzeV8Message(packet: Packet) {
+    const message = packet.readJsonUTF8() as QmlMessage;
+    const type = message.type;
+    if (type === 'response') {
+      const response = message as QmlResponse<QmlResponseBodySetBreakpoint>;
+      const debugCommand = response.command;
+      const success = response.success;
+      if (!success) {
+        logger.info('Request was unsuccessful');
+      }
+      const seq = response.request_seq;
+      if (this._callbackForToken.has(seq)) {
+        const cb = this._callbackForToken.get(seq);
+        this._callbackForToken.delete(seq);
+        if (cb) {
+          const castedCB = cb as (response: unknown) => void;
+          castedCB(response);
+        }
+      }
+      logger.info('Request sequence:', seq as unknown as string);
+      if (debugCommand === DISCONNECT) {
+        logger.info('Debugging session ended');
+      } else if (debugCommand === CONTINEDEBUGGING) {
+        logger.info('Continue debugging');
+      } else if (debugCommand === CLEARBREAKPOINT) {
+        logger.info('Clear breakpoint');
+      } else if (debugCommand === SETBREAKPOINT) {
+        //                { "seq"         : <number>,
+        //                  "type"        : "response",
+        //                  "request_seq" : <number>,
+        //                  "command"     : "setbreakpoint",
+        //                  "body"        : { "type"       : <"function" or "script">
+        //                                    "breakpoint" : <break point number of the new break point>
+        //                                  }
+        //                  "running"     : <is the VM running after sending this response>
+        //                  "success"     : true
+        //                }
+        const body = response.body;
+        const index = body.breakpoint;
+        logger.info('Breakpoint index:', index as unknown as string);
+        if (this._breakpointsSync.has(seq)) {
+          const bp = this._breakpointsSync.get(seq);
+          this._breakpointsSync.delete(seq);
+          const actualLocations = body.actual_locations;
+          if (actualLocations) {
+            //The breakpoint requested line should be same as actual line
+            if (bp && bp.state !== BreakpointState.BreakpointInserted) {
+              // bp->setActualLine(actualLocations[0]);
+              // bp->setActualColumn(actualLocations[1]);
+              logger.info('bp.line:', bp.line.toString());
+            }
+          }
+        } else {
+          this._breakpointsTemp.push(seq.toString());
+        }
+      }
+    } else if (type == EVENT) {
+      logger.info('Event received');
+      const response = message as IQmlEvent;
+      const eventType = response.event;
+      if (eventType === 'break') {
+        logger.info('Break event');
+        // clearRefs();
+        const breakData = response.body;
+        const invocationText = breakData.invocationText;
+        const scriptUrl = breakData.script;
+        const sourceLineText = breakData.sourceLineText;
+        const v8BreakpointIdList = breakData.breakpoints;
+        logger.info('invocationText:', invocationText);
+        logger.info('scriptUrl:', scriptUrl);
+        logger.info('sourceLineText:', sourceLineText);
+        logger.info('v8BreakpointIdList:', v8BreakpointIdList.join(','));
+
+        if (this.state === DebuggerState.InferiorRunOk) {
+          this.notifyInferiorSpontaneousStop(breakData);
+        }
+      }
+    }
+  }
+  notifyInferiorRunOk() {
+    this.setState(DebuggerState.InferiorRunOk);
+  }
+
+  notifyInferiorSpontaneousStop(breakData: IResponseBodyBreak) {
+    logger.info('NOTE: INFERIOR SPONTANEOUS STOP');
+    this.setState(DebuggerState.InferiorStopOk);
+    const stoppedEvent: DebugProtocol.StoppedEvent = new StoppedEvent(
+      'breakpoint',
+      this.mainQmlThreadId
+    );
+    const breakpointIds = breakData.breakpoints;
+    const description: string[] = [];
+    description.push(breakData.script);
+    description.push(breakData.sourceLineText);
+    description.push(breakData.invocationText);
+    description.push(breakData.breakpoints.join(','));
+    stoppedEvent.body.description = description.join(':');
+    stoppedEvent.body.hitBreakpointIds = breakData.breakpoints;
+
+    logger.info('Stopped event: breakpointIds: ', breakpointIds.join(','));
+    this._session.sendEvent(stoppedEvent);
+  }
+  runDirectCommand(type: string, msg: Buffer) {
+    const packet = new Packet();
+    packet.writeStringUTF8(V8DEBUG);
+    packet.writeStringUTF8(type);
+    packet.writeBuffer(msg);
+    if (this.getState() === QmlDebugConnectionState.Enabled) {
+      void this.sendMessage(packet);
+    } else {
+      this._sendBuffer.push(packet);
+    }
+  }
+  async flushSendBuffer() {
+    if (this.getState() !== QmlDebugConnectionState.Enabled) {
+      throw new Error('Connection is not enabled');
+    }
+    for (const packet of this._sendBuffer) {
+      await this.sendMessage(packet);
+    }
+    this._sendBuffer = [];
+  }
+
+  logServiceStateChange(
+    service: string,
+    version: number,
+    newState: QmlDebugConnectionState
+  ) {
+    switch (newState) {
+      case QmlDebugConnectionState.Unavailable:
+        this.showConnectionStateMessage(
+          `Status of "${service}" Version: ${version} changed to 'unavailable'.`
+        );
+        break;
+      case QmlDebugConnectionState.Enabled:
+        this.showConnectionStateMessage(
+          `Status of "${service}" Version: ${version} changed to 'enabled'.`
+        );
+        break;
+      case QmlDebugConnectionState.NotConnected:
+        this.showConnectionStateMessage(
+          `Status of "${service}" Version: ${version} changed to 'not connected'.`
+        );
+        break;
+      case QmlDebugConnectionState.Connected:
+        this.showConnectionStateMessage(
+          `Status of "${service}" Version: ${version} changed to 'connected'.`
+        );
+        break;
+    }
+  }
+
+  showConnectionStateMessage(message: string) {
+    if (this._isDying) {
+      return;
+    }
+    logger.info('QML Debugger: ' + message);
+  }
+  static appendDebugOutput(message: IMessageType) {
+    switch (message.type as QtMsgType) {
+      case QtMsgType.QtInfoMsg:
+      case QtMsgType.QtDebugMsg:
+        logger.info(message.message);
+        break;
+      case QtMsgType.QtWarningMsg:
+        logger.warn(message.message);
+        break;
+      case QtMsgType.QtCriticalMsg:
+      case QtMsgType.QtFatalMsg:
+        logger.error(message.message);
+        break;
+      default:
+        logger.info(message.message);
+        break;
+    }
+    // TODO: Print with logger for now and later use vscode debug console
+  }
+  checkConnectionState() {
+    if (!this.isConnected()) {
+      this.closeConnection();
+      this.connectionStartupFailed();
+    }
+  }
+  closeConnection() {
+    this._automaticConnect = false;
+    this._retryOnConnectFail = false;
+    this._connectionTimer.stop();
+    this.connection.close();
+  }
+  connectionEstablished() {
+    if (this.state == DebuggerState.EngineRunRequested) {
+      this.notifyEngineRunAndInferiorRunOk();
+    }
+  }
+  notifyEngineRunAndInferiorRunOk() {
+    logger.info('NOTE: ENGINE RUN AND INFERIOR RUN OK');
+    this.ui.removeWaitingForDebugger();
+    void this.ui.showSuccesfullAttach();
+    this.setState(DebuggerState.InferiorRunOk);
+  }
+  disconnected() {
+    if (this._isDying) {
+      return;
+    }
+    logger.info('QML debugger disconnected');
+    this.notifyInferiorExited();
+  }
+  notifyInferiorExited() {
+    logger.info('NOTE: INFERIOR EXITED');
+    this.setState(DebuggerState.InferiorShutdownFinished);
+    this.ui.removeWaitingForDebugger();
+    this.doShutdownEngine();
+  }
+  connectionFailed() {
+    if (this.isConnected()) {
+      logger.error('Connection to the QML debugger was lost');
+    } else {
+      this._connectionTimer.stop();
+      this.connectionStartupFailed();
+    }
+  }
+  connectionStartupFailed() {
+    if (this._isDying) {
+      return;
+    }
+    if (this._retryOnConnectFail) {
+      // retry after 3 seconds ...
+      Timer.singleShot(3000, () => {
+        logger.info('Retrying connection ...');
+        this.beginConnection();
+      });
+      return;
+    }
+    logger.error('Cannot connect to the in-process QML debugger');
+    // Do you want to retry?
+    // TODO: Show user an info message
+  }
+  isConnected() {
+    return this.connection.isConnected();
+  }
+  set server(server: Server | undefined) {
+    this._server = server;
+  }
+  get server() {
+    return this._server;
+  }
+  setupEngine() {
+    if (this.server === undefined) {
+      throw new Error('Server is not set');
+    }
+    this.notifyEngineSetupOk();
+
+    if (this.state !== DebuggerState.EngineRunRequested) {
+      throw new Error('Unexpected state:' + this.state);
+    }
+    void this.ui.showWaitingForDebugger(this.server.port.toString());
+    if (this._startMode === DebuggerStartMode.AttachToQmlServer) {
+      this.tryToConnect();
+    }
+    if (this._automaticConnect) {
+      this.beginConnection();
+    }
+  }
+  start() {
+    this.setState(DebuggerState.EngineSetupRequested);
+    logger.info('CALL: SETUP ENGINE');
+    this.setupEngine();
+  }
+  tryToConnect() {
+    logger.info('QML Debugger: Trying to connect ...');
+    this._retryOnConnectFail = true;
+
+    if (this.state === DebuggerState.EngineRunRequested) {
+      if (this._isDying) {
+        // Probably cpp is being debugged and hence we did not get the output yet.
+        this.appStartupFailed('No application output received in time');
+      } else {
+        this.beginConnection();
+      }
+    } else {
+      this._automaticConnect = true;
+    }
+  }
+  beginConnection() {
+    if (
+      this.state !== DebuggerState.EngineRunRequested &&
+      this._retryOnConnectFail
+    ) {
+      return;
+    }
+    if (this.server === undefined) {
+      throw new Error('Server is not set');
+    }
+    let host = this.server.host;
+    if (host === '') {
+      host = 'localhost';
+    }
+    const port = this.server.port;
+    const connection = this.connection;
+    if (connection.isConnected()) {
+      return;
+    }
+    connection.connectToHost(host, port);
+    this._connectionTimer.start();
+  }
+  appStartupFailed(errorMessage: string) {
+    logger.error(
+      'Cannot connect to the in-process QML debugger: ' + errorMessage
+    );
+    this.ui.showError(errorMessage);
+    this.notifyEngineRunFailed();
+  }
+  notifyEngineRunFailed() {
+    logger.info('NOTE: ENGINE RUN FAILED');
+    this.setState(DebuggerState.EngineRunFailed);
+    this.doShutdownEngine();
+  }
+  doShutdownEngine() {
+    this.setState(DebuggerState.EngineShutdownRequested);
+    this.startDying();
+    logger.info('CALL: SHUTDOWN ENGINE');
+    this.shutdownEngine();
+  }
+  startDying() {
+    this._isDying = true;
+  }
+  shutdownEngine() {
+    if (this._onShutdownEngine) {
+      this._onShutdownEngine();
+    }
+    this.notifyEngineShutdownFinished();
+  }
+  notifyEngineShutdownFinished() {
+    logger.info('NOTE: ENGINE SHUTDOWN FINISHED');
+    this.setState(DebuggerState.EngineShutdownFinished);
+    this.doFinishDebugger();
+  }
+  doFinishDebugger() {
+    this.setState(DebuggerState.DebuggerFinished);
+  }
+  notifyEngineSetupOk() {
+    logger.info('NOTE: ENGINE SETUP OK');
+
+    if (this.state !== DebuggerState.EngineSetupRequested) {
+      throw new Error('Unexpected state:' + this.state);
+    }
+    this.setState(DebuggerState.EngineRunRequested);
+  }
+
+  get state() {
+    return this._state;
+  }
+  setState(state: DebuggerState) {
+    this._state = state;
+  }
+}

--- a/qt-qml/src/debug/qmlv8debuggerclientconstants.ts
+++ b/qt-qml/src/debug/qmlv8debuggerclientconstants.ts
@@ -1,0 +1,80 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+export const V8REQUEST = 'v8request';
+export const V8MESSAGE = 'v8message';
+export const BREAKONSIGNAL = 'breakonsignal';
+export const CONNECT = 'connect';
+export const INTERRUPT = 'interrupt';
+export const V8DEBUG = 'V8DEBUG';
+export const SEQ = 'seq';
+export const TYPE = 'type';
+export const COMMAND = 'command';
+export const ARGUMENTS = 'arguments';
+export const STEPACTION = 'stepaction';
+export const EXPRESSION = 'expression';
+export const FRAME = 'frame';
+export const GLOBAL = 'global';
+export const DISABLE_BREAK = 'disable_break';
+export const CONTEXT = 'context';
+export const HANDLES = 'handles';
+export const INCLUDESOURCE = 'includeSource';
+export const FROMFRAME = 'fromFrame';
+export const TOFRAME = 'toFrame';
+export const BOTTOM = 'bottom';
+export const NUMBER = 'number';
+export const FRAMENUMBER = 'frameNumber';
+export const TYPES = 'types';
+export const IDS = 'ids';
+export const FILTER = 'filter';
+export const FROMLINE = 'fromLine';
+export const TOLINE = 'toLine';
+export const TARGET = 'target';
+export const LINE = 'line';
+export const COLUMN = 'column';
+export const ENABLED = 'enabled';
+export const CONDITION = 'condition';
+export const IGNORECOUNT = 'ignoreCount';
+export const BREAKPOINT = 'breakpoint';
+export const FLAGS = 'flags';
+
+export const CONTINEDEBUGGING = 'continue';
+export const EVALUATE = 'evaluate';
+export const LOOKUP = 'lookup';
+export const BACKTRACE = 'backtrace';
+export const SCOPE = 'scope';
+export const SCRIPTS = 'scripts';
+export const SETBREAKPOINT = 'setbreakpoint';
+export const CLEARBREAKPOINT = 'clearbreakpoint';
+export const CHANGEBREAKPOINT = 'changebreakpoint';
+export const SETEXCEPTIONBREAK = 'setexceptionbreak';
+export const VERSION = 'version';
+export const DISCONNECT = 'disconnect';
+// const PROFILE = "profile";
+
+export const REQUEST = 'request';
+export const IN = 'in';
+export const NEXT = 'next';
+export const OUT = 'out';
+
+export const FUNCTION = 'function';
+export const SCRIPTREGEXP = 'scriptRegExp';
+export const EVENT = 'event';
+
+export const ALL = 'all';
+export const UNCAUGHT = 'uncaught';
+
+export const PAUSE = 'pause';
+export const RESUME = 'resume';
+
+export const HANDLE = 'handle';
+export const REF = 'ref';
+export const REFS = 'refs';
+export const BODY = 'body';
+export const NAME = 'name';
+export const VALUE = 'value';
+export const SUCCESS = 'success';
+export const MESSAGE = 'message';
+
+export const OBJECT = '{}';
+export const ARRAY = '[]';

--- a/qt-qml/src/debug/qrc-parser.ts
+++ b/qt-qml/src/debug/qrc-parser.ts
@@ -1,0 +1,99 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import { XMLParser } from 'fast-xml-parser';
+import * as fs from 'fs';
+
+// Define the structure for the QRC XML
+interface QRCFile {
+  '@_alias': string | undefined; // The alias for the file
+  '#text': string | undefined; // The file path
+}
+
+interface QRCResource {
+  '@_prefix': string;
+  file: QRCFile | QRCFile[]; // A file or an array of files
+}
+
+interface QRCParsed {
+  RCC: {
+    qresource: QRCResource | QRCResource[] | undefined; // One or more qresource elements
+  };
+}
+
+export class QRCParser {
+  private readonly parser: XMLParser;
+  private readonly _cache = new Map<string, Map<string, string>>();
+
+  constructor() {
+    this.parser = new XMLParser({
+      ignoreAttributes: false,
+      parseAttributeValue: true
+    });
+  }
+
+  parseQRCFile(filePath: string): Map<string, string> {
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Cannot find file: ${filePath}`);
+    }
+    const cachedContent = this._cache.get(filePath);
+    if (cachedContent) {
+      return cachedContent;
+    }
+    const xmlContent = fs.readFileSync(filePath, 'utf8');
+    const fileMapping = this.parseQRC(xmlContent);
+    this._cache.set(filePath, fileMapping);
+    return fileMapping;
+  }
+
+  parseQRC(xmlContent: string): Map<string, string> {
+    try {
+      // Parse the XML content into the defined structure
+      const jsonObj = this.parser.parse(xmlContent) as QRCParsed; // Type assertion to QRCParsed
+
+      // Extract the resources (qresource)
+      const resources = jsonObj.RCC.qresource;
+
+      if (!resources) {
+        throw new Error('Cannot find "qresource" in the QRC file');
+      }
+
+      // Ensure resources is always an array
+      const resourcesArray = Array.isArray(resources) ? resources : [resources];
+
+      // Initialize a Map to store file paths and corresponding aliases
+      const resourceMap = new Map<string, string>();
+
+      // Loop through each <qresource> and add its files to the map
+      resourcesArray.forEach((resource) => {
+        const prefix = resource['@_prefix'] || '';
+        const files = Array.isArray(resource.file)
+          ? resource.file
+          : [resource.file];
+
+        files.forEach((file) => {
+          const fileAlias = file['@_alias']; // Use the alias as the key
+          const filePath = file['#text'];
+          if (!fileAlias || !filePath) {
+            return;
+          }
+          const alias = prefix + fileAlias; // Combine the prefix and alias
+          resourceMap.set(alias, filePath); // Store alias as key, file path as value
+        });
+      });
+
+      // Filter the Map to include only .qml and .js files
+      const filteredMap = new Map<string, string>();
+      resourceMap.forEach((filePath, alias) => {
+        // Only keep .qml and .js files
+        if (filePath.endsWith('.qml') || filePath.endsWith('.js')) {
+          filteredMap.set(alias, filePath);
+        }
+      });
+
+      return filteredMap;
+    } catch (error) {
+      throw new Error(`Cannot parse QRC file: ${error as string}`);
+    }
+  }
+}

--- a/qt-qml/src/debug/timer.ts
+++ b/qt-qml/src/debug/timer.ts
@@ -1,0 +1,63 @@
+// Copyright (C) 2024 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+
+export class Timer {
+  private readonly _onTimeout: vscode.EventEmitter<void> =
+    new vscode.EventEmitter<void>();
+  private _singleShot = false;
+  private _interval: number | undefined; // ms
+  private _timer: NodeJS.Timeout | undefined;
+  constructor(interval?: number) {
+    this._interval = interval;
+  }
+  get onTimeout() {
+    return this._onTimeout.event;
+  }
+  dispose() {
+    this.disconnect();
+    this.stop();
+  }
+  disconnect() {
+    this._onTimeout.dispose();
+  }
+
+  isActive() {
+    return this._timer ? true : false;
+  }
+
+  start(interval?: number) {
+    if (interval !== undefined) {
+      this._interval = interval;
+    }
+    if (this._timer) {
+      this.stop();
+    }
+    if (this._interval === undefined) {
+      return;
+    }
+    this._timer = setInterval(() => {
+      this._onTimeout.fire();
+      if (this._singleShot) {
+        this.stop();
+      }
+    }, this._interval);
+  }
+
+  setInterval(interval: number) {
+    this._interval = interval;
+  }
+
+  setSingleShot(singleShot: boolean) {
+    this._singleShot = singleShot;
+  }
+
+  stop() {
+    clearInterval(this._timer);
+    this._timer = undefined;
+  }
+  public static singleShot(interval: number, callback: () => void) {
+    setTimeout(callback, interval);
+  }
+}

--- a/qt-qml/src/debug/ui.ts
+++ b/qt-qml/src/debug/ui.ts
@@ -1,0 +1,56 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+
+export class QmlEngineUI {
+  private progressResolve: (() => void) | undefined;
+  showSuccesfullAttach() {
+    this.removeWaitingForDebugger();
+    // Remove notification after 5 seconds
+    const title = 'QML Debugger attached successfully';
+    const progressOptions = {
+      title: title,
+      location: vscode.ProgressLocation.Notification,
+      cancellable: false
+    };
+    const timeout = 5000;
+    return vscode.window.withProgress(progressOptions, async (progress) => {
+      progress.report({ increment: 100 });
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          resolve();
+        }, timeout);
+      });
+    });
+  }
+  showWaitingForDebugger(port?: string) {
+    void this;
+    let title = `Waiting for the executable to start... `;
+    if (port) {
+      title += `Port: ${port}`;
+    }
+    const progressOptions = {
+      title: title,
+      location: vscode.ProgressLocation.Notification,
+      cancellable: false
+    };
+
+    return vscode.window.withProgress(progressOptions, async () => {
+      return new Promise<void>((resolve) => {
+        this.progressResolve = resolve;
+      });
+    });
+  }
+
+  removeWaitingForDebugger() {
+    if (this.progressResolve) {
+      this.progressResolve();
+      this.progressResolve = undefined;
+    }
+  }
+  showError(message: string) {
+    this.removeWaitingForDebugger();
+    void vscode.window.showErrorMessage(message);
+  }
+}

--- a/qt-qml/src/extension.ts
+++ b/qt-qml/src/extension.ts
@@ -15,14 +15,22 @@ import {
 } from 'qt-lib';
 import { registerRestartQmllsCommand } from '@cmd/restart-qmlls';
 import { registerDownloadQmllsCommand } from '@cmd/download-qmlls';
+import { registerDebugPort } from '@cmd/debug';
 import { registerCheckQmllsUpdateCommand } from '@cmd/check-qmlls-update';
 import { getDoNotAskForDownloadingQmlls, Qmlls, QmllsStatus } from '@/qmlls';
 import { EXTENSION_ID } from '@/constants';
 import { QMLProjectManager, createQMLProject } from '@/project';
 import { registerResetCommand } from '@cmd/reset';
+import { registerQmlDebugAdapterFactory } from '@debug/debug-adapter';
+import {
+  acquirePortTaskProvider,
+  AcquirePortTaskProvider
+} from './tasks/acquire-port';
 
 export let projectManager: QMLProjectManager;
 export let coreAPI: CoreAPI | undefined;
+
+let taskProvider: vscode.Disposable | undefined;
 
 const logger = createLogger('extension');
 
@@ -55,11 +63,17 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   context.subscriptions.push(
+    registerDebugPort(),
     registerRestartQmllsCommand(),
     registerCheckQmllsUpdateCommand(),
     registerDownloadQmllsCommand(),
     vscode.languages.registerColorProvider('qml', createColorProvider()),
-    registerResetCommand()
+    registerResetCommand(),
+    registerQmlDebugAdapterFactory()
+  );
+  taskProvider = vscode.tasks.registerTaskProvider(
+    AcquirePortTaskProvider.type,
+    acquirePortTaskProvider
   );
   telemetry.sendEvent(`activated`);
   projectManager.getConfigValues();
@@ -82,6 +96,9 @@ export function deactivate() {
   logger.info(`Deactivating ${EXTENSION_ID}`);
   telemetry.dispose();
   projectManager.dispose();
+  if (taskProvider) {
+    taskProvider.dispose();
+  }
 }
 
 function processMessage(message: QtWorkspaceConfigMessage) {

--- a/qt-qml/src/project.ts
+++ b/qt-qml/src/project.ts
@@ -63,6 +63,15 @@ export class QMLProjectManager extends ProjectManager<QMLProject> {
       project.getConfigValues();
     }
   }
+  getBuildDirs() {
+    const buildDirs = [];
+    for (const project of this.getProjects()) {
+      if (project.buildDir) {
+        buildDirs.push(project.buildDir);
+      }
+    }
+    return buildDirs;
+  }
 }
 // Project class represents a workspace folder in the extension.
 export class QMLProject implements Project {

--- a/qt-qml/src/tasks/acquire-port.ts
+++ b/qt-qml/src/tasks/acquire-port.ts
@@ -1,0 +1,87 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+import getPort from 'get-port';
+
+import { telemetry } from 'qt-lib';
+
+interface AcquirePortTaskDefinition extends vscode.TaskDefinition {
+  /**
+   * The task name
+   */
+  task: string;
+}
+
+export let compoundPort: string | undefined = undefined;
+
+// This is a dummy terminal that does nothing.
+// Since vscode.CustomExecution expects a callback which returns a
+// Pseudoterminal, we need to provide one. That's why we have this dummy
+// terminal class.
+export class DummyTaskTerminal implements vscode.Pseudoterminal {
+  private readonly _writeEmitter = new vscode.EventEmitter<string>();
+  private readonly _closeEmitter = new vscode.EventEmitter<number>();
+  public get onDidWrite() {
+    return this._writeEmitter.event;
+  }
+  public get onDidClose() {
+    return this._closeEmitter.event;
+  }
+  open() {
+    this.close();
+  }
+  close() {
+    this._closeEmitter.fire(0);
+  }
+}
+
+export class AcquirePortTaskProvider implements vscode.TaskProvider {
+  static type = 'Qt';
+  constructor() {
+    vscode.debug.onDidTerminateDebugSession((session) => {
+      if (session.type === 'qml') {
+        compoundPort = undefined;
+      }
+    });
+  }
+  private static getTask(
+    taskDefinition: AcquirePortTaskDefinition
+  ): vscode.Task {
+    const taskCallback = async (
+      _callbacktaskDefinition: vscode.TaskDefinition
+    ) => {
+      void _callbacktaskDefinition;
+      telemetry.sendAction('acquirePortTaskProvider');
+      compoundPort = (await getPort()).toString();
+      return Promise.resolve(new DummyTaskTerminal());
+    };
+    const WASMStartTask = new vscode.Task(
+      taskDefinition,
+      vscode.TaskScope.Workspace,
+      'Acquire Port',
+      AcquirePortTaskProvider.type,
+      new vscode.CustomExecution(taskCallback)
+    );
+    return WASMStartTask;
+  }
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  public provideTasks(): vscode.Task[] {
+    const result: vscode.Task[] = [];
+    const taskDefinition: AcquirePortTaskDefinition = {
+      type: AcquirePortTaskProvider.type,
+      task: 'Acquire Port'
+    };
+    const AcquirePortTask = AcquirePortTaskProvider.getTask(taskDefinition);
+    result.push(AcquirePortTask);
+    return result;
+  }
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  public resolveTask(_task: vscode.Task): vscode.Task | undefined {
+    const definition: AcquirePortTaskDefinition =
+      _task.definition as AcquirePortTaskDefinition;
+    return AcquirePortTaskProvider.getTask(definition);
+  }
+}
+
+export const acquirePortTaskProvider = new AcquirePortTaskProvider();

--- a/qt-qml/tsconfig.json
+++ b/qt-qml/tsconfig.json
@@ -24,7 +24,8 @@
       "@/*": ["src/*"],
       "@cmd/*": ["src/commands/*"],
       "@task/*": ["src/tasks/*"],
-      "@util/*": ["src/util/*"]
+      "@util/*": ["src/util/*"],
+      "@debug/*": ["src/debug/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
This PR introduces the QML Debug Adapter for Visual Studio Code, which
enables debugging of QML applications. The current implementation in QtCreator
was ported to `qt-qml`

Supported features include:

- Breakpoints
- Step over
- Step into
- Step out
- Continue

New launch.json configuration snippets:

- Qt: QML: Attach by port
    It includes basic configuration for attaching to a running QML application.

- Qt: Debug with cppdbg and QML debugger
    It includes basic configuration and command line parameter for QML debugging.

New commands and tasks:

- Qt: Acquire Port
    This task is used with compound debugging configurations to acquire the port
    so that both cppdbg and QML debugger use the same port.
- qt-qml.debugPort
    This command is used pass the same port to both cppdbg and QML debugger
    when using compound debugging configurations.

Some classes were added with this commit:

* QmlEngine

It has the most of the functionality of the QML Debug Adapter. It is responsible
for communicating with the QML debugger and handling debugging events.

* DataStream

This class is used to serialize and deserialize data for the QML Debug Adapter
protocol. It provides methods for writing and reading various data types. It is
a replacement for the `QDataStream` class in Qt.

* QRCParser

It parses .qrc files to extract resource information. It is used to match QML
files shared between the QML Debug Adapter and pysical files.

* QmlEngineUI

This class handles UI elements and interactions for the QML Debug Adapter.

* Timer

This class provides a timer functionality for the QML Debug Adapter. It is used
to schedule tasks and manage timeouts during startup. It is a replacement
for the `QTimer` class in Qt.

Task-number: [VSCODEEXT-14](https://bugreports.qt.io/browse/VSCODEEXT-14)
<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
