### PR TITLE
qt-cli: Fix broken template for .ui file

### DIFF
--- a/qt-cli/src/assets/templates/types/ui/file.ui
+++ b/qt-cli/src/assets/templates/types/ui/file.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>Form</class>
- <widget class="{{ .base }}" name="Form">
+ <widget class="{{ .baseClass }}" name="Form">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -13,6 +13,11 @@
   <property name="windowTitle">
    <string>{{ .title }}</string>
   </property>
+{{- if eq .baseClass "QMainWindow" }}
+  <widget class="QWidget" name="centralwidget"/>
+  <widget class="QMenuBar" name="menubar"/>
+  <widget class="QStatusBar" name="statusbar"/>
+{{- end }}
  </widget>
  <resources/>
  <connections/>

--- a/qt-cli/src/assets/templates/types/ui/prompt.yml
+++ b/qt-cli/src/assets/templates/types/ui/prompt.yml
@@ -1,6 +1,15 @@
 version: "1"
 
 steps:
+  - id: baseClass
+    type: picker
+    question: "Base class:"
+    default: "QMainWindow"
+    items:
+      - text: "QMainWindow"
+      - text: "QWidget"
+      - text: "QDialog"
+
   - id: title
     type: input
     question: "Enter a window title:"


### PR DESCRIPTION
Add missing prompt for base class selection.
If QMainWindow is selected, additional widgets - status bar, menu bar, and central widget - will be added to the .ui file.

Task-number: [VSCODEEXT-168](https://bugreports.qt.io/browse/VSCODEEXT-168)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
