### PR TITLE
qt-core: Add non-usage of CMakePresets to Qt recommended setting

### DIFF
--- a/qt-core/src/recommended-settings.ts
+++ b/qt-core/src/recommended-settings.ts
@@ -24,6 +24,11 @@ export function registerSetRecommendedSettingsCommand() {
       extensionId: 'cmake',
       setting: 'buildDirectory',
       value: `\${workspaceFolder}${path.sep}builds${path.sep}\${buildKit}${path.sep}\${buildType}`
+    },
+    {
+      extensionId: 'cmake',
+      setting: 'useCMakePresets',
+      value: 'never'
     }
   ];
 


### PR DESCRIPTION
As long as we don't support CMakePresets their usage is set to never. Qt kits visibility is blocked other wise.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
