### PR TITLE
Update natvis file handling to use .natvis suffix && Update debugging_helpers submodule

### DIFF
--- a/qt-cpp/src/commands/natvis.ts
+++ b/qt-cpp/src/commands/natvis.ts
@@ -28,11 +28,12 @@ export function registerNatvisCommand() {
       logger.error(error);
       throw new Error(error);
     }
+    const natvisSuffix = '.natvis';
     const natvisFile = path.join(
       extensionPath,
       'res',
       'natvis',
-      `qt${version}.natvis.xml`
+      `qt${version}${natvisSuffix}`
     );
     if (!fs.existsSync(natvisFile)) {
       const error = `Cannot find the natvis file: ${natvisFile}`;

--- a/scripts/prepare_natvis_files.ts
+++ b/scripts/prepare_natvis_files.ts
@@ -30,12 +30,12 @@ function processNatvisFiles(): boolean {
     return false;
   }
 
-  // Get all .natvis.xml files from source directory
+  // Get all .natvis files from source directory
   let files: string[];
   try {
     files = fs
       .readdirSync(sourceDir)
-      .filter((file) => file.endsWith('.natvis.xml'));
+      .filter((file) => file.endsWith('.natvis'));
   } catch (error) {
     console.error(
       `Error: Failed to read source directory ${sourceDir}:`,
@@ -45,7 +45,7 @@ function processNatvisFiles(): boolean {
   }
 
   if (files.length === 0) {
-    console.error('Error: No .natvis.xml files found in source directory.');
+    console.error('Error: No .natvis files found in source directory.');
     console.log('Check the state of the git submodule.');
     return false;
   }


### PR DESCRIPTION
Since the natvis files' suffixes changed with https://codereview.qt-project.org/c/qt-labs/vs-debugtools/+/636014,
Our code should use the suffix `.natvis` instead of `.natvis.xml`.

Update debugging_helpers submodule

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
