### PR TITLE
qt-cli: Show all presets in `preset ls`

### DIFF
--- a/qt-cli/src/cmds/preset_cmd.go
+++ b/qt-cli/src/cmds/preset_cmd.go
@@ -28,13 +28,7 @@ var presetListCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		items := runner.Presets.User.GetAll()
-		if len(items) == 0 {
-			fmt.Println(util.Msg("<no custom preset>"))
-		}
-
-		if lsAllPresets {
-			items = append(items, runner.Presets.Default.GetAll()...)
-		}
+		items = append(items, runner.Presets.Default.GetAll()...)
 
 		for _, item := range items {
 			fmt.Println(item.GetDescription())
@@ -126,8 +120,6 @@ var presetClearCmd = &cobra.Command{
 	},
 }
 
-var lsAllPresets bool
-
 func getConfirm(msg string) bool {
 	r, _ := comps.NewConfirm().
 		Question(msg).
@@ -143,10 +135,6 @@ func userPresets() *formats.UserPresetFile {
 }
 
 func init() {
-	presetListCmd.Flags().BoolVarP(
-		&lsAllPresets, "all", "a", false,
-		util.Msg("Include default presets in the list"))
-
 	presetCmd.AddCommand(presetListCmd)
 	presetCmd.AddCommand(presetCatCmd)
 	presetCmd.AddCommand(presetMoveCmd)


### PR DESCRIPTION
`preset ls` now shows both default and user-defined presets. The `-a` flag has been removed as it's no longer needed.

Task-number: [VSCODEEXT-172](https://bugreports.qt.io/browse/VSCODEEXT-172)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
