### PR TITLE
ci-scripts: Set permissions for qtcli before publishing

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -15,7 +15,7 @@ function extractAndPlaceQtCli(qtcorePath: string, zipPath: string) {
     // Remove outputDir if it exists to clean up the previous extraction
     if (fs.existsSync(outputDir)) {
       console.log(`Removing existing ${outputDir}`);
-      fs.rmdirSync(outputDir, { recursive: true });
+      fs.rmSync(outputDir, { recursive: true });
     }
     console.log(`Creating "${outputDir}"`);
     fs.mkdirSync(outputDir, { recursive: true });

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -23,6 +23,20 @@ function extractAndPlaceQtCli(qtcorePath: string, zipPath: string) {
     // https://github.com/ZJONSSON/node-unzipper/issues/216
     console.log(`Extracting "${zipPath}" to "${outputDir}"`);
     execSync(`unzip -o ${zipPath} -d ${outputDir}`, { stdio: 'inherit' });
+    // chmod 755 to all files in the outputDir
+    console.log(`Setting permissions for files in "${outputDir}"`);
+    const setPermissions = (dir: string) => {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          setPermissions(fullPath);
+        } else {
+          fs.chmodSync(fullPath, 0o755);
+        }
+      }
+    };
+    setPermissions(outputDir);
   } catch (error) {
     console.error(error);
     process.exit(1);


### PR DESCRIPTION
* When `qtcli` executables are signed, their permissions get removed. This commit sets the permissions to 755 for all `qtcli` executables before publishing.

* Remove deprecated function. See https://nodejs.org/api/deprecations.html#dep0147-fsrmdirpath--recursive-true-
<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
