### PR TITLE
qt-cli: Add 'gen-all' command to utility script

### DIFF
--- a/qt-cli/.gitignore
+++ b/qt-cli/.gitignore
@@ -1,3 +1,4 @@
 dist/
 tests/qtcli
 tests/qtcli.exe
+tests/_*

--- a/qt-cli/run.sh
+++ b/qt-cli/run.sh
@@ -5,6 +5,7 @@ show_help() {
   echo "Commands:"
   echo "  build            build binaries, copy to qt-core/res/qtcli"
   echo "  tests            run tests (e2e)"
+  echo "  gen-all          generate items from all presets for manual check"
   echo "  print-version    print current version"
   echo "  install-tools    install tools for build, license update, etc."
   echo "  update-license   update license files"
@@ -35,6 +36,49 @@ tests() {
   go build -C ./src -o ../tests && \
   echo ">>> Running end-to-end tests ..." && \
   go test -C ./tests/e2e -v
+}
+
+gen-all() {
+  outdir="_new-all"
+
+  echo ">>> Building binary..." && \
+  rm -rf ./tests/qtcli ./tests/qtcli.* ./tests/${outdir} && \
+  go build -C ./src -o ../tests && \
+
+  echo ">>> Creating items with default options to ${outdir}" && \
+  mkdir ./tests/${outdir} && cd $_ || exit 1
+
+  ext=""
+  if [[ "$(uname -s)" =~ MINGW|MSYS|CYGWIN ]]; then
+    ext=".exe"
+  fi
+
+  presets=(
+    "@projects/cpp/console"
+    "@projects/cpp/qtquick"
+    "@projects/cpp/qwidget"
+    "@types/qml"
+    "@types/qrc"
+    "@types/ui"
+    "@cpp/class"
+  )
+
+  for preset in "${presets[@]}"; do
+    name="new_$(echo "$preset" | sed 's/^@//' | tr '/' '_')"
+    subcmd="new-file"
+    if [[ "$preset" == @projects/* ]]; then
+      subcmd="new"
+    fi
+
+    cmd="../qtcli${ext} $subcmd $name --preset $preset"
+    echo "Running: $cmd"
+    $cmd
+  done
+
+  echo '-----------------------------------'
+  echo Output Dir: $(pwd)
+  echo '-----------------------------------'
+  ls -al
 }
 
 print_version() {
@@ -69,6 +113,9 @@ case "$1" in
     ;;
   tests)
     tests
+    ;;
+  gen-all)
+    gen-all
     ;;
   print-version)
     print_version


### PR DESCRIPTION
Add a command to generate items from all presets using default options. 
Helps with manual review of qtcli's ouput.
Outputs are stored in tests/.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
