### PR TITLE
qt-cli: Refactor PresetData internals

### DIFF
--- a/qt-cli/src/cmds/preset_cmd.go
+++ b/qt-cli/src/cmds/preset_cmd.go
@@ -6,7 +6,7 @@ package cmds
 import (
 	"errors"
 	"fmt"
-	"qtcli/formats"
+	"qtcli/common"
 	"qtcli/prompt/comps"
 	"qtcli/runner"
 	"qtcli/util"
@@ -130,7 +130,7 @@ func getConfirm(msg string) bool {
 	return r.ValueAsBool(false)
 }
 
-func userPresets() *formats.UserPresetFile {
+func userPresets() *common.UserPresetFile {
 	return runner.Presets.User.GetFile()
 }
 

--- a/qt-cli/src/common/common.go
+++ b/qt-cli/src/common/common.go
@@ -4,27 +4,23 @@
 package common
 
 import (
-	"fmt"
+	"io/fs"
+	"qtcli/assets"
 
-	"github.com/charmbracelet/lipgloss"
+	"github.com/sirupsen/logrus"
 )
-
-const QtCliName = "Qt CLI"
-const QtCliExec = "qtcli"
-const QtCliVersion = "0.1"
-
-var QtCliInfoString string
-var QtCliInfoDecorated string
 
 const PromptFileName = "prompt.yml"
 const TemplateFileName = "templates.yml"
 const UserPresetFileName = ".qtcli.preset"
 
-func init() {
-	QtCliInfoString = fmt.Sprintf("%s v%s", QtCliName, QtCliVersion)
-	QtCliInfoDecorated = lipgloss.
-		NewStyle().
-		Foreground(lipgloss.Color("#5a33f7")).
-		Render(QtCliInfoString)
+var TemplatesFS fs.FS
 
+func init() {
+	fs_, err := fs.Sub(assets.Assets, "templates")
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	TemplatesFS = fs_
 }

--- a/qt-cli/src/common/preset.go
+++ b/qt-cli/src/common/preset.go
@@ -22,9 +22,29 @@ type Preset interface {
 
 type PresetData struct {
 	Name        string            `yaml:"name"`
-	TypeName    string            `yaml:"type"`
 	TemplateDir string            `yaml:"template"`
 	Options     util.StringAnyMap `yaml:"options"`
+
+	// private field
+	targetTypeId TargetType
+}
+
+func NewPresetData(
+	name, templateDir string, options util.StringAnyMap) PresetData {
+
+	// read type from a template file
+	targetTypeId := TargetTypeFile
+	templateFile, err := OpenTemplateFileIn(TemplatesFS, templateDir)
+	if err == nil {
+		targetTypeId = templateFile.GetTargetType()
+	}
+
+	return PresetData{
+		Name:         name,
+		TemplateDir:  templateDir,
+		Options:      options,
+		targetTypeId: targetTypeId,
+	}
 }
 
 func (p PresetData) GetName() string {
@@ -32,7 +52,7 @@ func (p PresetData) GetName() string {
 }
 
 func (p PresetData) GetTypeId() TargetType {
-	return TargetTypeFromString(p.TypeName)
+	return p.targetTypeId
 }
 
 func (p PresetData) GetTypeName() string {
@@ -62,4 +82,8 @@ func (item PresetData) ToYaml() string {
 	}
 
 	return string(output)
+}
+
+func (p *PresetData) MergeOptions(data util.StringAnyMap) {
+	p.Options = util.Merge(p.Options, data)
 }

--- a/qt-cli/src/common/prompt_file.go
+++ b/qt-cli/src/common/prompt_file.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2024 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
-package formats
+package common
 
 import (
 	"errors"

--- a/qt-cli/src/common/target_type.go
+++ b/qt-cli/src/common/target_type.go
@@ -13,7 +13,7 @@ const (
 )
 
 func TargetTypeFromString(s string) TargetType {
-	if strings.ToLower(s) == "project" {
+	if strings.TrimSpace(strings.ToLower(s)) == "project" {
 		return TargetTypeProject
 	}
 

--- a/qt-cli/src/common/template_file.go
+++ b/qt-cli/src/common/template_file.go
@@ -1,12 +1,13 @@
 // Copyright (C) 2024 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
-package formats
+package common
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
-	"qtcli/common"
+	"path"
 	"qtcli/util"
 
 	"github.com/sirupsen/logrus"
@@ -39,14 +40,50 @@ type TemplateItem struct {
 	Bypass bool   `yaml:"bypass"`
 }
 
-func NewTemplateFileFS(fs fs.FS, filePath string) *TemplateFile {
-	return &TemplateFile{
+func OpenTemplateFile(fs fs.FS, filePath string) (*TemplateFile, error) {
+	if len(filePath) == 0 {
+		return nil, errors.New(util.Msg("cannot determine a file path"))
+	}
+
+	if !util.EntryExistsFS(fs, filePath) {
+		return nil, fmt.Errorf(
+			util.Msg("template definition does not exist, path = '%v'"), filePath)
+	}
+
+	template := TemplateFile{
 		fs:       fs,
 		filePath: filePath,
 	}
+
+	err := template.open()
+	if err != nil {
+		return nil, err
+	}
+
+	return &template, nil
 }
 
-func (f *TemplateFile) Open() error {
+func OpenTemplateFileIn(fs fs.FS, dir string) (*TemplateFile, error) {
+	return OpenTemplateFile(fs, path.Join(dir, TemplateFileName))
+}
+
+func (f *TemplateFile) GetTypeName() string {
+	return f.contents.Meta.Type
+}
+
+func (f *TemplateFile) GetTargetType() TargetType {
+	return TargetTypeFromString(f.contents.Meta.Type)
+}
+
+func (f *TemplateFile) GetFileItems() []TemplateItem {
+	return f.contents.Files
+}
+
+func (f *TemplateFile) GetFields() []util.StringAnyMap {
+	return f.contents.Fields
+}
+
+func (f *TemplateFile) open() error {
 	logrus.Debug(fmt.Sprintf(
 		"reading template definition, file = '%v'", f.filePath))
 
@@ -61,20 +98,4 @@ func (f *TemplateFile) Open() error {
 	}
 
 	return nil
-}
-
-func (f *TemplateFile) GetTypeName() string {
-	return f.contents.Meta.Type
-}
-
-func (f *TemplateFile) GetTargetType() common.TargetType {
-	return common.TargetTypeFromString(f.contents.Meta.Type)
-}
-
-func (f *TemplateFile) GetFileItems() []TemplateItem {
-	return f.contents.Files
-}
-
-func (f *TemplateFile) GetFields() []util.StringAnyMap {
-	return f.contents.Fields
 }

--- a/qt-cli/src/common/user_preset_file.go
+++ b/qt-cli/src/common/user_preset_file.go
@@ -1,12 +1,11 @@
 // Copyright (C) 2024 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
-package formats
+package common
 
 import (
 	"fmt"
 	"os"
-	"qtcli/common"
 	"qtcli/util"
 
 	"github.com/sirupsen/logrus"
@@ -19,8 +18,8 @@ type UserPresetFile struct {
 }
 
 type UserPresetFileContents struct {
-	Version string              `yaml:"version"`
-	Items   []common.PresetData `yaml:"items"`
+	Version string       `yaml:"version"`
+	Items   []PresetData `yaml:"items"`
 }
 
 func NewUserPresetFile(filePath string) *UserPresetFile {
@@ -40,7 +39,7 @@ func (f *UserPresetFile) Open() error {
 
 	if !util.EntryExists(f.filePath) {
 		f.contents.Version = "1"
-		f.contents.Items = []common.PresetData{}
+		f.contents.Items = []PresetData{}
 		err := f.Save()
 		if err != nil {
 			return err
@@ -60,14 +59,14 @@ func (f *UserPresetFile) Open() error {
 	return nil
 }
 
-func (f *UserPresetFile) FindByName(name string) (common.PresetData, error) {
+func (f *UserPresetFile) FindByName(name string) (PresetData, error) {
 	for _, item := range f.contents.Items {
 		if item.Name == name {
 			return item, nil
 		}
 	}
 
-	return common.PresetData{},
+	return PresetData{},
 		fmt.Errorf(util.Msg("not found, given = '%v'"), name)
 }
 
@@ -99,13 +98,13 @@ func (f *UserPresetFile) GetAllNames() []string {
 	return all
 }
 
-func (f *UserPresetFile) GetAll() []common.PresetData {
+func (f *UserPresetFile) GetAll() []PresetData {
 	return f.contents.Items
 }
 
 func (f *UserPresetFile) GetItemsOfTargetType(
-	t common.TargetType) []common.PresetData {
-	found := []common.PresetData{}
+	t TargetType) []PresetData {
+	found := []PresetData{}
 
 	for _, item := range f.contents.Items {
 		if t == item.GetTypeId() {
@@ -116,7 +115,7 @@ func (f *UserPresetFile) GetItemsOfTargetType(
 	return found
 }
 
-func (f *UserPresetFile) Add(data common.PresetData) error {
+func (f *UserPresetFile) Add(data PresetData) error {
 	f.contents.Items = append(f.contents.Items, data)
 	return nil
 }
@@ -158,18 +157,18 @@ func (f *UserPresetFile) Remove(name string) error {
 }
 
 func (f *UserPresetFile) RemoveAll() {
-	f.contents.Items = []common.PresetData{}
+	f.contents.Items = []PresetData{}
 }
 
 func (f *UserPresetFile) Find(
-	t common.TargetType, name string) (common.PresetData, error) {
+	t TargetType, name string) (PresetData, error) {
 	for _, item := range f.contents.Items {
 		if item.Name == name && t == item.GetTypeId() {
 			return item, nil
 		}
 	}
 
-	return common.PresetData{},
+	return PresetData{},
 		fmt.Errorf(util.Msg("not found, given = '%v'"), name)
 }
 
@@ -185,49 +184,10 @@ func (f *UserPresetFile) Rename(from string, to string) error {
 			util.Msg("cannot rename, already exist, given = '%v'"), to)
 	}
 
-	err = f.Add(common.PresetData{
-		Name:        to,
-		TypeName:    src.TypeName,
-		TemplateDir: src.TemplateDir,
-		Options:     src.Options,
-	})
+	err = f.Add(NewPresetData(to, src.TemplateDir, src.Options))
 	if err != nil {
 		return err
 	}
 
 	return f.Remove(from)
-}
-
-// manager
-type UserPresetManager struct {
-	file *UserPresetFile
-}
-
-func NewUserPresetManager(f *UserPresetFile) UserPresetManager {
-	return UserPresetManager{file: f}
-}
-
-func (m UserPresetManager) GetAll() []common.PresetData {
-	return m.file.GetAll()
-}
-
-func (m UserPresetManager) FindByType(
-	t common.TargetType,
-) []common.PresetData {
-	return m.file.GetItemsOfTargetType(t)
-}
-
-func (m UserPresetManager) FindByName(name string) (common.PresetData, error) {
-	return m.file.FindByName(name)
-}
-
-func (m UserPresetManager) FindByTypeAndName(
-	t common.TargetType,
-	name string,
-) (common.PresetData, error) {
-	return common.FindByTypeAndName(m, t, name)
-}
-
-func (m UserPresetManager) GetFile() *UserPresetFile {
-	return m.file
 }

--- a/qt-cli/src/common/user_preset_manager.go
+++ b/qt-cli/src/common/user_preset_manager.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2024 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+package common
+
+type UserPresetManager struct {
+	file *UserPresetFile
+}
+
+func NewUserPresetManager(f *UserPresetFile) UserPresetManager {
+	return UserPresetManager{file: f}
+}
+
+func (m UserPresetManager) GetAll() []PresetData {
+	return m.file.GetAll()
+}
+
+func (m UserPresetManager) FindByType(t TargetType) []PresetData {
+	return m.file.GetItemsOfTargetType(t)
+}
+
+func (m UserPresetManager) FindByName(name string) (PresetData, error) {
+	return m.file.FindByName(name)
+}
+
+func (m UserPresetManager) FindByTypeAndName(
+	t TargetType,
+	name string,
+) (PresetData, error) {
+	return FindByTypeAndName(m, t, name)
+}
+
+func (m UserPresetManager) GetFile() *UserPresetFile {
+	return m.file
+}

--- a/qt-cli/src/generator/generator.go
+++ b/qt-cli/src/generator/generator.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"path"
 	"qtcli/common"
-	"qtcli/formats"
 	"qtcli/util"
 	"regexp"
 	"strings"
@@ -27,7 +26,7 @@ type Generator struct {
 type Context struct {
 	data      util.StringAnyMap
 	funcs     template.FuncMap
-	items     []formats.TemplateItem
+	items     []common.TemplateItem
 	outputDir string
 }
 
@@ -161,25 +160,24 @@ func (g *Generator) runNames() (Result, error) {
 }
 
 func (g *Generator) readFilesAndFields() (
-	[]formats.TemplateItem, []util.StringAnyMap, error) {
+	[]common.TemplateItem, []util.StringAnyMap, error) {
 	dir := g.preset.GetTemplateDir()
 	filePath := path.Join(dir, g.env.TemplateFileName)
 
 	if len(dir) == 0 {
-		return []formats.TemplateItem{}, []util.StringAnyMap{},
+		return []common.TemplateItem{}, []util.StringAnyMap{},
 			errors.New(util.Msg("cannot determine a config file path"))
 	}
 
 	if !util.EntryExistsFS(g.env.FS, filePath) {
-		return []formats.TemplateItem{}, []util.StringAnyMap{},
+		return []common.TemplateItem{}, []util.StringAnyMap{},
 			fmt.Errorf(
 				util.Msg("template definition does not exist, dir = '%v'"), dir)
 	}
 
-	template := formats.NewTemplateFileFS(g.env.FS, filePath)
-	err := template.Open()
+	template, err := common.OpenTemplateFile(g.env.FS, filePath)
 	if err != nil {
-		return []formats.TemplateItem{}, []util.StringAnyMap{}, err
+		return []common.TemplateItem{}, []util.StringAnyMap{}, err
 	}
 
 	return template.GetFileItems(), template.GetFields(), nil
@@ -227,7 +225,7 @@ func (g *Generator) runContents(result ResultItem) error {
 	return nil
 }
 
-func (g *Generator) createInputPath(file formats.TemplateItem) string {
+func (g *Generator) createInputPath(file common.TemplateItem) string {
 	if strings.HasPrefix(file.In, "@/") {
 		return file.In[2:]
 	}
@@ -236,7 +234,7 @@ func (g *Generator) createInputPath(file formats.TemplateItem) string {
 }
 
 func (g *Generator) createOutputFileName(
-	file formats.TemplateItem) (string, error) {
+	file common.TemplateItem) (string, error) {
 	if len(file.Out) == 0 {
 		return path.Base(file.In), nil
 	}
@@ -248,7 +246,7 @@ func (g *Generator) createOutputFileName(
 		RunString(file.Out)
 }
 
-func (g *Generator) evalWhenCondition(file formats.TemplateItem) (bool, error) {
+func (g *Generator) evalWhenCondition(file common.TemplateItem) (bool, error) {
 	return util.NewTemplateExpander().
 		Name(file.In).
 		Data(g.context.data).

--- a/qt-cli/src/generator/result.go
+++ b/qt-cli/src/generator/result.go
@@ -6,14 +6,14 @@ package generator
 import (
 	"fmt"
 	"io"
-	"qtcli/formats"
+	"qtcli/common"
 	"text/tabwriter"
 )
 
 type Result []ResultItem
 
 type ResultItem struct {
-	TemplateItem   formats.TemplateItem
+	TemplateItem   common.TemplateItem
 	InputFilePath  string
 	OutputFilePath string
 }

--- a/qt-cli/src/runner/default_preset.go
+++ b/qt-cli/src/runner/default_preset.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"path"
 	"qtcli/common"
-	"qtcli/formats"
 	"qtcli/util"
 )
 
@@ -47,33 +46,11 @@ func (m DefaultPresetManager) FindByType(
 	return []common.PresetData{}
 }
 
-func loadPresets(baseFS fs.FS, t common.TargetType) []common.PresetData {
-	all := []common.PresetData{}
-	dirs, err := findAllTemplateDirNames(baseFS, t)
-
-	if err == nil {
-		for _, dir := range dirs {
-			p := common.PresetData{
-				Name:        "@" + dir,
-				TypeName:    common.TargetTypeToString(t),
-				TemplateDir: dir,
-				Options:     readDefaultOptions(baseFS, dir),
-			}
-
-			all = append(all, p)
-		}
-	}
-
-	return all
-}
-
-func (m DefaultPresetManager) FindByName(
-	name string,
-) (common.PresetData, error) {
+func (m DefaultPresetManager) FindByName(n string) (common.PresetData, error) {
 	all := m.GetAll()
 
 	for _, preset := range all {
-		if preset.GetName() == name {
+		if preset.GetName() == n {
 			return preset, nil
 		}
 	}
@@ -89,6 +66,20 @@ func (m DefaultPresetManager) FindByTypeAndName(
 }
 
 // helpers
+func loadPresets(baseFS fs.FS, t common.TargetType) []common.PresetData {
+	all := []common.PresetData{}
+	dirs, err := findAllTemplateDirNames(baseFS, t)
+
+	if err == nil {
+		for _, dir := range dirs {
+			p := common.NewPresetData("@"+dir, dir, readDefaultOptions(baseFS, dir))
+			all = append(all, p)
+		}
+	}
+
+	return all
+}
+
 func findAllTemplateDirNames(
 	baseFS fs.FS,
 	t common.TargetType,
@@ -103,9 +94,7 @@ func findAllTemplateDirNames(
 
 			if d.IsDir() && walkingPath != "." {
 				fullPath := path.Join(walkingPath, common.TemplateFileName)
-				templateFile := formats.NewTemplateFileFS(baseFS, fullPath)
-				err := templateFile.Open()
-
+				templateFile, err := common.OpenTemplateFile(baseFS, fullPath)
 				if err == nil && templateFile.GetTargetType() == t {
 					found = append(found, walkingPath)
 				}
@@ -120,7 +109,7 @@ func findAllTemplateDirNames(
 func readDefaultOptions(baseFS fs.FS, templateDir string) util.StringAnyMap {
 	fullPath := path.Join(templateDir, common.PromptFileName)
 
-	f := formats.NewPromptFileFS(baseFS, fullPath)
+	f := common.NewPromptFileFS(baseFS, fullPath)
 	if err := f.Open(); err != nil {
 		return util.StringAnyMap{}
 	}

--- a/qt-cli/src/runner/runner.go
+++ b/qt-cli/src/runner/runner.go
@@ -4,12 +4,9 @@
 package runner
 
 import (
-	"io/fs"
 	"os"
 	"path"
-	"qtcli/assets"
 	"qtcli/common"
-	"qtcli/formats"
 	"qtcli/generator"
 
 	"github.com/sirupsen/logrus"
@@ -19,18 +16,13 @@ var GeneratorEnv *generator.Env
 
 var Presets struct {
 	Default DefaultPresetManager
-	User    formats.UserPresetManager
+	User    common.UserPresetManager
 	Any     common.CompositePresetManager
 }
 
 func init() {
-	baseFS, err := fs.Sub(assets.Assets, "templates")
-	if err != nil {
-		logrus.Fatal(err)
-	}
-
 	GeneratorEnv = &generator.Env{
-		FS:               baseFS,
+		FS:               common.TemplatesFS,
 		FileTypesBaseDir: "types",
 		TemplateFileName: common.TemplateFileName,
 	}
@@ -42,18 +34,18 @@ func init() {
 	}
 
 	fullPath := path.Join(home, common.UserPresetFileName)
-	userPresets := formats.NewUserPresetFile(fullPath)
+	userPresets := common.NewUserPresetFile(fullPath)
 	if err := userPresets.Open(); err != nil {
 		logrus.Fatal(err)
 	}
 
 	// preset managers
-	userPresetManager := formats.NewUserPresetManager(userPresets)
+	userPresetManager := common.NewUserPresetManager(userPresets)
 	defaultPresetManager := NewDefaultPresetManager(GeneratorEnv.FS)
 
 	Presets = struct {
 		Default DefaultPresetManager
-		User    formats.UserPresetManager
+		User    common.UserPresetManager
 		Any     common.CompositePresetManager
 	}{
 		Default: defaultPresetManager,

--- a/qt-cli/src/runner/text_ui.go
+++ b/qt-cli/src/runner/text_ui.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"path"
 	"qtcli/common"
-	"qtcli/formats"
 	"qtcli/prompt"
 	"qtcli/prompt/comps"
 	"qtcli/util"
@@ -25,7 +24,7 @@ func RunPromptFromDir(dir string) (util.StringAnyMap, error) {
 		return util.StringAnyMap{}, nil
 	}
 
-	promptFile := formats.NewPromptFileFS(GeneratorEnv.FS, fullPath)
+	promptFile := common.NewPromptFileFS(GeneratorEnv.FS, fullPath)
 	if err := promptFile.Open(); err != nil {
 		return util.StringAnyMap{}, nil
 	}
@@ -47,12 +46,7 @@ func RunFilePromptByExt(ext string) (common.Preset, error) {
 		return nil, err
 	}
 
-	return common.PresetData{
-		Name:        extName,
-		TypeName:    common.TargetTypeToString(common.TargetTypeFile),
-		TemplateDir: templateDir,
-		Options:     options,
-	}, nil
+	return common.NewPresetData(extName, templateDir, options), nil
 }
 
 func FindPresetOrRunSelector(
@@ -119,12 +113,11 @@ func runManualConfig(t common.TargetType) (common.Preset, error) {
 	}
 
 	// build preset
-	presetData := common.PresetData{
-		Name:        selectedDefaultPreset.GetName(),
-		TypeName:    common.TargetTypeToString(t),
-		TemplateDir: selectedDefaultPreset.GetTemplateDir(),
-		Options:     options,
-	}
+	presetData := common.NewPresetData(
+		selectedDefaultPreset.GetName(),
+		selectedDefaultPreset.GetTemplateDir(),
+		options,
+	)
 
 	// try to save
 	newName := runPresetSavePrompt()


### PR DESCRIPTION
Removed redundant TypeName field.
Type information is now derived from template during construction.
Moved files in formats/ to common/ to resolve a circular dependency.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
