### PR TITLE
qt-cli: Add GetUniqueId() to Preset interface

### DIFF
--- a/qt-cli/src/common/preset.go
+++ b/qt-cli/src/common/preset.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"fmt"
+	"hash/crc32"
 	"qtcli/util"
 	"strings"
 
@@ -18,6 +19,7 @@ type Preset interface {
 	GetDescription() string
 	GetTemplateDir() string
 	GetOptions() util.StringAnyMap
+	GetUniqueId() string
 }
 
 type PresetData struct {
@@ -25,7 +27,8 @@ type PresetData struct {
 	TemplateDir string            `yaml:"template"`
 	Options     util.StringAnyMap `yaml:"options"`
 
-	// private field
+	// private fields
+	uniqueId     string
 	targetTypeId TargetType
 }
 
@@ -39,10 +42,14 @@ func NewPresetData(
 		targetTypeId = templateFile.GetTargetType()
 	}
 
+	// make unique id for rest call
+	uniqueId := fmt.Sprintf("%010d", crc32.ChecksumIEEE([]byte(name)))
+
 	return PresetData{
 		Name:         name,
 		TemplateDir:  templateDir,
 		Options:      options,
+		uniqueId:     uniqueId,
 		targetTypeId: targetTypeId,
 	}
 }
@@ -73,6 +80,10 @@ func (p PresetData) GetTemplateDir() string {
 
 func (p PresetData) GetOptions() util.StringAnyMap {
 	return p.Options
+}
+
+func (p PresetData) GetUniqueId() string {
+	return p.uniqueId
 }
 
 func (item PresetData) ToYaml() string {

--- a/qt-cli/src/common/preset_manager.go
+++ b/qt-cli/src/common/preset_manager.go
@@ -13,6 +13,7 @@ type PresetManager interface {
 	FindByType(t TargetType) []PresetData
 	FindByName(name string) (PresetData, error)
 	FindByTypeAndName(t TargetType, name string) (PresetData, error)
+	FindByUniqueId(id string) (PresetData, error)
 }
 
 type CompositePresetManager struct {
@@ -66,6 +67,17 @@ func (m CompositePresetManager) FindByTypeAndName(
 	}
 
 	return notFoundError(name)
+}
+
+func (m CompositePresetManager) FindByUniqueId(id string) (PresetData, error) {
+	for _, c := range m.comps {
+		preset, err := c.FindByUniqueId(id)
+		if err == nil {
+			return preset, nil
+		}
+	}
+
+	return notFoundError(id)
 }
 
 // helpers

--- a/qt-cli/src/common/user_preset_file.go
+++ b/qt-cli/src/common/user_preset_file.go
@@ -59,6 +59,17 @@ func (f *UserPresetFile) Open() error {
 	return nil
 }
 
+func (f *UserPresetFile) FindByUniqueId(id string) (PresetData, error) {
+	for _, item := range f.contents.Items {
+		if item.GetUniqueId() == id {
+			return item, nil
+		}
+	}
+
+	return PresetData{},
+		fmt.Errorf(util.Msg("not found, given = '%v'"), id)
+}
+
 func (f *UserPresetFile) FindByName(name string) (PresetData, error) {
 	for _, item := range f.contents.Items {
 		if item.Name == name {

--- a/qt-cli/src/common/user_preset_manager.go
+++ b/qt-cli/src/common/user_preset_manager.go
@@ -30,6 +30,10 @@ func (m UserPresetManager) FindByTypeAndName(
 	return FindByTypeAndName(m, t, name)
 }
 
+func (m UserPresetManager) FindByUniqueId(id string) (PresetData, error) {
+	return m.file.FindByUniqueId(id)
+}
+
 func (m UserPresetManager) GetFile() *UserPresetFile {
 	return m.file
 }

--- a/qt-cli/src/runner/default_preset.go
+++ b/qt-cli/src/runner/default_preset.go
@@ -65,6 +65,16 @@ func (m DefaultPresetManager) FindByTypeAndName(
 	return common.FindByTypeAndName(m, t, name)
 }
 
+func (m DefaultPresetManager) FindByUniqueId(id string) (common.PresetData, error) {
+	for _, preset := range m.GetAll() {
+		if preset.GetUniqueId() == id {
+			return preset, nil
+		}
+	}
+
+	return common.PresetData{}, errors.New("not found")
+}
+
 // helpers
 func loadPresets(baseFS fs.FS, t common.TargetType) []common.PresetData {
 	all := []common.PresetData{}


### PR DESCRIPTION
Update Preset to generate a unique ID from its name. 
This is useful when a preset needs to be identified by a REST call, 
as names contain incompatible characters such as @ or /.

Relevant structs implementing Preset interface have been updated accordingly.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
