### PR TITLE
qt-cli: Add options to generator and update result struct

### DIFF
--- a/qt-cli/src/generator/generator.go
+++ b/qt-cli/src/generator/generator.go
@@ -6,7 +6,9 @@ package generator
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path"
+	"path/filepath"
 	"qtcli/common"
 	"qtcli/util"
 	"regexp"
@@ -17,22 +19,29 @@ import (
 )
 
 type Generator struct {
-	env     *Env
-	name    string
-	preset  common.Preset
-	context Context
+	env        *Env
+	name       string
+	preset     common.Preset
+	workingDir string
+	dryRun     bool
+	context    Context
 }
 
 type Context struct {
-	data      util.StringAnyMap
-	funcs     template.FuncMap
-	items     []common.TemplateItem
-	outputDir string
+	data            util.StringAnyMap
+	funcs           template.FuncMap
+	items           []common.TemplateItem
+	outputDirOffset string
 }
 
 func NewGenerator(name string) *Generator {
+	cwd, _ := os.Getwd()
+	cwd = filepath.ToSlash(cwd)
+
 	return &Generator{
-		name: name,
+		name:       name,
+		workingDir: cwd,
+		dryRun:     false,
 	}
 }
 
@@ -46,7 +55,18 @@ func (g *Generator) Preset(preset common.Preset) *Generator {
 	return g
 }
 
+func (g *Generator) WorkingDir(dir string) *Generator {
+	g.workingDir = dir
+	return g
+}
+
+func (g *Generator) DryRun(on bool) *Generator {
+	g.dryRun = on
+	return g
+}
+
 func (g *Generator) Render() (Result, error) {
+	// prep.
 	if err := g.prepContext(); err != nil {
 		return Result{}, err
 	}
@@ -58,18 +78,18 @@ func (g *Generator) Render() (Result, error) {
 	}
 
 	// check if exists
-	for _, item := range result {
-		if !util.EntryExistsFS(g.env.FS, item.InputFilePath) {
-			logrus.Fatalf("file not found, %s", item.InputFilePath)
+	for _, item := range result.items {
+		if !util.EntryExistsFS(g.env.FS, item.inputFileRel) {
+			logrus.Fatalf("file not found, %s", item.inputFileRel)
 		}
 
-		if util.EntryExists(item.OutputFilePath) {
-			logrus.Fatalf("output already exists, %s", item.OutputFilePath)
+		if util.EntryExists(item.outputFileAbs) {
+			logrus.Fatalf("output already exists, %s", item.outputFileAbs)
 		}
 	}
 
 	// run contents and save
-	for _, item := range result {
+	for _, item := range result.items {
 		if err := g.runContents(item); err != nil {
 			return Result{}, err
 		}
@@ -88,9 +108,9 @@ func (g *Generator) prepContext() error {
 	g.context.data["name"] = g.name
 	g.context.funcs = getApi()
 	g.context.items = files
-	g.context.outputDir = "."
+	g.context.outputDirOffset = ""
 	if g.preset.GetTypeId() == common.TargetTypeProject {
-		g.context.outputDir = g.name
+		g.context.outputDirOffset = g.name
 	}
 
 	err = g.evalFields(fields)
@@ -127,8 +147,10 @@ func (g *Generator) evalFields(fields []util.StringAnyMap) error {
 }
 
 func (g *Generator) runNames() (Result, error) {
-
-	result := Result{}
+	result := Result{
+		workingDir:   g.workingDir,
+		outputDirAbs: path.Join(g.workingDir, g.context.outputDirOffset),
+	}
 
 	for _, file := range g.context.items {
 		okay, err := g.evalWhenCondition(file)
@@ -143,16 +165,17 @@ func (g *Generator) runNames() (Result, error) {
 			continue
 		}
 
-		inputPath := g.createInputPath(file)
-		outputName, err := g.createOutputFileName(file)
+		inputRel := g.createInputFileRel(file)
+		outputRel, err := g.createOutputFileRel(file)
 		if err != nil {
 			return Result{}, err
 		}
 
-		result = append(result, ResultItem{
-			TemplateItem:   file,
-			InputFilePath:  inputPath,
-			OutputFilePath: path.Join(g.context.outputDir, outputName),
+		result.items = append(result.items, ResultItem{
+			templateItem:  file,
+			inputFileRel:  inputRel,
+			outputFileRel: outputRel,
+			outputFileAbs: path.Join(result.outputDirAbs, outputRel),
 		})
 	}
 
@@ -185,7 +208,7 @@ func (g *Generator) readFilesAndFields() (
 
 func (g *Generator) runContents(result ResultItem) error {
 	// expand input file contents
-	allBytes, err := util.ReadAllFromFS(g.env.FS, result.InputFilePath)
+	allBytes, err := util.ReadAllFromFS(g.env.FS, result.inputFileRel)
 
 	if err != nil {
 		return err
@@ -194,7 +217,7 @@ func (g *Generator) runContents(result ResultItem) error {
 	input := string(allBytes)
 	var output string
 
-	if result.TemplateItem.Bypass {
+	if result.templateItem.Bypass {
 		output = input
 	} else {
 		expander := util.NewTemplateExpander().
@@ -202,8 +225,8 @@ func (g *Generator) runContents(result ResultItem) error {
 			Funcs(g.context.funcs)
 
 		output, err = expander.
-			Name(result.OutputFilePath).
-			AddData("fileName", result.OutputFilePath).
+			Name(result.outputFileAbs).
+			AddData("fileName", result.outputFileAbs).
 			RunString(input)
 	}
 
@@ -212,20 +235,18 @@ func (g *Generator) runContents(result ResultItem) error {
 	}
 
 	// save to file
-	if len(g.context.outputDir) == 0 {
-		return errors.New("cannot determine output directory")
-	}
-
-	output = polishOutput(output)
-	_, err = util.WriteAll([]byte(output), result.OutputFilePath)
-	if err != nil {
-		return err
+	if !g.dryRun {
+		output = polishOutput(output)
+		_, err = util.WriteAll([]byte(output), result.outputFileAbs)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (g *Generator) createInputPath(file common.TemplateItem) string {
+func (g *Generator) createInputFileRel(file common.TemplateItem) string {
 	if strings.HasPrefix(file.In, "@/") {
 		return file.In[2:]
 	}
@@ -233,7 +254,7 @@ func (g *Generator) createInputPath(file common.TemplateItem) string {
 	return path.Join(g.preset.GetTemplateDir(), file.In)
 }
 
-func (g *Generator) createOutputFileName(
+func (g *Generator) createOutputFileRel(
 	file common.TemplateItem) (string, error) {
 	if len(file.Out) == 0 {
 		return path.Base(file.In), nil

--- a/qt-cli/src/generator/result.go
+++ b/qt-cli/src/generator/result.go
@@ -10,30 +10,39 @@ import (
 	"text/tabwriter"
 )
 
-type Result []ResultItem
+type Result struct {
+	items        []ResultItem
+	workingDir   string
+	outputDirAbs string
+}
 
 type ResultItem struct {
-	TemplateItem   common.TemplateItem
-	InputFilePath  string
-	OutputFilePath string
+	templateItem  common.TemplateItem
+	inputFileRel  string // relative to env.FS
+	outputFileRel string // relative to outputDirAbs
+	outputFileAbs string
 }
 
 func (r *Result) Print(output io.Writer) {
 	w := tabwriter.NewWriter(output, 0, 0, 2, ' ', 0)
 
-	for _, item := range *r {
+	for _, item := range r.items {
 		fmt.Fprintf(
-			w, "%s\t->\t%s\n", item.TemplateItem.In, item.OutputFilePath)
+			w, "%s\t->\t%s\n", item.templateItem.In, item.outputFileRel)
 	}
 
 	w.Flush()
 }
 
-func (r *Result) GetOutputFilePaths() []string {
+func (r *Result) GetOutputDirAbs() string {
+	return r.outputDirAbs
+}
+
+func (r *Result) GetOutputFilesRel() []string {
 	all := []string{}
 
-	for _, item := range *r {
-		all = append(all, item.OutputFilePath)
+	for _, item := range r.items {
+		all = append(all, item.outputFileRel)
 	}
 
 	return all

--- a/qt-cli/src/server/handlers.go
+++ b/qt-cli/src/server/handlers.go
@@ -53,7 +53,7 @@ func CreateNewFileOrProject(c *gin.Context) {
 
 	c.JSON(http.StatusCreated, ResNew{
 		Message: "File created successfully",
-		Files:   output.GetOutputFilePaths(),
+		Files:   output.GetOutputFilesRel(),
 		Input:   req,
 	})
 }


### PR DESCRIPTION
Add two options to generator:
- Working directory: Specifies the base directory of generator outputs.
- Dry run: If set to true, runs the generator without creating any files.

Update Result and ResultItem structs to include more information, 
which will be useful for the REST client.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
