### PR TITLE
qt-cli: Minor clean up - use any and maps package

### DIFF
--- a/qt-cli/src/common/prompt_file.go
+++ b/qt-cli/src/common/prompt_file.go
@@ -4,7 +4,6 @@
 package common
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/fs"
 	"qtcli/util"
@@ -31,20 +30,20 @@ type PromptStep struct {
 	Question     string             `yaml:"question" json:"question"`
 	Description  string             `yaml:"description" json:"description"`
 	Value        string             `yaml:"value" json:"value"`
-	DefaultValue interface{}        `yaml:"default" json:"default"`
+	DefaultValue any                `yaml:"default" json:"default"`
 	When         string             `yaml:"when" json:"when"`
 	Items        []PromptListItem   `yaml:"items" json:"items"`
 	Rules        []PromptInputRules `yaml:"rules" json:"rules"`
 }
 
 type PromptListItem struct {
-	Text        string      `yaml:"text" json:"text"`
-	Data        interface{} `yaml:"data" json:"data"`
-	Description string      `yaml:"description" json:"description"`
-	Checked     string      `yaml:"checked" json:"checked"`
+	Text        string `yaml:"text" json:"text"`
+	Data        any    `yaml:"data" json:"data"`
+	Description string `yaml:"description" json:"description"`
+	Checked     string `yaml:"checked" json:"checked"`
 }
 
-type PromptInputRules map[string]interface{}
+type PromptInputRules map[string]any
 
 func NewPromptFileFS(fs fs.FS, filePath string) *PromptFile {
 	return &PromptFile{
@@ -86,28 +85,4 @@ func (f *PromptFile) ExtractDefaults() util.StringAnyMap {
 
 func (f *PromptFile) GetContents() *PromptFileContents {
 	return &f.contents
-}
-
-func (f *PromptFile) GetContentsAsJson() ([]byte, error) {
-	// TODO: simplify implementation
-	// Marshal the struct into a YAML string
-	// yamlData, err := yaml.Marshal(f.contents)
-	// if err != nil {
-	// 	return "", err
-	// }
-
-	// // Unmarshal YAML into an interface{} (can also be a map or struct)
-	// var yamlMap interface{}
-	// err = yaml.Unmarshal(yamlData, &yamlMap)
-	// if err != nil {
-	// 	return "", err
-	// }
-
-	// Marshal the interface{} (which now holds the YAML data) into a JSON string
-	return json.MarshalIndent(&f.contents, "", "  ")
-	// if err != nil {
-	// 	return "", err
-	// }
-
-	// return string(jsonData), nil
 }

--- a/qt-cli/src/generator/api_global.go
+++ b/qt-cli/src/generator/api_global.go
@@ -9,11 +9,11 @@ import (
 
 type GlobalApi struct{}
 
-func (GlobalApi) ParseFloat(name interface{}) float64 {
+func (GlobalApi) ParseFloat(name any) float64 {
 	return util.ToFloat64(name, 0)
 }
 
-func (GlobalApi) NewArray(values ...interface{}) []interface{} {
+func (GlobalApi) NewArray(values ...any) []any {
 	return values
 }
 
@@ -24,11 +24,11 @@ func (GlobalApi) Reverse(slice []string) []string {
 	return slice
 }
 
-func (GlobalApi) Append(s []interface{}, values interface{}) []interface{} {
+func (GlobalApi) Append(s []any, values any) []any {
 	return append(s, values)
 }
 
-func (GlobalApi) AppendIf(s []interface{}, values interface{}, condition bool) []interface{} {
+func (GlobalApi) AppendIf(s []any, values any, condition bool) []any {
 	if condition {
 		return append(s, values)
 	} else {

--- a/qt-cli/src/prompt/comps/list_item.go
+++ b/qt-cli/src/prompt/comps/list_item.go
@@ -18,7 +18,7 @@ type ListItem struct {
 	description string
 	checked     bool
 	checkable   bool
-	data        interface{}
+	data        any
 }
 
 func NewItem(text string) ListItem {
@@ -43,7 +43,7 @@ func (i ListItem) Checked(c bool) ListItem {
 	return i
 }
 
-func (i ListItem) Data(data interface{}) ListItem {
+func (i ListItem) Data(data any) ListItem {
 	i.data = data
 	return i
 }

--- a/qt-cli/src/prompt/result.go
+++ b/qt-cli/src/prompt/result.go
@@ -13,7 +13,7 @@ type Result struct {
 	Done  bool
 }
 
-func (r Result) ValueNormalized() interface{} {
+func (r Result) ValueNormalized() any {
 	switch s := r.Value.(type) {
 	case SelectionItem:
 		return s.DataOrText()
@@ -37,4 +37,4 @@ func (r Result) ValueAsSelectionItem() (SelectionItem, bool) {
 
 type ResultList []Result
 type ResultMap map[string]Result
-type ResultValue interface{}
+type ResultValue any

--- a/qt-cli/src/prompt/selection.go
+++ b/qt-cli/src/prompt/selection.go
@@ -8,7 +8,7 @@ import "strings"
 type SelectionItem struct {
 	Index int
 	Text  string
-	Data  interface{}
+	Data  any
 }
 
 type Selection []SelectionItem
@@ -22,7 +22,7 @@ func (item SelectionItem) String() string {
 	return item.Text
 }
 
-func (item SelectionItem) DataOrText() interface{} {
+func (item SelectionItem) DataOrText() any {
 	if item.Data != nil {
 		return item.Data
 	}

--- a/qt-cli/src/util/expander.go
+++ b/qt-cli/src/util/expander.go
@@ -33,8 +33,7 @@ func (e *TemplateExpander) Data(data StringAnyMap) *TemplateExpander {
 	return e
 }
 
-func (e *TemplateExpander) AddData(
-	name string, value interface{}) *TemplateExpander {
+func (e *TemplateExpander) AddData(name string, value any) *TemplateExpander {
 	e.data[name] = value
 	return e
 }

--- a/qt-cli/src/util/util.go
+++ b/qt-cli/src/util/util.go
@@ -8,6 +8,7 @@ import (
 	"hash/crc32"
 	"io"
 	"io/fs"
+	"maps"
 	"os"
 	"path"
 	"runtime"
@@ -16,19 +17,11 @@ import (
 	"syscall"
 )
 
-type StringAnyMap map[string]interface{}
+type StringAnyMap map[string]any
 
 func Merge(base StringAnyMap, other StringAnyMap) StringAnyMap {
-	all := StringAnyMap{}
-
-	for k, v := range base {
-		all[k] = v
-	}
-
-	for k, v := range other {
-		all[k] = v
-	}
-
+	all := maps.Clone(base)
+	maps.Copy(all, other)
 	return all
 }
 
@@ -78,7 +71,7 @@ func EntryExistsFS(targetFS fs.FS, path string) bool {
 	return !os.IsNotExist(err)
 }
 
-func ToBool(value interface{}, defaultValue bool) bool {
+func ToBool(value any, defaultValue bool) bool {
 	switch c := value.(type) {
 	case bool:
 		return c
@@ -100,7 +93,7 @@ func ToBool(value interface{}, defaultValue bool) bool {
 	}
 }
 
-func ToFloat64(value interface{}, defaultValue float64) float64 {
+func ToFloat64(value any, defaultValue float64) float64 {
 	switch c := value.(type) {
 	case string:
 		v, err := strconv.ParseFloat(c, 64)


### PR DESCRIPTION
- Updated interface{} to any.
- Simplified map merging by using maps standard package.
- Removed a leftover function missed in the previous commit.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
