### PR TITLE
qt-cli: Add more validation for new file generation

### DIFF
--- a/qt-cli/src/common/string_validator.go
+++ b/qt-cli/src/common/string_validator.go
@@ -19,12 +19,13 @@ const (
 	TagMaxLength = "max" // "max=255"
 
 	// custom tags
-	TagMatch        = "match" // "match=^[a-z]{5,10}$"
-	TagDirName      = "dirname"
-	TagFileName     = "filename"
-	TagAbsPath      = "abspath"
-	TagProjectName  = "projectname"
-	TagWindowsDrive = "windowsdrive"
+	TagMatch           = "match" // "match=^[a-z]{5,10}$"
+	TagDirName         = "dirname"
+	TagFileName        = "filename"
+	TagAbsPath         = "abspath"
+	TagSafeFileName    = "safefilename"
+	TagSafeProjectName = "safeprojectname"
+	TagWindowsDrive    = "windowsdrive"
 )
 
 type StringValidator struct {
@@ -41,7 +42,8 @@ func NewStringValidator() *StringValidator {
 	v.RegisterValidation(TagDirName, validateDirName)
 	v.RegisterValidation(TagFileName, validateFileName)
 	v.RegisterValidation(TagAbsPath, validateAbsPath)
-	v.RegisterValidation(TagProjectName, validateProjectName)
+	v.RegisterValidation(TagSafeFileName, validateSafeFileName)
+	v.RegisterValidation(TagSafeProjectName, validateSafeProjectName)
 	v.RegisterValidation(TagWindowsDrive, validateWindowsDrive)
 
 	return &StringValidator{
@@ -122,8 +124,20 @@ func validateAbsPath(fl validator.FieldLevel) bool {
 	return filepath.IsAbs(s)
 }
 
-func validateProjectName(fl validator.FieldLevel) bool {
+func validateSafeProjectName(fl validator.FieldLevel) bool {
 	if !runRegex(fl, "^[a-zA-Z_][a-zA-Z0-9_-]*$") {
+		return false
+	}
+
+	if runtime.GOOS == "windows" {
+		return !util.IsWindowsReservedName(fl.Field().String())
+	}
+
+	return true
+}
+
+func validateSafeFileName(fl validator.FieldLevel) bool {
+	if !runRegex(fl, "^[a-zA-Z_][a-zA-Z0-9_-]*(\\.[a-zA-Z0-9]+)?$") {
 		return false
 	}
 
@@ -145,15 +159,16 @@ func runRegex(fl validator.FieldLevel, pattern string) bool {
 }
 
 var TagToValidatorMessage = map[string]string{
-	TagRequired:     ValidatorTagRequired,
-	TagMinLength:    ValidatorTagMinLength,
-	TagMaxLength:    ValidatorTagMaxLength,
-	TagMatch:        ValidatorTagPattern,
-	TagDirName:      ValidatorTagDirName,
-	TagFileName:     ValidatorTagFileName,
-	TagAbsPath:      ValidatorTagAbsPath,
-	TagProjectName:  ValidatorTagProjectName,
-	TagWindowsDrive: ValidatorTagWindowsDrive,
+	TagRequired:        ValidatorTagRequired,
+	TagMinLength:       ValidatorTagMinLength,
+	TagMaxLength:       ValidatorTagMaxLength,
+	TagMatch:           ValidatorTagPattern,
+	TagDirName:         ValidatorTagDirName,
+	TagFileName:        ValidatorTagFileName,
+	TagAbsPath:         ValidatorTagAbsPath,
+	TagSafeFileName:    ValidatorTagSafeFileName,
+	TagSafeProjectName: ValidatorTagSafeProjectName,
+	TagWindowsDrive:    ValidatorTagWindowsDrive,
 }
 
 func defaultIssueBuilder(

--- a/qt-cli/src/common/string_validator_test.go
+++ b/qt-cli/src/common/string_validator_test.go
@@ -29,17 +29,12 @@ func TestValidationHelper_SingleTag(t *testing.T) {
 
 		// dir name
 		{"", TagDirName, false},
-		{" ", TagDirName, false},
-		{"abc*", TagDirName, false},
 		{"abc/de", TagDirName, false},
-
 		{"abc", TagDirName, true},
 		{"abc de", TagDirName, true},
 
 		// file name
 		{"", TagFileName, false},
-		{" ", TagFileName, false},
-		{"abc*", TagFileName, false},
 		{"abc/de", TagFileName, false},
 
 		{"abc", TagFileName, true},
@@ -52,24 +47,34 @@ func TestValidationHelper_SingleTag(t *testing.T) {
 		{"abc/def", TagAbsPath, false},
 
 		// project name
-		{"", TagProjectName, false},
-		{" ", TagProjectName, false},
-		{"abc*", TagProjectName, false},
-		{"abc#", TagProjectName, false},
-		{"abc de", TagProjectName, false},
+		{"", TagSafeProjectName, false},
+		{" ", TagSafeProjectName, false},
+		{"abc*", TagSafeProjectName, false},
+		{"abc#", TagSafeProjectName, false},
+		{"abc de", TagSafeProjectName, false},
 
-		{"abc", TagProjectName, true},
+		{"abc", TagSafeProjectName, true},
 	}
 
 	// additionl os-specific test data
 	if runtime.GOOS == "windows" {
 		dataSet = append(dataSet, []DataRecord{
+			{" ", TagDirName, false},
+			{"abc*", TagDirName, false},
+			{" ", TagFileName, false},
+			{"abc*", TagFileName, false},
+
 			{"C:/abc", TagAbsPath, true},
 			{"C:/abc/def", TagAbsPath, true},
 			{"C:\\abc\\def", TagAbsPath, true},
 		}...)
 	} else {
 		dataSet = append(dataSet, []DataRecord{
+			{" ", TagDirName, true},
+			{"abc*", TagDirName, true},
+			{" ", TagFileName, true},
+			{"abc*", TagFileName, true},
+
 			{"/abc", TagAbsPath, true},
 			{"/abc/def", TagAbsPath, true},
 		}...)
@@ -79,10 +84,10 @@ func TestValidationHelper_SingleTag(t *testing.T) {
 }
 
 func TestValidationHelper_MultipleTag(t *testing.T) {
-	tag1 := NewCombinedTags([]string{TagRequired, TagDirName, TagProjectName})
+	tag1 := NewCombinedTags([]string{TagRequired, TagDirName, TagSafeProjectName})
 	tag2 := NewCombinedTags([]string{
 		TagRequired, TagDirName,
-		NewRegexTag("^[A-Z]"), TagProjectName})
+		NewRegexTag("^[A-Z]"), TagSafeProjectName})
 
 	dataSet := []DataRecord{
 		{"", tag1, false},

--- a/qt-cli/src/common/texts.go
+++ b/qt-cli/src/common/texts.go
@@ -4,15 +4,16 @@
 package common
 
 const (
-	ValidatorTagRequired     = "This field is required"
-	ValidatorTagMinLength    = "The input is too short"
-	ValidatorTagMaxLength    = "The input is too long"
-	ValidatorTagPattern      = "The input doesn't match the required pattern"
-	ValidatorTagDirName      = "Enter a valid directory name"
-	ValidatorTagFileName     = "Enter a valid file name"
-	ValidatorTagAbsPath      = "The path must be absolute"
-	ValidatorTagProjectName  = "Enter a valid project name"
-	ValidatorTagWindowsDrive = "The drive name is invalid"
+	ValidatorTagRequired        = "This field is required"
+	ValidatorTagMinLength       = "The input is too short"
+	ValidatorTagMaxLength       = "The input is too long"
+	ValidatorTagPattern         = "The input doesn't match the required pattern"
+	ValidatorTagDirName         = "Enter a valid directory name"
+	ValidatorTagFileName        = "Enter a valid file name"
+	ValidatorTagAbsPath         = "The path must be absolute"
+	ValidatorTagSafeFileName    = "Enter a valid file name"
+	ValidatorTagSafeProjectName = "Enter a valid project name"
+	ValidatorTagWindowsDrive    = "The drive name is invalid"
 
 	ValidatorInvalid            = "The input is invalid"
 	ValidatorSameFileExists     = "A file with the same name already exists"

--- a/qt-cli/src/generator/validator.go
+++ b/qt-cli/src/generator/validator.go
@@ -14,13 +14,14 @@ import (
 
 var NameTagsOnProject = strings.Join([]string{
 	common.TagRequired,
-	common.TagProjectName,
+	common.TagSafeProjectName,
 	common.TagDirName,
 	common.NewTagWithParam(common.TagMaxLength, "255"),
 }, ",")
 
 var NameTagsOnFile = strings.Join([]string{
 	common.TagRequired,
+	common.TagSafeFileName,
 	common.TagFileName,
 	common.NewTagWithParam(common.TagMaxLength, "255"),
 }, ",")


### PR DESCRIPTION
- Add regex-based validation to ensure file names are valid.
- Rename validator tags for improved clarity.
- Update unit tests accordingly.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
