### PR TITLE
qt-cli: Respect file extension if already present in the filename

### DIFF
--- a/qt-cli/src/assets/templates/projects/cpp/qwidget/templates.yml
+++ b/qt-cli/src/assets/templates/projects/cpp/qwidget/templates.yml
@@ -13,13 +13,13 @@ files:
   - in: main.cpp
 
   - in: mainwindow.cpp
-    out: '{{ .fileNameBase }}.cpp'
+    out: '{{ .fileNameBase }}'
 
   - in: mainwindow.h
-    out: '{{ .fileNameBase }}.h'
+    out: '{{ .fileNameBase }}'
 
   - in: mainwindow.ui
-    out: '{{ .fileNameBase }}.ui'
+    out: '{{ .fileNameBase }}'
     when: '{{ .useForm }}'
 
   - in: '@/common/git.ignore'

--- a/qt-cli/src/assets/templates/types/qml/templates.yml
+++ b/qt-cli/src/assets/templates/types/qml/templates.yml
@@ -9,4 +9,4 @@ meta:
 
 files:
   - in: file.qml
-    out: '{{ .name }}.qml'
+    out: '{{ .name }}'

--- a/qt-cli/src/assets/templates/types/qrc/templates.yml
+++ b/qt-cli/src/assets/templates/types/qrc/templates.yml
@@ -7,4 +7,4 @@ meta:
 
 files:
   - in: file.qrc
-    out: '{{ .name }}.qrc'
+    out: '{{ .name }}'

--- a/qt-cli/src/assets/templates/types/ui/templates.yml
+++ b/qt-cli/src/assets/templates/types/ui/templates.yml
@@ -11,4 +11,4 @@ meta:
 
 files:
   - in: file.ui
-    out: '{{ .name }}.ui'
+    out: '{{ .name }}'

--- a/qt-cli/src/generator/generator.go
+++ b/qt-cli/src/generator/generator.go
@@ -276,11 +276,17 @@ func (g *Generator) createOutputFileRel(
 		return path.Base(file.In), nil
 	}
 
-	return util.NewTemplateExpander().
+	out, err := util.NewTemplateExpander().
 		Name(file.In).
 		Data(g.context.data).
 		Funcs(g.context.funcs).
 		RunString(file.Out)
+
+	if err != nil {
+		return out, err
+	}
+
+	return util.NormalizeFileExt(out, path.Ext(file.In)), nil
 }
 
 func (g *Generator) evalWhenCondition(file common.TemplateItem) (bool, error) {

--- a/qt-cli/src/util/util.go
+++ b/qt-cli/src/util/util.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -190,4 +191,26 @@ func SendSigTermOrKill(pid int) error {
 
 func CreatePresetUniqueId(name string) string {
 	return fmt.Sprintf("%010d", crc32.ChecksumIEEE([]byte(name)))
+}
+
+var multiDotRegex = regexp.MustCompile(`\.{2,}`)
+
+func NormalizeFileExt(fileName, fallbackExt string) string {
+	fileName = multiDotRegex.ReplaceAllString(fileName, ".")
+	ext := filepath.Ext(fileName)
+	base := strings.TrimSuffix(fileName, ext)
+	if ext == "." {
+		ext = ""
+	}
+
+	effectiveName := base + ext
+	if fallbackExt == "" || fallbackExt == "." || ext != "" {
+		return effectiveName
+	}
+
+	if !strings.HasPrefix(fallbackExt, ".") {
+		fallbackExt = "." + fallbackExt
+	}
+
+	return effectiveName + fallbackExt
 }

--- a/qt-cli/src/util/util_test.go
+++ b/qt-cli/src/util/util_test.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2024 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+package util
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeFileExt(t *testing.T) {
+	tests := []struct {
+		fileName    string
+		fallbackExt string
+		expected    string
+	}{
+		// normal extension appending when no extension exists
+		{"my", "qml", "my.qml"},
+		{"my", ".qml", "my.qml"},
+		{"my.", "qml", "my.qml"},
+		{"my.", ".qml", "my.qml"},
+
+		// already has correct extension — should stay unchanged
+		{"my.qml", "", "my.qml"},
+		{"my.qml", "qml", "my.qml"},
+		{"my.qml", ".qml", "my.qml"},
+
+		// has different extension — should stay unchanged
+		{"my.txt", "", "my.txt"},
+		{"my.txt", "qml", "my.txt"},
+		{"my.txt", ".qml", "my.txt"},
+
+		// has multiple extensions — should stay unchanged
+		{"my.tar.gz", "", "my.tar.gz"},
+		{"my.tar.gz", "qml", "my.tar.gz"},
+		{"my.tar.gz", ".qml", "my.tar.gz"},
+
+		// edge cases
+		{"", "", ""},
+		{"", "someignore", ".someignore"},
+		{"", ".someignore", ".someignore"},
+
+		{"wierdbutvalidfile..", "", "wierdbutvalidfile"},
+		{"wierdbutvalidfile..", "qml", "wierdbutvalidfile.qml"},
+		{"wierdbutvalidfile..", ".qml", "wierdbutvalidfile.qml"},
+	}
+
+	for _, tc := range tests {
+		testname := fmt.Sprintf("|%s|%s|", tc.fileName, tc.fallbackExt)
+		t.Run(testname, func(t *testing.T) {
+			actual := NormalizeFileExt(tc.fileName, tc.fallbackExt)
+			require.Equal(t,
+				tc.expected, actual,
+				fmt.Sprintf("expected '%s', got '%s'", tc.expected, actual),
+			)
+		})
+	}
+}


### PR DESCRIPTION
- Generator now checks if the output filename already includes an extension. If present, it is used as-is. Otherwise, the extension from the input filename is applied.
- Removed hardcoded extensions from template files.
- Added unit tests for the relavant utility function.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
