### PR TITLE
qt-core: Enable 'Create' button by default and refine font styles

### DIFF
--- a/qt-core/webview-ui/src/app/PresetList.svelte
+++ b/qt-core/webview-ui/src/app/PresetList.svelte
@@ -4,7 +4,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
-  import { Listgroup, ListgroupItem, P } from 'flowbite-svelte';
+  import { Listgroup, ListgroupItem } from 'flowbite-svelte';
 
   import { data } from './states.svelte';
   import * as viewlogic from './viewlogic.svelte';
@@ -46,7 +46,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 <div class="flex flex-col">
   <Listgroup
     active
-    class="flex-grow overflow-y-auto qt-list"
+    class="flex-grow overflow-y-auto qt-list items-center"
     onkeydown={onKeyPressed}
     tabindex={0}
   >
@@ -64,7 +64,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
         </div>
 
         {#if !preset.name.startsWith('@')}
-          <P size="xs" class="qt-label">{preset.meta.title}</P>
+          <div class="ml-auto mr-0.5 qt-badge">{preset.meta.title}</div>
         {:else}
           <div></div>
         {/if}

--- a/qt-core/webview-ui/src/app/PresetOptionsTable.svelte
+++ b/qt-core/webview-ui/src/app/PresetOptionsTable.svelte
@@ -5,7 +5,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 <script lang="ts">
   import {
-    Label,
+    P,
     Table,
     TableBody,
     TableBodyRow,
@@ -32,10 +32,10 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
       {#each steps as step (step.id)}
         <TableBodyRow class="last:border-0">
           <TableBodyCell class="p-0.5">
-            <Label class="qt-label">{step.question}</Label>
+            <P class="qt-label">{step.question}</P>
           </TableBodyCell>
           <TableBodyCell class="p-0.5">
-            <Label class="qt-label">{toDisplayValue(step.default)}</Label>
+            <P class="qt-label">{toDisplayValue(step.default)}</P>
           </TableBodyCell>
         </TableBodyRow>
       {/each}

--- a/qt-core/webview-ui/src/app/Wizard.svelte
+++ b/qt-core/webview-ui/src/app/Wizard.svelte
@@ -18,9 +18,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   open
   size="lg"
   color="none"
-  class="qt-modal w-[80vw] h-[80vh] min-w-[500px] min-h-[500px]"
-  classBody="p-2.5"
-  classHeader="py-2.5 px-5"
+  class="qt-modal w-[80vw] h-[90vh] min-w-[500px] min-h-[500px]"
   backdropClass="hidden"
   on:close={onModalClosed}
 >
@@ -30,7 +28,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
     </div>
   </svelte:fragment>
 
-  <div class="w-full h-full flex flex-col gap-3.5">
+  <div class="w-full h-full flex flex-col gap-4">
     <WizardSectionPresets />
     <WizardSectionInput />
     <LoadingMask

--- a/qt-core/webview-ui/src/app/WizardSectionInput.svelte
+++ b/qt-core/webview-ui/src/app/WizardSectionInput.svelte
@@ -4,7 +4,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
-  import { Checkbox, Label } from 'flowbite-svelte';
+  import { Checkbox, P } from 'flowbite-svelte';
   import { CheckOutline } from 'flowbite-svelte-icons';
 
   import IconButton from '@/comps/IconButton.svelte';
@@ -17,25 +17,10 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
     createItemFromSelectedPreset,
     validateInput
   } from './viewlogic.svelte';
-
-  // let nameInputUi = $state<InputWithIssue | null>();
-
-  // export function onEntered() {
-  //   if (!import.meta.env.DEV) {
-  //     input.workingDir =
-  //       data.selected.type === 'file'
-  //         ? data.configs.newFileBaseDir
-  //         : data.configs.newProjectBaseDir;
-  //   } else {
-  //     input.workingDir = '/dev';
-  //   }
-
-  //   validateInput();
-  // }
 </script>
 
 <div
-  class={`grid gap-1.5
+  class={`grid gap-2
     grid-cols-[max-content_1fr] 
     grid-rows-[1fr_repeat(3,min-content)]`}
 >
@@ -43,7 +28,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
     <SectionLabel text={texts.wizard.nameAndLocation} />
   </div>
 
-  <Label class="qt-label pl-4">{texts.wizard.name}</Label>
+  <P class="qt-label pl-4">{texts.wizard.name}</P>
   <InputWithIssue
     bind:value={input.name}
     onInput={validateInput}
@@ -51,7 +36,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
     message={input.issues.name.message}
   />
 
-  <Label class="qt-label pl-4">{texts.wizard.workingDir}</Label>
+  <P class="qt-label pl-4">{texts.wizard.workingDir}</P>
   <WorkingDirInput />
 
   <div></div>

--- a/qt-core/webview-ui/src/app/WizardSectionPresets.svelte
+++ b/qt-core/webview-ui/src/app/WizardSectionPresets.svelte
@@ -4,7 +4,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
-  import { Label } from 'flowbite-svelte';
+  import { P } from 'flowbite-svelte';
 
   import SectionLabel from '@/comps/SectionLabel.svelte';
   import * as texts from './texts';
@@ -16,7 +16,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 <div
   class={`
-      grow grid gap-x-2.5 gap-y-1.5
+      grow grid gap-2
       grid-rows-[min-content_1fr] 
       grid-cols-[min-content_minmax(300px,1fr)_1fr]
       `}
@@ -27,12 +27,12 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   <div class="flex flex-col">
     <SectionLabel text={texts.wizard.description} />
     <div>
-      <Label class="qt-label whitespace-pre-wrap leading-relaxed"
+      <P class="qt-label whitespace-pre-wrap leading-relaxed"
         >{(data.selected.preset?.meta?.description ?? '').replaceAll(
           '\n',
           '\n\n'
         )}
-      </Label>
+      </P>
     </div>
     <div class="flex-grow"></div>
 

--- a/qt-core/webview-ui/src/app/main.ts
+++ b/qt-core/webview-ui/src/app/main.ts
@@ -8,6 +8,6 @@ const app = mount(App, {
   target: document.getElementById('app')!
 });
 
-document.body.classList.add(import.meta.env.DEV ? 'dev' : 'prod');
+document.documentElement.classList.add(import.meta.env.DEV ? 'dev' : 'prod');
 
 export default app;

--- a/qt-core/webview-ui/src/app/states.svelte.ts
+++ b/qt-core/webview-ui/src/app/states.svelte.ts
@@ -36,5 +36,5 @@ export const ui = $state({
     delayedTimerId: null as NodeJS.Timeout | null
   },
 
-  canCreate: false
+  canCreate: true
 });

--- a/qt-core/webview-ui/src/comps/LoadingMask.svelte
+++ b/qt-core/webview-ui/src/comps/LoadingMask.svelte
@@ -4,7 +4,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
-  import { Label, Button, Spinner } from 'flowbite-svelte';
+  import { P, Button, Spinner } from 'flowbite-svelte';
 
   let {
     busy = false,
@@ -25,11 +25,11 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   {#if busy}
     <div class="flex w-full justify-center items-center">
       <Spinner class="me-3" size="8" color="green" />
-      <Label>{busyText}</Label>
+      <P>{busyText}</P>
     </div>
   {:else if error}
     <div class="flex flex-col gap-4">
-      <Label>{error}</Label>
+      <P>{error}</P>
       <Button
         class="qt-button mx-auto"
         on:click={() => {

--- a/qt-core/webview-ui/src/comps/SectionLabel.svelte
+++ b/qt-core/webview-ui/src/comps/SectionLabel.svelte
@@ -4,7 +4,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
-  import { Label } from 'flowbite-svelte';
+  import { P } from 'flowbite-svelte';
   import { AngleRightOutline } from 'flowbite-svelte-icons';
 
   let { text, icon = true, class: className = '' } = $props();
@@ -14,5 +14,5 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   {#if icon}
     <AngleRightOutline class="qt-label highlight" size="sm" />
   {/if}
-  <Label class="qt-label highlight text-md">{text}</Label>
+  <P class="qt-label highlight">{text}</P>
 </div>

--- a/qt-core/webview-ui/src/mock/data/_presets_project.json
+++ b/qt-core/webview-ui/src/mock/data/_presets_project.json
@@ -1,5 +1,14 @@
 [
   {
+    "id": "0000000000",
+    "name": "ttt",
+    "meta": {
+      "type": "project",
+      "title": "Qt console application",
+      "description": "Creates a project containing a single main.cpp file with a stub implementation and no graphical UI."
+    }
+  },
+  {
     "id": "3972419898",
     "name": "@projects/cpp/console",
     "meta": {

--- a/qt-core/webview-ui/src/styles/dev.css
+++ b/qt-core/webview-ui/src/styles/dev.css
@@ -5,7 +5,12 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 @import 'tailwindcss';
 
-body.dev {
+html.dev {
+  --qt-border-radius: 2px;
+
+  --qt-font-size: 13px;
+  --qt-font-family: sans-serif;
+
   --qt-widget-fill: var(--color-gray-500);
   --qt-widget-border: var(--color-gray-700);
   --qt-widget-borderFocus: var(--color-green-400);

--- a/qt-core/webview-ui/src/styles/prod.css
+++ b/qt-core/webview-ui/src/styles/prod.css
@@ -5,7 +5,12 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 @import 'tailwindcss';
 
-body.prod {
+html.prod {
+  --qt-border-radius: 2px;
+
+  --qt-font-size: var(--vscode-font-size);
+  --qt-font-family: var(--vscode-font-family);
+
   --qt-widget-fill: var(--vscode-sideBar-background);
   --qt-widget-border: var(--vscode-widget-border, transparent);
   --qt-widget-borderFocus: var(--vscode-focusBorder);

--- a/qt-core/webview-ui/src/styles/styles.css
+++ b/qt-core/webview-ui/src/styles/styles.css
@@ -4,12 +4,6 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 */
 
 /* common */
-body {
-  --qt-border-radius: 2px;
-  --qt-font-family: var(--vscode-font-family);
-  --qt-font-weight: var(--vscode-font-weight, normal);
-}
-
 @utility qt-focusRing {
   @apply focus:ring-1 focus:ring-[var(--qt-widget-borderFocus)];
 }
@@ -19,17 +13,14 @@ body {
 }
 
 /* basic tags */
-body {
-  font-family: var(--qt-font-family);
-  font-weight: var(--qt-font-weight);
+html {
+  font-size: var(--qt-font-size);
 }
 
 /* label */
 .qt-label {
   color: var(--qt-text-normal);
   margin: 2px;
-  font-weight: var(--qt-font-weight);
-  font-size: 0.9rem;
 }
 
 .qt-label.info {
@@ -41,7 +32,8 @@ body {
 
 .qt-label.highlight {
   color: var(--qt-text-highlight);
-  font-size: 1.02rem;
+  font-size: 1.1rem;
+  @apply font-semibold
 }
 
 /* modal */
@@ -65,11 +57,11 @@ body {
   background: var(--qt-button-fill);
   border: 1px solid var(--qt-widget-border);
   border-radius: var(--qt-border-radius);
-  font-weight: var(--qt-font-weight);
   line-height: normal;
   cursor: pointer;
   @apply ring-offset-0;
   @apply qt-focusRing;
+  @apply text-base font-normal;
 }
 
 .qt-button:hover {
@@ -96,7 +88,7 @@ body {
 .qt-checkbox {
   color: var(--qt-text-normal);
   background: transparent;
-  font-weight: var(--qt-font-weight);
+  @apply text-base font-normal;
 }
 
 .qt-checkbox > input[type='checkbox'] {
@@ -140,6 +132,7 @@ body {
   border-radius: var(--qt-border-radius);
   padding: 5px 0px 5px 10px;
   box-shadow: none;
+  @apply text-base;
 }
 
 .qt-input:focus {
@@ -185,9 +178,9 @@ body {
   border-width: 1px 0px 1px 0px;
   border-color: transparent;
   padding: 5px 10px 5px 10px;
-  font-weight: var(--qt-font-weight);
   cursor: pointer;
   box-shadow: none;
+  @apply text-base font-normal;
 }
 
 .qt-list-item:hover {
@@ -214,6 +207,11 @@ body {
   border-top-width: 0px;
 }
 
+.qt-list-item .qt-badge {
+  background-color: transparent;
+  font-size: 0.8rem;
+}
+
 /* vertical tab */
 .qt-vtab-item {
   color: var(--qt-text-normal);
@@ -221,11 +219,11 @@ body {
   border-radius: var(--qt-border-radius);
   border-bottom: 1px solid var(--qt-widget-separator);
   border: 1px solid transparent;
-  font-weight: var(--qt-font-weight);
   line-height: normal;
   cursor: pointer;
   @apply ring-offset-0;
   @apply qt-focusRing;
+  @apply text-base font-normal;
 }
 
 .qt-vtab-item:last-of-type,
@@ -252,6 +250,7 @@ body {
   border: 1px solid var(--qt-alert-border);
   border-radius: var(--qt-border-radius);
   padding: 10px;
+  @apply text-base;
 }
 
 .qt-alert:hover {
@@ -260,6 +259,7 @@ body {
 
 /* others */
 .qt-simple-table {
-  @apply bg-transparent;
   color: var(--qt-widget-separator);
+  @apply bg-transparent;
+  @apply text-base;
 }


### PR DESCRIPTION
- Set initial enabled state of 'Create' button to true.
- Adjust font-related styles for better consistency with VSCode UI.
- Add user preset data to mock dataset.
- Update styling for custom presets in the list.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
