### PR TITLE
qt-cli: Fix socket file creation error

### DIFF
--- a/qt-cli/src/server/server_others.go
+++ b/qt-cli/src/server/server_others.go
@@ -5,12 +5,25 @@
 
 package server
 
-import "net"
+import (
+	"net"
+	"os"
+)
+
+const TempDir = "/tmp/qtcli"
 
 func getPidFilePath() string {
-	return "/tmp/qtcli/qtcli-server.pid"
+	if err := os.MkdirAll(TempDir, 0755); err != nil {
+		return ""
+	}
+
+	return TempDir + "/qtcli-server.pid"
 }
 
 func getLocalIpcListener() (net.Listener, error) {
-	return net.Listen("unix", "/tmp/qtcli/qtcli-server.sock")
+	if err := os.MkdirAll(TempDir, 0755); err != nil {
+		return nil, err
+	}
+
+	return net.Listen("unix", TempDir+"/qtcli-server.sock")
 }

--- a/qt-cli/src/server/server_windows.go
+++ b/qt-cli/src/server/server_windows.go
@@ -13,7 +13,12 @@ import (
 )
 
 func getPidFilePath() string {
-	return os.Getenv("LOCALAPPDATA") + `\qtcli\qtcli-server.pid`
+	dir := os.Getenv("LOCALAPPDATA") + `\qtcli`
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return ""
+	}
+
+	return dir + `\qtcli-server.pid`
 }
 
 func getLocalIpcListener() (net.Listener, error) {


### PR DESCRIPTION
Ensure that the parent directory of the Unix domain socket exists before attempting to create the listener. This prevents runtime failure when launching the server on macOS on Linux.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
