### PR TITLE
qt-ui: Rename `Qt: Open Widget Designer` to `Qt: Open Widgets Designer`

### DIFF
--- a/qt-ui/package.nls.json
+++ b/qt-ui/package.nls.json
@@ -1,3 +1,3 @@
 {
-  "qt-ui.command.openWidgetDesigner.title": "Open Widget Designer"
+  "qt-ui.command.openWidgetDesigner.title": "Open Qt Widgets Designer"
 }


### PR DESCRIPTION
Fixes: [VSCODEEXT-162](https://bugreports.qt.io/browse/VSCODEEXT-162)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
