### PR TITLE
qt-cli: Add endpoints for managing custom presets

### DIFF
--- a/qt-cli/src/common/prompt_file.go
+++ b/qt-cli/src/common/prompt_file.go
@@ -86,3 +86,11 @@ func (f *PromptFile) ExtractDefaults() util.StringAnyMap {
 func (f *PromptFile) GetContents() *PromptFileContents {
 	return &f.contents
 }
+
+func (fc *PromptFileContents) UpdateDefaultValues(options util.StringAnyMap) {
+	for i, step := range fc.Steps {
+		if value, ok := options[step.Id]; ok {
+			fc.Steps[i].DefaultValue = value
+		}
+	}
+}

--- a/qt-cli/src/common/texts.go
+++ b/qt-cli/src/common/texts.go
@@ -24,8 +24,13 @@ const (
 	InputOkay      = "Input validation passed successfully"
 	InputHasIssues = "Cannot validate input"
 
-	ServerNoPreset       = "Cannot find a matching preset"
-	ServerNoPresets      = "Cannot find presets"
-	ServerNoTemplateFile = "Cannot open the template file"
-	ServerClosing        = "The server is shutting down"
+	ServerNoPreset            = "Cannot find a matching preset"
+	ServerNoPresets           = "Cannot find presets"
+	ServerNoTemplateFile      = "Cannot open the template file"
+	ServerClosing             = "The server is shutting down"
+	ServerPresetDeleted       = "The preset has been deleted"
+	ServerPresetAlreadyExists = "The preset name is already taken"
+
+	ServerStatusCreated = "Created"
+	ServerStatusUpdated = "Updated"
 )

--- a/qt-cli/src/common/user_preset_file.go
+++ b/qt-cli/src/common/user_preset_file.go
@@ -149,6 +149,14 @@ func (f *UserPresetFile) Save() error {
 	return nil
 }
 
+func (f *UserPresetFile) Replace(data PresetData) error {
+	if err := f.Remove(data.Name); err != nil {
+		return err
+	}
+
+	return f.Add(data)
+}
+
 func (f *UserPresetFile) Remove(name string) error {
 	var found = -1
 

--- a/qt-cli/src/server/api.http
+++ b/qt-cli/src/server/api.http
@@ -7,37 +7,89 @@
 // How to use:
 // - Install the "REST Client" extension in VSCode.
 // - Start qtcli in server mode, for example:
-//     $ qtcli server start
+//     $ qtcli server start --tcp --port 8080
 //     $ cd <srcdir, e.g. qt-cli/src/> && go run . server start (for local dev)
 // - Click "Send Request" above any request to execute it.
 
 @baseUrl = http://localhost:8080/v1
-
-@presetCppClass = 2239089261
-@presetConsoleApp = 3972419898
-@presetInvalid = 1111111111
-
-@workingDir = C:/ws_temp
+@presetIdCppClass = 2239089261
+@presetIdQtQuickApp = 3605019760
 
 ###
-### Get presets
+### Retrieve preset information
 ###
 
-### Get a list of all available presets
+###
 GET {{baseUrl}}/presets HTTP/1.1
 
-### Get details of a specific preset - cpp class
-GET {{baseUrl}}/presets/{{presetCppClass}} HTTP/1.1
+###
+GET {{baseUrl}}/presets?type=project HTTP/1.1
 
-### Get details of a specific preset - console app
-GET {{baseUrl}}/presets/{{presetConsoleApp}} HTTP/1.1
+###
+GET {{baseUrl}}/presets?type=file HTTP/1.1
 
-### Get details of a specific preset - non existing
-GET {{baseUrl}}/presets/{{presetInvalid}} HTTP/1.1
+###
+GET {{baseUrl}}/presets?name=@projects/cpp/console HTTP/1.1
+
+###
+GET {{baseUrl}}/presets?name=non-existing-preset-name HTTP/1.1
+
+###
+GET {{baseUrl}}/presets/{{presetIdCppClass}} HTTP/1.1
+
+###
+GET {{baseUrl}}/presets/{{presetIdQtQuickApp}} HTTP/1.1
+
+###
+GET {{baseUrl}}/presets/0000000000 HTTP/1.1
+
+
+###
+### Managing custom presets
+###
+
+@newPresetId = 3399596650
+@newPresetName = mypreset
+
+### Create
+POST {{baseUrl}}/presets HTTP/1.1
+Content-Type: application/json
+
+{
+    "name": "{{newPresetName}}",
+    "presetId": "{{presetIdQtQuickApp}}",
+    "options": {
+        "qqcStyle": "Material",
+        "qqcTheme": "Dark"
+    }
+}
+
+### Read (by id)
+GET {{baseUrl}}/presets/{{newPresetId}} HTTP/1.1
+
+### Read (by name)
+GET {{baseUrl}}/presets?name={{newPresetName}} HTTP/1.1
+
+### Update
+PATCH {{baseUrl}}/presets/{{newPresetId}} HTTP/1.1
+Content-Type: application/json
+
+{
+    "options": {
+        "minimumQtVersion": "6.4",
+        "qqcStyle": "Universal"
+    }
+}
+
+### Delete
+DELETE {{baseUrl}}/presets/{{newPresetId}} HTTP/1.1
+
 
 ###
 ### Create a new item
 ###
+
+@workingDir = C:/ws_temp
 
 ### Create c++ class
 POST {{baseUrl}}/items HTTP/1.1
@@ -46,30 +98,55 @@ Content-Type: application/json
 {
     "name": "myclass",
     "workingDir": "{{workingDir}}",
-    "presetId": "{{presetCppClass}}"
+    "presetId": "{{presetIdCppClass}}"
 }
 
-### Create console application
+### Create qtquick application
 POST {{baseUrl}}/items HTTP/1.1
 Content-Type: application/json
 
 {
     "name": "myapp",
     "workingDir": "{{workingDir}}",
-    "presetId": "{{presetConsoleApp}}"
+    "presetId": "{{presetIdQtQuickApp}}"
 }
 
-### Create console application (dry run)
+### Create qtquick application (dry run)
 POST {{baseUrl}}/items?dry_run=true HTTP/1.1
 Content-Type: application/json
 
 {
     "name": "myapp2",
     "workingDir": "{{workingDir}}",
-    "presetId": "{{presetConsoleApp}}"
+    "presetId": "{{presetIdQtQuickApp}}"
 }
 
+### Validate
+POST {{baseUrl}}/items/validate HTTP/1.1
+Content-Type: application/json
+
+{
+    "name": "myapp",
+    "workingDir": "{{workingDir}}",
+    "presetId": "{{presetIdQtQuickApp}}"
+}
+
+### Validate - error case
+POST {{baseUrl}}/items/validate HTTP/1.1
+Content-Type: application/json
+
+{
+    "name": "myapp*",
+    "workingDir": "{{workingDir}}",
+    "presetId": "{{presetIdQtQuickApp}}"
+}
+
+
 ###
-### Delete server
+### Others
+###
+
+GET {{baseUrl}}/ready HTTP/1.1
+
 ###
 DELETE {{baseUrl}}/server HTTP/1.1

--- a/qt-cli/src/server/handlers/common.go
+++ b/qt-cli/src/server/handlers/common.go
@@ -11,12 +11,17 @@ import (
 )
 
 type ErrorResponse struct {
-	Error   string         `json:"error"`
+	Error   string         `json:"error" binding:"required"`
 	Details *common.Issues `json:"details,omitempty"`
 }
 
 type StatusResponse struct {
-	Status string `json:"status"`
+	Status string `json:"status" binding:"required"`
+}
+
+type StatusAndIdResponse struct {
+	Status string `json:"status" binding:"required"`
+	Id     any    `json:"id" binding:"required"`
 }
 
 // convenients
@@ -26,6 +31,10 @@ func ReplyGet[T any](c *gin.Context, data T) {
 
 func ReplyPost[T any](c *gin.Context, data T) {
 	c.JSON(http.StatusCreated, data)
+}
+
+func ReplyDelete[T any](c *gin.Context, data T) {
+	c.JSON(http.StatusOK, data)
 }
 
 func ReplyStatus(c *gin.Context, msg string) {

--- a/qt-cli/src/server/handlers/delete.go
+++ b/qt-cli/src/server/handlers/delete.go
@@ -6,11 +6,18 @@ package handlers
 import (
 	"os"
 	"qtcli/common"
+	"qtcli/runner"
 	"qtcli/util"
 	"time"
 
 	"github.com/gin-gonic/gin"
 )
+
+type PresetDeleteResponse struct {
+	Name     string `json:"name" binding:"required"`
+	PresetId string `json:"id" binding:"required"`
+	Status   string `json:"status" binding:"required"`
+}
 
 func DeleteServer(c *gin.Context) {
 	ReplyStatus(c, common.ServerClosing)
@@ -19,4 +26,33 @@ func DeleteServer(c *gin.Context) {
 		time.Sleep(1 * time.Second)
 		util.SendSigTermOrKill(os.Getpid())
 	}()
+}
+
+func DeleteCustomPresetById(c *gin.Context) {
+	id := c.Param("id")
+	var preset common.PresetData
+	var err error
+
+	if id != "" {
+		preset, err = runner.Presets.User.FindByUniqueId(id)
+	} else {
+		ReplyErrorMsg(c, common.ServerNoPreset)
+		return
+	}
+
+	if err != nil {
+		ReplyErrorMsg(c, common.ServerNoPreset)
+		return
+	}
+
+	f := runner.Presets.User.GetFile()
+	f.Remove(preset.Name)
+	f.Save()
+
+	// TODO: error handling in case of fail
+	ReplyDelete(c, PresetDeleteResponse{
+		Name:     preset.Name,
+		PresetId: preset.GetUniqueId(),
+		Status:   common.ServerPresetDeleted,
+	})
 }

--- a/qt-cli/src/server/handlers/get.go
+++ b/qt-cli/src/server/handlers/get.go
@@ -30,7 +30,13 @@ func GetReady(c *gin.Context) {
 	ReplyStatus(c, "ready")
 }
 
-func GetPresets(c *gin.Context) {
+func GetPresetsByNameOrType(c *gin.Context) {
+	name := c.Query("name")
+	if len(name) != 0 {
+		getPresetBy(c, name, "name")
+		return
+	}
+
 	var presets []common.PresetData
 	type_s := c.DefaultQuery("type", "")
 
@@ -67,8 +73,20 @@ func GetPresets(c *gin.Context) {
 }
 
 func GetPresetById(c *gin.Context) {
-	id := c.Param("id")
-	p, err := runner.Presets.Any.FindByUniqueId(id)
+	getPresetBy(c, c.Param("id"), "id")
+}
+
+// helpers
+func getPresetBy(c *gin.Context, value, by string) {
+	var p common.PresetData
+	var err error
+
+	if by == "id" {
+		p, err = runner.Presets.Any.FindByUniqueId(value)
+	} else {
+		p, err = runner.Presets.Any.FindByName(value)
+	}
+
 	if err != nil {
 		ReplyErrorMsg(c, common.ServerNoPreset)
 		return
@@ -81,11 +99,16 @@ func GetPresetById(c *gin.Context) {
 		return
 	}
 
+	prompt := getPromptFileContents(p.GetTemplateDir())
+	if prompt != nil {
+		prompt.UpdateDefaultValues(p.GetOptions())
+	}
+
 	ReplyGet(c, PresetDetailResponse{
 		Id:     p.GetUniqueId(),
 		Name:   p.GetName(),
 		Meta:   template.GetMeta(),
-		Prompt: getPromptFileContents(p.GetTemplateDir()),
+		Prompt: prompt,
 	})
 }
 

--- a/qt-cli/src/server/handlers/get_test.go
+++ b/qt-cli/src/server/handlers/get_test.go
@@ -33,7 +33,7 @@ func TestHandler_GetPresets(t *testing.T) {
 			ctx, _ := gin.CreateTestContext(w)
 			ctx.Request = httptest.NewRequest("GET", "/dont-care"+query, nil)
 
-			GetPresets(ctx)
+			GetPresetsByNameOrType(ctx)
 			ensureHttpCode(t, w, http.StatusOK)
 			ensureResponseType[PresetsResponse](t, w)
 		})

--- a/qt-cli/src/server/handlers/patch.go
+++ b/qt-cli/src/server/handlers/patch.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+package handlers
+
+import (
+	"qtcli/common"
+	"qtcli/runner"
+	"qtcli/util"
+
+	"github.com/gin-gonic/gin"
+)
+
+type PatchCustomPresetRequest struct {
+	Options map[string]any `json:"options"`
+}
+
+func PatchCustomPresetById(c *gin.Context) {
+	var req PatchCustomPresetRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		ReplyErrorMsg(c, err.Error())
+		return
+	}
+
+	id := c.Param("id")
+	preset, err := runner.Presets.User.FindByUniqueId(id)
+	if err != nil {
+		ReplyErrorMsg(c, err.Error())
+		return
+	}
+
+	preset.Options = util.Merge(preset.GetOptions(), req.Options)
+
+	f := runner.Presets.User.GetFile()
+	f.Replace(preset)
+	f.Save()
+
+	ReplyPost(c, StatusAndIdResponse{
+		Status: common.ServerStatusUpdated,
+		Id:     preset.GetUniqueId(),
+	})
+}

--- a/qt-cli/src/server/handlers/post.go
+++ b/qt-cli/src/server/handlers/post.go
@@ -8,6 +8,7 @@ import (
 	"qtcli/common"
 	"qtcli/generator"
 	"qtcli/runner"
+	"qtcli/util"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -26,6 +27,16 @@ type NewItemResponse struct {
 	FilesDir   string   `json:"filesDir" binding:"required"`
 	WorkingDir string   `json:"workingDir" binding:"required"`
 	DryRun     bool     `json:"dryRun" binding:"required"`
+}
+
+type NewCustomPresetRequest struct {
+	Name     string         `json:"name" binding:"required"`
+	PresetId string         `json:"presetId" binding:"required"`
+	Options  map[string]any `json:"options"`
+}
+type NewCustomPresetResponse struct {
+	Status   string `json:"status" binding:"required"`
+	PresetId string `json:"presetId" binding:"required"`
 }
 
 type PostNewItemContext struct {
@@ -105,4 +116,40 @@ func PostItemsValidate(c *gin.Context) {
 	}
 
 	ReplyStatus(c, common.InputOkay)
+}
+
+func PostCustomPreset(c *gin.Context) {
+	var req NewCustomPresetRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		ReplyErrorMsg(c, err.Error())
+		return
+	}
+
+	src, err := runner.Presets.Any.FindByUniqueId(req.PresetId)
+	if err != nil {
+		ReplyErrorMsg(c, err.Error())
+		return
+	}
+
+	_, err = runner.Presets.User.FindByName(req.Name)
+	if err == nil {
+		ReplyErrorMsg(c, common.ServerPresetAlreadyExists)
+		return
+	}
+
+	// TODO: validate name - ensure not starting with '@', not special chars...
+	newPreset := common.NewPresetData(
+		req.Name,
+		src.GetTemplateDir(),
+		util.Merge(src.GetOptions(), req.Options),
+	)
+
+	f := runner.Presets.User.GetFile()
+	f.Add(newPreset)
+	f.Save()
+
+	ReplyPost(c, StatusAndIdResponse{
+		Status: common.ServerStatusCreated,
+		Id:     newPreset.GetUniqueId(),
+	})
 }

--- a/qt-cli/src/server/server.go
+++ b/qt-cli/src/server/server.go
@@ -91,7 +91,7 @@ func createApiHandler() *gin.Engine {
 
 	r := gin.Default()
 	r.Use(cors.New(cors.Config{
-		AllowMethods:     []string{"GET", "POST", "DELETE", "OPTIONS"},
+		AllowMethods:     []string{"GET", "POST", "PATCH", "DELETE", "OPTIONS"},
 		AllowHeaders:     []string{"Content-Type", "Authorization"},
 		ExposeHeaders:    []string{"Content-Length"},
 		MaxAge:           12 * time.Hour,
@@ -103,11 +103,21 @@ func createApiHandler() *gin.Engine {
 
 	v1 := r.Group("/v1")
 
-	v1.GET("/ready", handlers.GetReady)
-	v1.GET("/presets", handlers.GetPresets)
+	// read presets or details of the specific preset
+	v1.GET("/presets", handlers.GetPresetsByNameOrType)
 	v1.GET("/presets/:id", handlers.GetPresetById)
+
+	// manage custom presets
+	v1.POST("/presets", handlers.PostCustomPreset)
+	v1.PATCH("/presets/:id", handlers.PatchCustomPresetById)
+	v1.DELETE("/presets/:id", handlers.DeleteCustomPresetById)
+
+	// create item (project or file) & validation
 	v1.POST("/items", handlers.PostItems)
 	v1.POST("/items/validate", handlers.PostItemsValidate)
+
+	// others
+	v1.GET("/ready", handlers.GetReady)
 	v1.DELETE("/server", handlers.DeleteServer)
 
 	return r


### PR DESCRIPTION
Add three endpoints for CRUD operations on custom presets:
- POST /presets
- PATCH /presets/:id
- DELETE /presets/:id

GET /presets now supports the `name` query parameter. 
This is useful when the `id` needs to be retrieved from the preset name.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
