### PR TITLE
qt-cli: Remove explicit fallback for empty strings in prompt file

### DIFF
--- a/qt-cli/src/assets/templates/projects/cpp/qtquick/prompt.yml
+++ b/qt-cli/src/assets/templates/projects/cpp/qtquick/prompt.yml
@@ -15,8 +15,7 @@ steps:
     question: "Qt Quick Controls style:"
     default: ""
     items:
-      - text: <None>
-        data: ""
+      - text: ""
       - text: Material
       - text: Universal
 

--- a/qt-cli/src/prompt/comps/list_item.go
+++ b/qt-cli/src/prompt/comps/list_item.go
@@ -49,7 +49,7 @@ func (i ListItem) Data(data any) ListItem {
 }
 
 func (i *ListItem) IsSeparator() bool {
-	return len(i.text) == 0
+	return i.text == "-"
 }
 
 func (i ListItem) FilterValue() string {
@@ -87,10 +87,14 @@ func (d ListItemDelegate) Render(
 	text := item.text
 	desc := ""
 
-	if len(text) == 0 {
+	if item.IsSeparator() {
 		fmt.Fprint(w, sty.ListItem.Separator.Render(
 			strings.Repeat(string(prompt.MarkingSeparatorChar), 30)))
 		return
+	}
+
+	if len(text) == 0 {
+		text = "<None>"
 	}
 
 	if item.checkable {


### PR DESCRIPTION
Previously, empty list items in prompt definitions (`prompt.yml`) were written as:
```
  - text: "<None>"
    data: ""
```

This mixed UI logic into the data file.
They are now simply written as:
``` 
- text: ""
```

The UI (CLI prompt or webview) is now responsible for rendering empty text as needed.

Additionally, the internal separator definition has been changed from "" to "-" to avoid collisions with this logic.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
