### PR TITLE
qt-core/webview: Add support for managing custom presets

### DIFF
--- a/qt-cli/src/server/handlers/common.go
+++ b/qt-cli/src/server/handlers/common.go
@@ -33,10 +33,12 @@ func ReplyStatus(c *gin.Context, msg string) {
 }
 
 func ReplyError(c *gin.Context, msg string, details *common.Issues) {
-	c.JSON(http.StatusBadRequest, ErrorResponse{
-		Error:   msg,
-		Details: details,
-	})
+	e := ErrorResponse{Error: msg}
+	if details != nil && len(*details) != 0 {
+		e.Details = details
+	}
+
+	c.JSON(http.StatusBadRequest, e)
 }
 
 func ReplyErrorMsg(c *gin.Context, msg string) {

--- a/qt-core/src/qtcli/rest.ts
+++ b/qt-core/src/qtcli/rest.ts
@@ -4,7 +4,7 @@
 import os from 'os';
 import axios, { AxiosRequestConfig, isAxiosError } from 'axios';
 
-import { ErrorResponse, Issue } from '@/webview/shared/types';
+import { isErrorResponse, Issue } from '@/webview/shared/types';
 
 // axios wrapper
 export class QtcliRestClient {
@@ -29,8 +29,12 @@ export class QtcliRestClient {
     return this.call({ method: 'post', url, data, params });
   }
 
-  public async delete(url: string) {
-    return this.call({ method: 'delete', url });
+  public async patch(url: string, data?: unknown) {
+    return this.call({ method: 'patch', url, data });
+  }
+
+  public async delete(url: string, data?: unknown) {
+    return this.call({ method: 'delete', url, data });
   }
 
   public async call<T = unknown>(req: AxiosRequestConfig): Promise<T> {
@@ -65,31 +69,49 @@ export class QtcliRestClient {
 }
 
 export class QtcliRestError extends Error {
-  public details = [] as Issue[];
-
-  constructor(message: string, details?: Issue[]) {
+  constructor(
+    message: string,
+    public details: Issue[] = []
+  ) {
     super(message);
     this.name = 'QtcliRestError';
-
-    if (details) {
-      this.details = details;
-    }
+    Object.setPrototypeOf(this, QtcliRestError.prototype);
   }
 
   public static from(e: unknown) {
-    if (isAxiosError<ErrorResponse>(e)) {
-      const data = e.response?.data;
-      if (data) {
-        return new QtcliRestError(data.error, data.details);
+    let message = '';
+    let details: Issue[] = [];
+
+    if (isAxiosError(e)) {
+      const data = e.response?.data as unknown;
+      if (isErrorResponse(data)) {
+        message = data.error;
+        details = data.details ?? [];
+      } else {
+        message = e.message;
+        details = [
+          {
+            level: 'error',
+            field: 'method',
+            message: (e.config?.method ?? '').toUpperCase()
+          },
+          {
+            level: 'error',
+            field: 'url',
+            message: e.config?.url ?? ''
+          }
+        ];
       }
+    } else {
+      message = e instanceof Error ? e.message : String(e);
     }
 
-    return new QtcliRestError(e instanceof Error ? e.message : String(e));
+    return new QtcliRestError(message, details);
   }
 
   public override toString(): string {
-    const details = this.details.map((d) => d.message).join(', ');
-    return details ? `${this.message} - ${details}` : this.message;
+    const all = this.details.map((d) => d.message).join(', ');
+    return all.length > 0 ? `${this.message} - ${all}` : this.message;
   }
 }
 

--- a/qt-core/src/webview/new-item-handlers.ts
+++ b/qt-core/src/webview/new-item-handlers.ts
@@ -31,6 +31,7 @@ export class NewItemCommandHandler {
       [CommandId.UiGetAllPresets, this.onUiGetAllPresets],
       [CommandId.UiGetPresetById, this.onUiGetPresetById],
       [CommandId.UiValidateInputs, this.onUiValidateInputs],
+      [CommandId.UiManageCustomPreset, this.onUiManageCustomPreset],
       [CommandId.UiSelectWorkingDir, this.onUiSelectWorkingDir]
     ]);
   }
@@ -118,6 +119,48 @@ export class NewItemCommandHandler {
     const id = _.toString(cmd.payload);
     const data = await this._qtcliRest.get(`/presets/${id}`);
     this._panel?.post(cmd.id, { data }, cmd.tag);
+  };
+
+  private readonly onUiManageCustomPreset = async (cmd: Command) => {
+    const action = _.get(cmd.payload, 'action', '') as string;
+    const presetId = _.get(cmd.payload, 'presetId', '') as string;
+    if (presetId.length === 0) {
+      return;
+    }
+
+    try {
+      switch (action) {
+        case 'create': {
+          const data = await this._qtcliRest.post('/presets', cmd.payload);
+          this._panel?.postDataReply(cmd, data);
+          break;
+        }
+
+        case 'rename': {
+          await this._qtcliRest.post('/presets', cmd.payload);
+          await this._qtcliRest.delete(`/presets/${presetId}`);
+          this._panel?.postDataReply(cmd, cmd.payload);
+          break;
+        }
+
+        case 'update': {
+          await this._qtcliRest.patch(`/presets/${presetId}`, cmd.payload);
+          this._panel?.postDataReply(cmd, cmd.payload);
+          break;
+        }
+
+        case 'delete': {
+          const data = await this._qtcliRest.delete(`/presets/${presetId}`);
+          this._panel?.postDataReply(cmd, data);
+          break;
+        }
+      }
+    } catch (e) {
+      if (e instanceof QtcliRestError) {
+        await vscode.window.showErrorMessage(e.toString());
+        this._panel?.postErrorReplyFrom(cmd, e.message, e.details);
+      }
+    }
   };
 
   private readonly onUiValidateInputs = async (cmd: Command) => {

--- a/qt-core/src/webview/new-item-panel.ts
+++ b/qt-core/src/webview/new-item-panel.ts
@@ -12,9 +12,10 @@ import {
   getNewProjectBaseDir
 } from '@/qtcli/commands';
 import { getUri, getNonce } from './utils';
-import { CommandId } from '@/webview/shared/message';
+import { Command, CommandId } from '@/webview/shared/message';
 import { NewItemCommandHandler } from './new-item-handlers';
 import * as texts from '@/texts';
+import { ErrorResponse, Issue } from './shared/types';
 
 const logger = createLogger('new-item-panel');
 let qtcliRunner: QtcliRunner | undefined = undefined;
@@ -81,6 +82,21 @@ export class NewItemPanel {
     tag: string | undefined = undefined
   ) {
     void this._panel.webview.postMessage({ id, payload, tag });
+  }
+
+  public postDataReply(cmd: Command, data: unknown) {
+    this.post(cmd.id, { data }, cmd.tag);
+  }
+
+  public postErrorReply(cmd: Command, error: unknown) {
+    this.post(cmd.id, { error }, cmd.tag);
+  }
+
+  public postErrorReplyFrom(cmd: Command, msg: string, details: Issue[]) {
+    this.postErrorReply(cmd, {
+      error: msg,
+      details
+    } as ErrorResponse);
   }
 }
 

--- a/qt-core/src/webview/shared/message.ts
+++ b/qt-core/src/webview/shared/message.ts
@@ -14,8 +14,15 @@ export enum CommandId {
   UiGetAllPresets,
   UiGetPresetById,
   UiValidateInputs,
+  UiManageCustomPreset,
   UiSelectWorkingDir
 }
+
+export type ManageCustomPresetArgs =
+  | { action: 'create'; name: string }
+  | { action: 'rename'; name: string }
+  | { action: 'update' }
+  | { action: 'delete' };
 
 export interface Command<T = unknown> {
   id: CommandId;

--- a/qt-core/webview-ui/eslint.config.mjs
+++ b/qt-core/webview-ui/eslint.config.mjs
@@ -32,8 +32,7 @@ export default ts.config(
   },
   {
     rules: {
-      // Override or add rule settings here, such as:
-      // 'svelte/rule-name': 'error'
+      "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_\\w*" }]
     }
   }
 );

--- a/qt-core/webview-ui/package-lock.json
+++ b/qt-core/webview-ui/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@types/vscode-webview": "^1.57.5",
-        "marked": "^15.0.7"
+        "marked": "^15.0.7",
+        "nanoid": "^5.1.5",
+        "zod": "^3.25.67"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
@@ -3781,10 +3783,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
       "funding": [
         {
           "type": "github",
@@ -3793,10 +3794,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {
@@ -4059,6 +4060,25 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prelude-ls": {
@@ -4823,6 +4843,15 @@
       "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/qt-core/webview-ui/package.json
+++ b/qt-core/webview-ui/package.json
@@ -38,6 +38,8 @@
   },
   "dependencies": {
     "@types/vscode-webview": "^1.57.5",
-    "marked": "^15.0.7"
+    "marked": "^15.0.7",
+    "nanoid": "^5.1.5",
+    "zod": "^3.25.67"
   }
 }

--- a/qt-core/webview-ui/src/app/PresetList.svelte
+++ b/qt-core/webview-ui/src/app/PresetList.svelte
@@ -4,10 +4,16 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
-  import { Listgroup, ListgroupItem } from 'flowbite-svelte';
+  import { Listgroup } from 'flowbite-svelte';
 
-  import { data } from './states.svelte';
+  import { data, ui } from './states.svelte';
+  import { PresetWrapper } from './types.svelte';
   import * as viewlogic from './viewlogic.svelte';
+  import PresetListItem from './PresetListItem.svelte';
+
+  let wrappedPresets = $derived.by(() => {
+    return data.presets.map((p) => new PresetWrapper(p));
+  });
 
   const adjustSelectedIndex = (offset: number) => {
     if (!data.selected.preset || data.selected.presetIndex < 0) {
@@ -19,7 +25,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
     candidate = Math.min(candidate, data.presets.length - 1);
 
     if (candidate != data.selected.presetIndex) {
-      viewlogic.setSelectedPreset(data.presets[candidate], candidate);
+      viewlogic.setSelectedPresetAt(candidate);
     }
   };
 
@@ -28,6 +34,10 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
       adjustSelectedIndex(-1);
     } else if (e.key === 'ArrowDown') {
       adjustSelectedIndex(+1);
+    } else if (e.key === 'Delete') {
+      if (data.selected.preset.isCustomPreset()) {
+        ui.activeDialog = 'delete';
+      }
     } else {
       return;
     }
@@ -40,6 +50,8 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
         item.focus();
       }
     }
+
+    e.preventDefault();
   };
 </script>
 
@@ -50,25 +62,8 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
     onkeydown={onKeyPressed}
     tabindex={0}
   >
-    {#each data.presets as preset, index (index)}
-      <ListgroupItem
-        class="qt-list-item flex flex-row"
-        currentClass="selected"
-        current={data.selected.presetIndex === index}
-        on:click={() => {
-          viewlogic.setSelectedPreset(preset, index);
-        }}
-      >
-        <div class="flex-1">
-          {viewlogic.createPresetDisplayText(preset)}
-        </div>
-
-        {#if !preset.name.startsWith('@')}
-          <div class="ml-auto mr-0.5 qt-badge">{preset.meta.title}</div>
-        {:else}
-          <div></div>
-        {/if}
-      </ListgroupItem>
+    {#each wrappedPresets as preset, index (preset.id)}
+      <PresetListItem {preset} {index} />
     {/each}
   </Listgroup>
 </div>

--- a/qt-core/webview-ui/src/app/PresetListItem.svelte
+++ b/qt-core/webview-ui/src/app/PresetListItem.svelte
@@ -1,0 +1,57 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { ListgroupItem, Tooltip } from 'flowbite-svelte';
+  import { DotsHorizontalOutline } from 'flowbite-svelte-icons';
+
+  import TruncatableLabel from '@/comps/TruncatableLabel.svelte';
+  import PresetListItemMenu from './PresetListItemMenu.svelte';
+  import { data } from './states.svelte';
+  import { PresetWrapper } from './types.svelte';
+  import { setSelectedPresetAt } from './viewlogic.svelte';
+
+  let { index = -1, preset = new PresetWrapper() } = $props();
+
+  let truncated = $state(false);
+  let menuOpened = $state(false);
+</script>
+
+<ListgroupItem
+  class="qt-list-item flex flex-row gap-1"
+  currentClass="selected"
+  current={data.selected.presetIndex === index}
+  on:click={() => {
+    setSelectedPresetAt(index);
+  }}
+>
+  <TruncatableLabel text={preset.itemText} class="flex-1" bind:truncated />
+
+  {#if preset.isCustomPreset()}
+    <div class="ml-auto mr-0.5 qt-badge flex flex-row gap-1">
+      {preset.title}
+      <DotsHorizontalOutline
+        class="qt-button flat-borderless"
+        onclick={() => {
+          menuOpened = true;
+        }}
+      />
+      {#if menuOpened}
+        <PresetListItemMenu
+          open={true}
+          onClosed={() => {
+            menuOpened = false;
+          }}
+        />
+      {/if}
+    </div>
+  {/if}
+</ListgroupItem>
+
+{#if truncated && !menuOpened}
+  <Tooltip placement="top" data-placement="top" class="qt-tooltip" offset={10}>
+    {preset.itemText}
+  </Tooltip>
+{/if}

--- a/qt-core/webview-ui/src/app/PresetListItemMenu.svelte
+++ b/qt-core/webview-ui/src/app/PresetListItemMenu.svelte
@@ -1,0 +1,42 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { EditOutline, TrashBinOutline } from 'flowbite-svelte-icons';
+
+  import * as texts from './texts';
+  import { ui } from './states.svelte';
+  import PickerList from '@/comps/PickerList.svelte';
+
+  let { open = false, onClosed = () => {} } = $props();
+
+  const items = [
+    { icon: TrashBinOutline, text: texts.wizard.buttons.delete },
+    { icon: EditOutline, text: texts.wizard.buttons.rename }
+  ];
+
+  function onItemClickedAt(index: number) {
+    if (index === 0) {
+      ui.activeDialog = 'delete';
+    } else if (index === 1) {
+      ui.activeDialog = 'rename';
+    }
+
+    open = false;
+    onClosed();
+  }
+</script>
+
+{#if open}
+  <PickerList
+    active={true}
+    {items}
+    width={100}
+    offset={12}
+    currentIndex="-1"
+    onRejected={onClosed}
+    onAccepted={onItemClickedAt}
+  />
+{/if}

--- a/qt-core/webview-ui/src/app/PresetOptionsHeader.svelte
+++ b/qt-core/webview-ui/src/app/PresetOptionsHeader.svelte
@@ -1,0 +1,65 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only 
+-->
+
+<script lang="ts">
+  import { PlusOutline, FloppyDiskOutline } from 'flowbite-svelte-icons';
+
+  import IconButton from '@/comps/IconButton.svelte';
+  import SectionLabel from '@/comps/SectionLabel.svelte';
+  import * as texts from './texts';
+  import { data, ui } from './states.svelte';
+  import { manageCustomPreset } from './viewlogic.svelte';
+
+  let createEnabled = $derived.by(() => {
+    return (
+      data.selected.preset.isDefaultPreset() &&
+      data.selected.preset.hasSteps() &&
+      Object.keys(ui.unsavedOptionChanges).length !== 0
+    );
+  });
+
+  let saveEnabled = $derived.by(() => {
+    return (
+      data.selected.preset.isCustomPreset() &&
+      Object.keys(ui.unsavedOptionChanges).length !== 0
+    );
+  });
+</script>
+
+<!-- title and toolbar -->
+<div class="w-full flex items-end justify-between mb-2">
+  <div>
+    <SectionLabel text={texts.wizard.options} />
+  </div>
+  <div
+    class={`
+      flex flex-row transition-opacity duration-200
+      ${!(createEnabled || saveEnabled) ? 'opacity-0 pointer-events-none' : ''}
+      `}
+  >
+    <IconButton
+      icon={PlusOutline}
+      tooltip={texts.wizard.buttonTooltips.create}
+      tooltipPlacement="top-end"
+      visible={createEnabled}
+      text={texts.wizard.buttons.create}
+      onClicked={() => {
+        ui.activeDialog = 'create';
+      }}
+    />
+
+    <IconButton
+      icon={FloppyDiskOutline}
+      tooltip={texts.wizard.buttonTooltips.save}
+      tooltipPlacement="top-end"
+      visible={saveEnabled}
+      text={texts.wizard.buttons.save}
+      class="px-4 py-2"
+      onClicked={() => {
+        manageCustomPreset({ action: 'update' });
+      }}
+    />
+  </div>
+</div>

--- a/qt-core/webview-ui/src/app/PresetOptionsTable.svelte
+++ b/qt-core/webview-ui/src/app/PresetOptionsTable.svelte
@@ -4,41 +4,45 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
-  import {
-    P,
-    Table,
-    TableBody,
-    TableBodyRow,
-    TableBodyCell
-  } from 'flowbite-svelte';
+  import type { Component } from 'svelte';
+  import { P } from 'flowbite-svelte';
 
-  import { data } from './states.svelte';
+  import { data, ui } from './states.svelte';
+  import type { PresetPromptStep } from './types.svelte';
+  import PromptStepInput from './PromptStepInput.svelte';
+  import PromptStepPicker from './PromptStepPicker.svelte';
+  import PromptStepConfirm from './PromptStepConfirm.svelte';
 
-  const steps = $derived(data.selected.preset?.prompt?.steps);
-  const toDisplayValue = (value: unknown) => {
-    if (typeof value === 'string' && value.length === 0) {
-      return '-';
-    } else if (typeof value === 'boolean') {
-      return value ? 'Yes' : 'No';
-    }
+  const steps = $derived(data.selected.preset?.steps);
 
-    return value;
+  type Props = {
+    step: PresetPromptStep | undefined;
+    onValueChanged: (_step: PresetPromptStep, _value: unknown) => void;
   };
+
+  const stepComponents: Record<string, Component<Props, object, ''>> = {
+    input: PromptStepInput,
+    picker: PromptStepPicker,
+    confirm: PromptStepConfirm
+  };
+
+  function onValueChanged(step: PresetPromptStep, value: unknown) {
+    ui.unsavedOptionChanges[step.id] = value;
+  }
 </script>
 
 {#if steps}
-  <Table color="custom" class="qt-simple-table">
-    <TableBody>
-      {#each steps as step (step.id)}
-        <TableBodyRow class="last:border-0">
-          <TableBodyCell class="p-0.5">
-            <P class="qt-label">{step.question}</P>
-          </TableBodyCell>
-          <TableBodyCell class="p-0.5">
-            <P class="qt-label">{toDisplayValue(step.default)}</P>
-          </TableBodyCell>
-        </TableBodyRow>
-      {/each}
-    </TableBody>
-  </Table>
+  <div class="grid grid-cols-[1fr_max-content] gap-1">
+    {#each steps as step (step.id)}
+      <P class="qt-label">{step.question}</P>
+      {#if step.type in stepComponents}
+        {@const Comp = stepComponents[step.type]}
+        <div class="flex item-center min-w-[120px]">
+          <Comp {step} {onValueChanged} />
+        </div>
+      {:else}
+        <P class="qt-label">{step.default}</P>
+      {/if}
+    {/each}
+  </div>
 {/if}

--- a/qt-core/webview-ui/src/app/PromptStepConfirm.svelte
+++ b/qt-core/webview-ui/src/app/PromptStepConfirm.svelte
@@ -1,0 +1,36 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { Checkbox } from 'flowbite-svelte';
+
+  import { toBool } from '@/utils/utils';
+  import * as texts from './texts';
+  import type { PresetPromptStep } from './types.svelte';
+
+  let {
+    step = undefined as PresetPromptStep | undefined,
+    onValueChanged = (_step: PresetPromptStep, _value: unknown) => {}
+  } = $props();
+
+  let checked = $state(false);
+
+  onMount(() => {
+    if (step?.default) {
+      checked = toBool(step.default);
+    }
+  });
+</script>
+
+<Checkbox
+  class="qt-checkbox"
+  bind:checked
+  on:change={() => {
+    onValueChanged(step, checked);
+  }}
+>
+  {texts.wizard.buttons.yes}
+</Checkbox>

--- a/qt-core/webview-ui/src/app/PromptStepInput.svelte
+++ b/qt-core/webview-ui/src/app/PromptStepInput.svelte
@@ -1,0 +1,32 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { Input } from 'flowbite-svelte';
+  import type { PresetPromptStep } from './types.svelte';
+
+  let {
+    step = undefined as PresetPromptStep | undefined,
+    onValueChanged = (_step: PresetPromptStep, _value: unknown) => {}
+  } = $props();
+
+  let value = $state('');
+
+  onMount(() => {
+    if (step?.default) {
+      value = step.default;
+    }
+  });
+</script>
+
+<Input
+  type="text"
+  class="qt-input w-full"
+  bind:value
+  on:input={() => {
+    onValueChanged(step, value);
+  }}
+/>

--- a/qt-core/webview-ui/src/app/PromptStepPicker.svelte
+++ b/qt-core/webview-ui/src/app/PromptStepPicker.svelte
@@ -1,0 +1,31 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import Picker from '@/comps/Picker.svelte';
+  import type { PresetPromptStep, PickerItem } from './types.svelte';
+
+  let {
+    step = undefined as PresetPromptStep | undefined,
+    onValueChanged = (_step: PresetPromptStep, _value: unknown) => {}
+  } = $props();
+
+  let defaultText = $derived(step?.default ?? '');
+  let items = $derived.by(() => {
+    if (!step?.items) {
+      return [] as PickerItem[];
+    }
+
+    return step.items.map((e) => {
+      return { text: e.text, icon: undefined };
+    });
+  });
+
+  function onSelected(i: number) {
+    onValueChanged(step, items[i].text);
+  }
+</script>
+
+<Picker {items} {defaultText} {onSelected} showIcon={false} />

--- a/qt-core/webview-ui/src/app/Wizard.svelte
+++ b/qt-core/webview-ui/src/app/Wizard.svelte
@@ -10,12 +10,14 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   import { ui } from './states.svelte';
   import { onModalClosed } from './viewlogic.svelte';
   import LoadingMask from '@/comps/LoadingMask.svelte';
+  import WizardAllDialogs from './WizardAllDialogs.svelte';
   import WizardSectionInput from './WizardSectionInput.svelte';
   import WizardSectionPresets from './WizardSectionPresets.svelte';
 </script>
 
 <Modal
   open
+  dismissable={false}
   size="lg"
   color="none"
   class="qt-modal w-[80vw] h-[90vh] min-w-[500px] min-h-[500px]"
@@ -36,5 +38,6 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
       busyText={texts.loading.busy}
       closeText={texts.loading.close}
     />
+    <WizardAllDialogs />
   </div>
 </Modal>

--- a/qt-core/webview-ui/src/app/WizardAllDialogs.svelte
+++ b/qt-core/webview-ui/src/app/WizardAllDialogs.svelte
@@ -1,0 +1,79 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import * as texts from './texts';
+  import { data, ui } from './states.svelte';
+  import { manageCustomPreset, validatePresetName } from './viewlogic.svelte';
+  import InputDialog from '@/comps/InputDialog.svelte';
+  import ConfirmDialog from '@/comps/ConfirmDialog.svelte';
+
+  let input = $state({
+    value: '',
+    error: {
+      level: '',
+      message: undefined as string | undefined
+    }
+  });
+
+  function onInputAccepted() {
+    if (ui.activeDialog === 'create' || ui.activeDialog === 'rename') {
+      manageCustomPreset({
+        action: ui.activeDialog,
+        name: input.value.trim()
+      });
+    }
+
+    closeDialogs();
+  }
+
+  function onInputDialongReady() {
+    if (ui.activeDialog === 'create') {
+      input.value = 'mynewpreset';
+    } else if (ui.activeDialog === 'rename') {
+      input.value = data.selected.preset.name ?? '';
+    }
+
+    validateInputs();
+  }
+
+  function validateInputs() {
+    input.error.message = validatePresetName(input.value);
+    input.error.level = (input.error.message !== undefined ? 'error' : '')
+  }
+
+  function closeDialogs() {
+    ui.activeDialog = undefined;
+  }
+</script>
+
+{#if ui.activeDialog === 'create' || ui.activeDialog === 'rename'}
+  <InputDialog
+    acceptOnEnter
+    bind:value={input.value}
+    level={input.error.level}
+    message={input.error.message}
+    text={texts.wizard.enterNewPresetName}
+    acceptText={texts.wizard.buttons.okay}
+    rejectText={texts.wizard.buttons.cancel}
+    onReady={onInputDialongReady}
+    onInput={validateInputs}
+    onAccepted={onInputAccepted}
+    onRejected={closeDialogs}
+  />
+{/if}
+
+{#if ui.activeDialog === 'delete'}
+  <ConfirmDialog
+    text={texts.wizard.confirmDeletePreset}
+    acceptText={texts.wizard.buttons.yes}
+    rejectText={texts.wizard.buttons.no}
+    onAccepted={() => {
+      closeDialogs();
+      manageCustomPreset({ action: 'delete' });
+    }}
+    onRejected={closeDialogs}
+  />
+{/if}

--- a/qt-core/webview-ui/src/app/WizardSectionPresets.svelte
+++ b/qt-core/webview-ui/src/app/WizardSectionPresets.svelte
@@ -12,6 +12,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   import PresetList from './PresetList.svelte';
   import PresetTypeSelector from './PresetTypeSelector.svelte';
   import PresetOptionsTable from './PresetOptionsTable.svelte';
+  import PresetOptionsHeader from './PresetOptionsHeader.svelte';
 </script>
 
 <div
@@ -28,16 +29,13 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
     <SectionLabel text={texts.wizard.description} />
     <div>
       <P class="qt-label whitespace-pre-wrap leading-relaxed"
-        >{(data.selected.preset?.meta?.description ?? '').replaceAll(
-          '\n',
-          '\n\n'
-        )}
+        >{(data.selected.preset?.description ?? '').replaceAll('\n', '\n\n')}
       </P>
     </div>
     <div class="flex-grow"></div>
 
-    {#if data.selected.preset?.prompt?.steps}
-      <SectionLabel text={texts.wizard.options} />
+    {#if data.selected.preset?.steps}
+      <PresetOptionsHeader />
       <PresetOptionsTable />
     {/if}
   </div>

--- a/qt-core/webview-ui/src/app/states.svelte.ts
+++ b/qt-core/webview-ui/src/app/states.svelte.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
-import { type Preset, InputIssue } from './types.svelte';
+import { type Preset, InputIssue, PresetWrapper } from './types.svelte';
 
 export const data = $state({
   serverReady: false,
@@ -12,7 +12,7 @@ export const data = $state({
   presets: [] as Preset[],
   selected: {
     type: 'project',
-    preset: undefined as Preset | undefined,
+    preset: new PresetWrapper(),
     presetIndex: -1
   }
 });
@@ -36,5 +36,8 @@ export const ui = $state({
     delayedTimerId: null as NodeJS.Timeout | null
   },
 
-  canCreate: true
+  activeDialog: undefined as 'create' | 'rename' | 'delete' | undefined,
+
+  canCreate: true,
+  unsavedOptionChanges: {} as Record<string, unknown>
 });

--- a/qt-core/webview-ui/src/app/texts.ts
+++ b/qt-core/webview-ui/src/app/texts.ts
@@ -4,7 +4,19 @@
 export const wizard = {
   title: 'Create a new project or file',
   buttons: {
-    create: 'Create'
+    create: 'Create',
+    rename: 'Rename',
+    delete: 'Delete',
+    save: 'Save',
+    yes: 'Yes',
+    no: 'No',
+    okay: 'OK',
+    cancel: 'Cancel'
+  },
+
+  buttonTooltips: {
+    create: 'Create a new preset from the currently edited options',
+    save: 'Save changes to the current preset'
   },
 
   types: {
@@ -21,7 +33,17 @@ export const wizard = {
   name: 'Name',
   workingDir: 'Create in',
   workingDirTooltip: 'Browse',
-  workingDirSaveCheckbox: 'Use as default project directory'
+  workingDirSaveCheckbox: 'Use as default project directory',
+
+  enterNewPresetName: 'Enter a new name for the custom preset',
+  confirmDeletePreset: 'Delete the preset?',
+
+  presetNameErrors: {
+    empty: 'Give the preset a name',
+    invalid: 'Preset names can contain letters from a to z, numbers, and underscore characters',
+    tooLong: 'Enter a shorter name',
+    alreadyTaken: 'Enter a unique name'
+  }
 };
 
 export const loading = {

--- a/qt-core/webview-ui/src/app/types.svelte.ts
+++ b/qt-core/webview-ui/src/app/types.svelte.ts
@@ -2,31 +2,93 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 import _ from 'lodash';
+import { FileCloneOutline } from 'flowbite-svelte-icons';
 
 export interface Preset {
   id: string;
   name: string;
-  meta: {
-    title: string;
-    description: string;
-  };
+  meta: PresetMeta;
   prompt?: PresetPrompt;
 }
 
-export interface PresetPromptStep {
-  id: string;
+export interface PresetMeta {
   type: string;
-  question: string;
-  default: unknown;
-  items: unknown[];
-  when: string;
-  rules: object[];
+  title: string;
+  description: string;
 }
 
 export interface PresetPrompt {
   version: string;
   steps: PresetPromptStep[];
   consts: object[];
+}
+
+export interface PresetPromptStep {
+  id: string;
+  type: string;
+  question: string;
+  default: string;
+  items: PresetPromptStepItem[];
+  when: string;
+  rules: object[];
+}
+
+export interface PresetPromptStepItem {
+  text: string;
+  data: unknown;
+  description: string;
+  checked: string;
+}
+
+export class PresetWrapper {
+  private _raw = $state(undefined as Preset | undefined);
+
+  constructor(data?: Preset) {
+    this.setData(data);
+  }
+
+  get id() {
+    return this._raw?.id ?? '';
+  }
+  get name() {
+    return this._raw?.name ?? '';
+  }
+  get title() {
+    return this._raw?.meta.title;
+  }
+  get description() {
+    return this._raw?.meta.description ?? '';
+  }
+  get steps() {
+    return this._raw?.prompt?.steps;
+  }
+  get itemText() {
+    if (this.isValid() && this.isDefaultPreset() && this._raw?.meta.title) {
+      return this._raw?.meta.title;
+    }
+
+    return this.name;
+  }
+
+  public isValid() {
+    return this._raw !== undefined;
+  }
+
+  public isCustomPreset() {
+    return this.name.length > 0 && !this.name.startsWith('@');
+  }
+
+  public isDefaultPreset() {
+    return this.name.length > 0 && this.name.startsWith('@');
+  }
+
+  public hasSteps() {
+    return this.steps !== undefined && this.steps.length > 0;
+  }
+
+  public setData(data: Preset | undefined) {
+    this._raw = data;
+  }
 }
 
 export class InputIssue {
@@ -46,6 +108,11 @@ export class InputIssue {
   public isError(): boolean {
     return this.level.toLocaleLowerCase() === 'error';
   }
+}
+
+export interface PickerItem {
+  text: string;
+  icon?: typeof FileCloneOutline | undefined;
 }
 
 // type guard functions

--- a/qt-core/webview-ui/src/app/viewlogic.svelte.ts
+++ b/qt-core/webview-ui/src/app/viewlogic.svelte.ts
@@ -1,11 +1,18 @@
 // Copyright (C) 2025 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
+import { z } from 'zod';
+
 import { vscode } from '@/app/vscode';
 import { isErrorResponse } from '@shared/types';
-import { type CommandReply, CommandId } from '@shared/message';
+import {
+  CommandId,
+  type CommandReply,
+  type ManageCustomPresetArgs
+} from '@shared/message';
 import { type Preset, isPreset, isPresetArray } from './types.svelte';
 import { data, input, ui } from './states.svelte';
+import * as texts from './texts';
 
 export async function onAppMount() {
   vscode.onDidReceiveNotification(async (r: CommandReply) => {
@@ -74,21 +81,44 @@ export async function setPresetType(type: string) {
   }
 }
 
-export async function setSelectedPreset(preset: Preset, index: number) {
+export async function setSelectedPresetByName(name: string) {
+  const index = data.presets.findIndex((p) => p.name === name);
+  if (index !== -1) {
+    setSelectedPresetAt(index);
+  }
+}
+
+export async function setSelectedPresetAt(index: number) {
   if (!data.serverReady) return;
+  if (index < 0 || index >= data.presets.length) return;
 
-  data.selected.preset = preset;
-  data.selected.presetIndex = index;
+  const p = data.presets[index];
+  if (p) {
+    data.selected.presetIndex = index;
+    data.selected.preset.setData(p);
+    ui.unsavedOptionChanges = {};
 
-  if (preset.id.length > 0) {
-    try {
-      const r = await vscode.post(CommandId.UiGetPresetById, preset.id);
-      if (isPreset(r)) {
-        data.selected.preset = r;
-      }
-    } catch (e) {
-      reportUiError('Error getting preset by id', e);
+    await refreshPresetDetails();
+  }
+}
+
+async function refreshPresetDetails() {
+  if (!data.selected.preset.isValid()) {
+    return;
+  }
+
+  try {
+    const id = data.selected.preset.id;
+    if (id.length === 0) {
+      return;
     }
+
+    const r = await vscode.post(CommandId.UiGetPresetById, id);
+    if (isPreset(r)) {
+      data.selected.preset.setData(r);
+    }
+  } catch (e) {
+    reportUiError('Error getting preset by id', e);
   }
 }
 
@@ -142,6 +172,85 @@ export async function validateInput() {
   }
 }
 
+export async function manageCustomPreset(args: ManageCustomPresetArgs) {
+  const presetId = data.selected.preset?.id;
+  if (!presetId) {
+    return;
+  }
+
+  const action = args.action;
+  const options = $state.snapshot(ui.unsavedOptionChanges);
+  const isCustom = data.selected.preset.isCustomPreset();
+  const isDefault = data.selected.preset.isDefaultPreset();
+
+  switch (args.action) {
+    case 'create': {
+      const name = args.name.trim();
+      if (isDefault && name.length !== 0) {
+        const payload = { action, presetId, name, options };
+        await vscode.post(CommandId.UiManageCustomPreset, payload);
+        await loadPresets();
+        await setSelectedPresetByName(name);
+      }
+      break;
+    }
+
+    case 'rename': {
+      const name = args.name.trim();
+      if (isCustom && name.length !== 0 && name !== data.selected.preset.name) {
+        const payload = { action, presetId, name };
+        await vscode.post(CommandId.UiManageCustomPreset, payload);
+        await loadPresets();
+        await setSelectedPresetByName(name);
+      }
+      break;
+    }
+
+    case 'update':
+      if (isCustom && Object.keys(options).length !== 0) {
+        const payload = { action, presetId, options };
+        await vscode.post(CommandId.UiManageCustomPreset, payload);
+        await setSelectedPresetAt(data.selected.presetIndex);
+      }
+      break;
+
+    case 'delete':
+      if (isCustom) {
+        const payload = { action, presetId };
+        await vscode.post(CommandId.UiManageCustomPreset, payload);
+        await loadPresets();
+        await setSelectedPresetAt(Math.max(0, data.selected.presetIndex - 1));
+      }
+      break;
+  }
+}
+
+export function validatePresetName(name: string): string | undefined {
+  const current = data.selected.preset?.name;
+  if (name.trim() === current) {
+    return undefined;
+  }
+
+  const m = texts.wizard.presetNameErrors;
+  const taken = data.presets.map((p) => {
+    return p.name;
+  });
+  const schema = z
+    .string()
+    .trim()
+    .nonempty({ message: m.empty })
+    .max(30, { message: m.tooLong })
+    .regex(/^[a-zA-Z0-9_-]+$/i, { message: m.invalid })
+    .refine((v) => !taken.includes(v), { message: m.alreadyTaken });
+
+  const result = schema.safeParse(name);
+  if (!result.success) {
+    return result.error.errors[0].message;
+  }
+
+  return undefined;
+}
+
 async function loadPresets() {
   if (!data.serverReady) return;
 
@@ -174,7 +283,7 @@ function loadDefaultWorkingDir() {
 
 async function selectAnyPresetAndValidate() {
   if (data.presets.length > 0) {
-    await setSelectedPreset(data.presets[0], 0);
+    await setSelectedPresetAt(0);
     await validateInput();
   }
 }

--- a/qt-core/webview-ui/src/comps/ConfirmDialog.svelte
+++ b/qt-core/webview-ui/src/comps/ConfirmDialog.svelte
@@ -1,0 +1,52 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { Modal, Button, P } from 'flowbite-svelte';
+
+  let {
+    open = $bindable(true),
+    text = '<Title>',
+    acceptText = '<Accept>',
+    rejectText = '<Reject>',
+    onAccepted = () => {},
+    onRejected = () => {}
+  } = $props();
+
+  function onAcceptClicked() {
+    open = false;
+    onAccepted();
+  }
+
+  function onRejectClicked() {
+    open = false;
+    onRejected();
+  }
+</script>
+
+<Modal
+  bind:open
+  color="none"
+  class="qt-popup"
+  size="sm"
+  classBackdrop="qt-popup-backdrop"
+  bodyClass="p-4"
+  outsideclose
+  on:close={() => {
+    onRejected();
+  }}
+>
+  <P class="qt-label dialog pb-3">{text}</P>
+
+  <div class="flex flex-row gap-2 mt-5">
+    <div class="grow"></div>
+    <Button class="qt-button" on:click={onAcceptClicked}>
+      {acceptText}
+    </Button>
+    <Button class="qt-button" on:click={onRejectClicked}>
+      {rejectText}
+    </Button>
+  </div>
+</Modal>

--- a/qt-core/webview-ui/src/comps/IconButton.svelte
+++ b/qt-core/webview-ui/src/comps/IconButton.svelte
@@ -4,24 +4,28 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
-  import { Button } from 'flowbite-svelte';
+  import type { Placement } from '@floating-ui/dom';
+  import { Button, Tooltip } from 'flowbite-svelte';
   import { CheckOutline } from 'flowbite-svelte-icons';
 
   let {
     id = '',
     text = '',
+    tooltip = '',
+    tooltipPlacement = 'top' as Placement,
     icon = CheckOutline,
     flat = false,
     visible = true,
     disabled = false,
-    onClicked
+    class: className = '',
+    onClicked = () => {}
   } = $props();
 </script>
 
 {#if visible}
   <Button
     {disabled}
-    class={`qt-button ${flat ? 'flat' : ''}`}
+    class={`qt-button ${flat ? 'flat' : ''} ${className}`}
     on:click={() => {
       onClicked(id);
     }}
@@ -32,4 +36,15 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
     {/if}
     {text}
   </Button>
+
+  {#if tooltip.length !== 0}
+    <Tooltip
+      placement={tooltipPlacement}
+      data-placement={tooltipPlacement}
+      class="qt-tooltip"
+      offset={10}
+    >
+      {tooltip}
+    </Tooltip>
+  {/if}
 {/if}

--- a/qt-core/webview-ui/src/comps/InputDialog.svelte
+++ b/qt-core/webview-ui/src/comps/InputDialog.svelte
@@ -1,0 +1,93 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { Modal, Button, P } from 'flowbite-svelte';
+
+  import InputWithIssue from './InputWithIssue.svelte';
+
+  let {
+    open = $bindable(true),
+    text = '<Title>',
+    acceptText = '<Accept>',
+    rejectText = '<Reject>',
+    value = $bindable(''),
+    level = '',
+    message = undefined as string | undefined,
+    acceptOnEnter = false,
+    onReady = () => {},
+    onInput = () => {},
+    onAccepted = (_: string) => {},
+    onRejected = () => {}
+  } = $props();
+
+  let inputComp: InputWithIssue | undefined;
+  let acceptable = $derived(level !== 'error');
+
+  function onAcceptClicked() {
+    open = false;
+    onAccepted(value);
+  }
+
+  function onRejectClicked() {
+    open = false;
+    onRejected();
+  }
+
+  function onEnter() {
+    if (acceptOnEnter) {
+      onAcceptClicked();
+    }
+  }
+
+  onMount(() => {
+    onReady();
+    setTimeout(() => {
+      inputComp?.focus();
+    }, 0);
+  });
+</script>
+
+<Modal
+  bind:open
+  color="none"
+  class="qt-popup"
+  size="sm"
+  classBackdrop="qt-popup-backdrop"
+  bodyClass="p-4"
+  outsideclose
+  on:close={() => {
+    onRejectClicked();
+  }}
+>
+  <P class="qt-label dialog pb-3">{text}</P>
+
+  <div class="flex flex-col gap-2">
+    <InputWithIssue
+      bind:this={inputComp}
+      bind:value
+      {level}
+      {message}
+      alertPosition="bottom"
+      {onInput}
+      {onEnter}
+    />
+
+    <div class="flex flex-row gap-2">
+      <div class="grow"></div>
+      <Button class="qt-button min-w-[75px] flat" on:click={onRejectClicked}>
+        {rejectText}
+      </Button>
+      <Button
+        class="qt-button min-w-[75px]"
+        disabled={!acceptable}
+        on:click={onAcceptClicked}
+      >
+        {acceptText}
+      </Button>
+    </div>
+  </div>
+</Modal>

--- a/qt-core/webview-ui/src/comps/InputWithIssue.svelte
+++ b/qt-core/webview-ui/src/comps/InputWithIssue.svelte
@@ -1,27 +1,37 @@
 <!--
 Copyright (C) 2025 The Qt Company Ltd.
-SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only 
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
+  import { nanoid } from 'nanoid';
   import { Input, Button, Alert } from 'flowbite-svelte';
   import { CircleMinusSolid, InfoCircleOutline } from 'flowbite-svelte-icons';
 
   let {
     value = $bindable(''),
-    onInput,
     level = '',
-    message = undefined,
+    message = undefined as string | undefined,
+    alertPosition = 'top' as 'top' | 'bottom',
+    class: className = '',
+    onInput,
+    onEnter = () => {},
     ...restProps
   } = $props();
 
-  const id = 'input_name';
+  const id = `input_${nanoid()}`;
   let hovered = $state(false);
   let focused = $state(false);
-  let hasIssue = $derived(message && message.length > 0);
+  let hasIssue = $derived(message !== undefined && message.length > 0);
 
   export function focus() {
     document.getElementById(id)?.focus();
+  }
+
+  function onKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      onEnter();
+    }
   }
 </script>
 
@@ -30,7 +40,9 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
     <Alert
       border
       color="none"
-      class="absolute w-full bottom-full -mb-0.5 qt-alert"
+      class={`qt-alert absolute w-full z-1
+        ${alertPosition === 'top' ? 'bottom-full -mb-0.5' : 'top-full -mt-0.5'}
+      `}
     >
       {message}
     </Alert>
@@ -39,8 +51,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   <Input
     {id}
     type="text"
-    required
-    class={`qt-input ${hasIssue ? 'error' : ''}`}
+    class={`qt-input ${hasIssue ? 'error' : ''} ${className}`}
     bind:value
     onblur={() => {
       focused = false;
@@ -50,6 +61,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
       (e.target as HTMLInputElement).select();
       focused = true;
     }}
+    on:keydown={onKeyDown}
     {...restProps}
   >
     <Button

--- a/qt-core/webview-ui/src/comps/Picker.svelte
+++ b/qt-core/webview-ui/src/comps/Picker.svelte
@@ -1,0 +1,71 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  import type { PickerItem } from '@/app/types.svelte';
+  import PickerList from './PickerList.svelte';
+  import PickerTrigger from './PickerTrigger.svelte';
+
+  let {
+    open = $bindable(false),
+    showIcon = true,
+    items = [] as PickerItem[],
+    defaultText = '',
+    onSelected = (_: number) => {}
+  } = $props();
+
+  let width = $state(100);
+  let currentIndex = $state(-1);
+  let pickerList: PickerList;
+
+  function onRejected() {
+    open = false;
+  }
+
+  function onAccepted(i: number) {
+    open = false;
+    currentIndex = i;
+    onSelected(currentIndex);
+  }
+
+  function onTriggered(r: DOMRect) {
+    if (open) {
+      open = false;
+      return;
+    }
+
+    open = true;
+    width = r.width;
+    pickerList.focus();
+    updateIndexFromDefault();
+  }
+
+  function updateIndexFromDefault() {
+    if (currentIndex === -1 && defaultText.length > 0) {
+      currentIndex = items.findIndex((e) => e.text === defaultText);
+    }
+  }
+
+  onMount(updateIndexFromDefault);
+</script>
+
+<PickerTrigger
+  text={items[currentIndex]?.text ?? '-'}
+  active={open}
+  {onTriggered}
+/>
+
+<PickerList
+  bind:this={pickerList}
+  active={open}
+  {items}
+  {width}
+  {showIcon}
+  {onAccepted}
+  {onRejected}
+  {currentIndex}
+/>

--- a/qt-core/webview-ui/src/comps/PickerList.svelte
+++ b/qt-core/webview-ui/src/comps/PickerList.svelte
@@ -1,0 +1,95 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { nanoid } from 'nanoid';
+  import { P, Dropdown } from 'flowbite-svelte';
+
+  import { textOrFallback } from '@/utils/utils';
+  import type { PickerItem } from '@/app/types.svelte';
+  import { onMount } from 'svelte';
+
+  let {
+    active = false,
+    width = -1,
+    offset = 1,
+    showIcon = true,
+    items = [] as PickerItem[],
+    currentIndex = -1,
+    onRejected = () => {},
+    onAccepted = (_: number) => {}
+  } = $props();
+
+  const id = `pickerlist_${nanoid()}`;
+
+  function setCurrentIndex(i: number) {
+    const candidate = Math.max(0, Math.min(i, items.length - 1));
+    if (currentIndex !== candidate) {
+      currentIndex = candidate;
+    }
+  }
+
+  function onItemClicked(i: number) {
+    setCurrentIndex(i);
+    onAccepted(currentIndex);
+  }
+
+  function onKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      onRejected();
+    } else if (e.key === 'Enter') {
+      onAccepted(currentIndex);
+    } else if (e.key === 'ArrowDown') {
+      setCurrentIndex((currentIndex + 1) % items.length);
+    } else if (e.key === 'ArrowUp') {
+      setCurrentIndex((currentIndex - 1 + items.length) % items.length);
+    } else {
+      return;
+    }
+
+    e.preventDefault();
+  }
+
+  export function focus() {
+    requestAnimationFrame(() => {
+      document.getElementById(id)?.focus();
+    });
+  }
+
+  onMount(focus);
+</script>
+
+<Dropdown
+  {id}
+  open={active}
+  classContainer="qt-list"
+  style={`width: ${width - 1}px`}
+  {offset}
+  tabindex={0}
+  onkeydown={onKeyDown}
+  onblur={() => {
+    onRejected();
+  }}
+>
+  {#each items as item, i (i)}
+    <P
+      role="option"
+      class={`
+        flex flex-row gap-2 items-center
+        qt-list-item ${i === currentIndex ? 'selected' : ''}`}
+      onclick={() => onItemClicked(i)}
+    >
+      {#if showIcon}
+        {@const IconComp = item.icon}
+        {#if IconComp}
+          <IconComp class="aspect-square h-5" />
+        {:else}
+          <div class="aspect-square h-5"></div>
+        {/if}
+      {/if}
+      {textOrFallback(item.text)}
+    </P>
+  {/each}
+</Dropdown>

--- a/qt-core/webview-ui/src/comps/PickerTrigger.svelte
+++ b/qt-core/webview-ui/src/comps/PickerTrigger.svelte
@@ -1,0 +1,34 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { ChevronDownOutline } from 'flowbite-svelte-icons';
+
+  import { textOrFallback } from '@/utils/utils';
+
+  let {
+    text = '-',
+    active = false,
+    onTriggered = (_: DOMRect) => {}
+  } = $props();
+
+  let el: HTMLButtonElement;
+
+  function onClicked(_: MouseEvent) {
+    onTriggered(el.getBoundingClientRect());
+  }
+</script>
+
+<button
+  class={`
+    w-full flex items-center justify-between
+    qt-picker-trigger ${active ? 'active' : ''}
+  `}
+  bind:this={el}
+  onclick={onClicked}
+>
+  <div class="truncate">{textOrFallback(text)}</div>
+  <ChevronDownOutline class="w-4 h-4" />
+</button>

--- a/qt-core/webview-ui/src/comps/TruncatableLabel.svelte
+++ b/qt-core/webview-ui/src/comps/TruncatableLabel.svelte
@@ -1,0 +1,37 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+
+  let {
+    text = '',
+    truncated = $bindable(false),
+    class: className = ''
+  } = $props();
+
+  let el: HTMLDivElement;
+
+  function updateFlag() {
+    truncated = el && el.scrollWidth > el.clientWidth;
+  }
+
+  $effect(() => {
+    updateFlag();
+  });
+
+  onMount(() => {
+    updateFlag();
+    window.addEventListener('resize', updateFlag);
+  });
+
+  onDestroy(() => {
+    window.removeEventListener('resize', updateFlag);
+  });
+</script>
+
+<div bind:this={el} class={`truncate ${className}`}>
+  {text}
+</div>

--- a/qt-core/webview-ui/src/styles/styles.css
+++ b/qt-core/webview-ui/src/styles/styles.css
@@ -33,7 +33,7 @@ html {
 .qt-label.highlight {
   color: var(--qt-text-highlight);
   font-size: 1.1rem;
-  @apply font-semibold
+  @apply font-semibold;
 }
 
 /* modal */
@@ -76,6 +76,12 @@ html {
 .qt-button.flat:hover {
   color: var(--qt-button-text);
   background: var(--qt-button-fillHover);
+}
+
+.qt-button.flat-borderless {
+  color: var(--qt-text-normal);
+  background: transparent;
+  border: 1px solid transparent;
 }
 
 .qt-button:disabled {
@@ -242,6 +248,31 @@ html {
   background: var(--qt-itemSelection-fill);
 }
 
+/* picker (combobox, menu, etc) */
+.qt-picker-trigger {
+  color: var(--vscode-dropdown-foreground);
+  background-color: var(--vscode-dropdown-background);
+  border-color: var(--vscode-settings-dropdownBorder);
+  border-width: 1px;
+  border-radius: var(--qt-border-radius);
+  cursor: pointer;
+  line-height: 2;
+  font-weight: normal;
+  box-shadow: none;
+  @apply px-2;
+}
+
+.qt-picker-trigger.active,
+.qt-picker-trigger:hover {
+  color: var(--vscode-button-foreground);
+  background-color: var(--vscode-button-background);
+  border: 1px solid var(--vscode-widget-border, transparent);
+}
+
+.qt-picker-trigger:focus-visible {
+  @apply qt-focusRing;
+}
+
 /* alert - for bad inputs, etc. */
 .qt-alert {
   opacity: 90%;
@@ -258,8 +289,15 @@ html {
 }
 
 /* others */
-.qt-simple-table {
-  color: var(--qt-widget-separator);
-  @apply bg-transparent;
-  @apply text-base;
+.qt-popup {
+  background: var(--vscode-sideBar-background);
+  border: 1px solid var(--vscode-focusBorder);
+  border-radius: var(--qt-border-radius);
+  @apply translate-y-[100px];
+  @apply md:-translate-y-[100px];
+  @apply shadow-lg;
+}
+
+.qt-popup-backdrop {
+  @apply bg-white/5;
 }

--- a/qt-core/webview-ui/src/utils/utils.ts
+++ b/qt-core/webview-ui/src/utils/utils.ts
@@ -1,0 +1,15 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+export function textOrFallback(text: string, fallback = '-') {
+  return text.trim().length === 0 ? fallback : text;
+}
+
+export function toBool(value: unknown): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value !== 0;
+  if (value == null) return false;
+
+  const s = String(value).toLowerCase();
+  return ['true', '1', 'yes', 'on'].includes(s);
+}


### PR DESCRIPTION
- Add components for editing presets, 
   including option controls and dialogs for text input and confirmation.
- Update layouts: add delete/rename buttons to the preset list 
   and create/update buttons to the options section.
- Improve axios error parsing
- Ensure qt-cli never returns 'null' in the details field to simplify frontend handling.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
