### PR TITLE
qt-cli: Fix errors in Qt Widgets application template

### DIFF
--- a/qt-cli/src/assets/templates/projects/cpp/qwidget/main.cpp
+++ b/qt-cli/src/assets/templates/projects/cpp/qwidget/main.cpp
@@ -3,7 +3,7 @@
 #include <QLocale>
 #include <QTranslator>
 {{- end }}
-#include "mainwindow.h"
+#include "{{ .fileNameBase }}.h"
 
 int main(int argc, char *argv[])
 {

--- a/qt-cli/src/assets/templates/projects/cpp/qwidget/mainwindow.cpp
+++ b/qt-cli/src/assets/templates/projects/cpp/qwidget/mainwindow.cpp
@@ -5,7 +5,9 @@
 
 {{ .className }}::{{ .className }}(QWidget *parent)
     : {{ .baseClass }}(parent)
+{{- if .useForm }}
     , ui(new Ui::{{ .className }})
+{{- end }}
 {
 {{- if .useForm }}
     ui->setupUi(this);


### PR DESCRIPTION
Fixes two issues in `@projects/cpp/qwidget` template:
- Incorrect header file name in `main.cpp`
- Incorrect ui variable initialization in the class constructor.

Both issues may cause build failures when the base class is not QMainWindow.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
