### PR TITLE
qt-cli: Enable wrapping in prompt list navigation

### DIFF
--- a/qt-cli/src/prompt/comps/list.go
+++ b/qt-cli/src/prompt/comps/list.go
@@ -78,6 +78,7 @@ func (p *ListPrompt) Run() (prompt.Result, error) {
 	l.SetShowStatusBar(false)
 	l.SetFilteringEnabled(false)
 	l.SetShowPagination(false)
+	l.InfiniteScrolling = true
 
 	if p.initIndex >= 0 && p.initIndex < count {
 		l.Select(p.initIndex)


### PR DESCRIPTION
Improves user experience by allowing users to cycle through the prompt list seamlessly.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
