### PR TITLE
qt-ui: Add "Open with Text Editor" button

### DIFF
--- a/qt-ui/package.json
+++ b/qt-ui/package.json
@@ -34,7 +34,7 @@
   "contributes": {
     "configurationDefaults": {
       "workbench.editorAssociations": {
-        "{git,gitlens}:/**/*.ui": "default"
+        "{git,gitlens,chat-editing-snapshot-text-model,copilot,git-graph,git-graph-3}:/**/*.ui": "default"
       }
     },
     "commands": [

--- a/qt-ui/src/editors/ui/ui-editor.ts
+++ b/qt-ui/src/editors/ui/ui-editor.ts
@@ -43,7 +43,7 @@ export class UIEditorProvider implements vscode.CustomTextEditorProvider {
       if (project === undefined) {
         const err = `Project not found for file: ${document.uri.toString()}`;
         logger.error(err);
-        throw new Error(err);
+        return;
       }
       const designerServer = project.designerServer;
       const designerClient = project.designerClient;
@@ -57,7 +57,7 @@ export class UIEditorProvider implements vscode.CustomTextEditorProvider {
               askForKitSelection();
             }
             logger.error('Designer client not found');
-            throw new Error('Designer client not found');
+            return;
           }
           if (!designerClient.isRunning()) {
             logger.info(`Starting designer client:${designerClient.exe}`);
@@ -77,7 +77,7 @@ export class UIEditorProvider implements vscode.CustomTextEditorProvider {
           break;
         default:
           logger.error('Unknown message type');
-          throw new Error('Unknown message type');
+          return;
       }
     });
     return Promise.resolve();

--- a/qt-ui/src/editors/ui/ui-editor.ts
+++ b/qt-ui/src/editors/ui/ui-editor.ts
@@ -39,17 +39,18 @@ export class UIEditorProvider implements vscode.CustomTextEditorProvider {
     };
     webviewPanel.webview.html = this.getHtmlForWebview(webviewPanel.webview);
     webviewPanel.webview.onDidReceiveMessage(async (e: { type: string }) => {
-      const project = projectManager.findProjectContainingFile(document.uri);
-      if (project === undefined) {
-        const err = `Project not found for file: ${document.uri.toString()}`;
-        logger.error(err);
-        return;
-      }
-      const designerServer = project.designerServer;
-      const designerClient = project.designerClient;
-
       switch (e.type) {
-        case 'run':
+        case 'run': {
+          const project = projectManager.findProjectContainingFile(
+            document.uri
+          );
+          if (project === undefined) {
+            const err = `Project not found for file: ${document.uri.toString()}`;
+            logger.error(err);
+            return;
+          }
+          const designerServer = project.designerServer;
+          const designerClient = project.designerClient;
           if (designerClient === undefined) {
             // User may not have selected the kit.
             // We can check and ask for kit selection.
@@ -72,9 +73,11 @@ export class UIEditorProvider implements vscode.CustomTextEditorProvider {
           designerServer.sendFile(document.uri.fsPath);
           logger.info('File sent to designer server: ' + document.uri.fsPath);
           break;
-        case 'openWithTextEditor':
+        }
+        case 'openWithTextEditor': {
           void UIEditorProvider.openWithTextEditor(document);
           break;
+        }
         default:
           logger.error('Unknown message type');
           return;

--- a/qt-ui/src/editors/ui/ui-editor.ts
+++ b/qt-ui/src/editors/ui/ui-editor.ts
@@ -72,6 +72,9 @@ export class UIEditorProvider implements vscode.CustomTextEditorProvider {
           designerServer.sendFile(document.uri.fsPath);
           logger.info('File sent to designer server: ' + document.uri.fsPath);
           break;
+        case 'openWithTextEditor':
+          void UIEditorProvider.openWithTextEditor(document);
+          break;
         default:
           logger.error('Unknown message type');
           throw new Error('Unknown message type');
@@ -79,7 +82,27 @@ export class UIEditorProvider implements vscode.CustomTextEditorProvider {
     });
     return Promise.resolve();
   }
-
+  private static async openWithTextEditor(
+    document: vscode.TextDocument
+  ): Promise<void> {
+    // Reveal the file in the current editor tab instead of opening a new one
+    await vscode.commands.executeCommand(
+      'workbench.action.revertAndCloseActiveEditor'
+    );
+    await vscode.commands.executeCommand(
+      'vscode.openWith',
+      document.uri,
+      'default',
+      {
+        preview: false,
+        preserveFocus: false
+      }
+    );
+    telemetry.sendAction('openWithTextEditor');
+    logger.info(
+      'File opened with text editor in current tab: ' + document.uri.fsPath
+    );
+  }
   private getHtmlForWebview(webview: vscode.Webview): string {
     // Use a nonce to whitelist which scripts can be run
     const nonce = getNonce();
@@ -113,6 +136,7 @@ export class UIEditorProvider implements vscode.CustomTextEditorProvider {
     <body>
       <div>
         <vscode-button id="openWithDesignerButton" tabindex="0">Open this file with Qt Widgets Designer</vscode-button>
+        <vscode-button id="openWithTextEditorButton" tabindex="0" style="margin-left: 12px;">Open this file with Text Editor</vscode-button>
       </div>
       <script type="module" nonce="${nonce}" src="${scriptUri.toString()}"></script>
     </body>

--- a/qt-ui/src/editors/ui/ui-editor.ts
+++ b/qt-ui/src/editors/ui/ui-editor.ts
@@ -41,8 +41,9 @@ export class UIEditorProvider implements vscode.CustomTextEditorProvider {
     webviewPanel.webview.onDidReceiveMessage(async (e: { type: string }) => {
       const project = projectManager.findProjectContainingFile(document.uri);
       if (project === undefined) {
-        logger.error('Project not found');
-        throw new Error('Project not found');
+        const err = `Project not found for file: ${document.uri.toString()}`;
+        logger.error(err);
+        throw new Error(err);
       }
       const designerServer = project.designerServer;
       const designerClient = project.designerClient;

--- a/qt-ui/src/editors/ui/webview-ui/main.ts
+++ b/qt-ui/src/editors/ui/webview-ui/main.ts
@@ -18,6 +18,9 @@ function main() {
   const openWithDesignerButton = document.getElementById(
     'openWithDesignerButton'
   );
+  const openWithTextEditorButton = document.getElementById(
+    'openWithTextEditorButton'
+  );
   if (openWithDesignerButton) {
     openWithDesignerButton.focus();
   }
@@ -26,27 +29,45 @@ function main() {
       type: 'run'
     });
   }
+  function onOpenWithTextEditorButtonClick() {
+    vscode.postMessage({
+      type: 'openWithTextEditor'
+    });
+  }
   openWithDesignerButton?.addEventListener(
     'click',
     onOpenWithDesignerButtonClick
   );
-
   openWithDesignerButton?.addEventListener('keydown', function (event) {
     if (event.key === 'Enter') {
       event.preventDefault();
       onOpenWithDesignerButtonClick();
     }
   });
+  openWithTextEditorButton?.addEventListener(
+    'click',
+    onOpenWithTextEditorButtonClick
+  );
+  openWithTextEditorButton?.addEventListener('keydown', function (event) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      onOpenWithTextEditorButtonClick();
+    }
+  });
   document.addEventListener('keydown', function (event) {
-    // if any arrow key is pressed, focus the this button
+    // Toggle focus between the two buttons with arrow keys
     if (
-      event.key === 'ArrowUp' ||
-      event.key === 'ArrowDown' ||
       event.key === 'ArrowLeft' ||
-      event.key === 'ArrowRight'
+      event.key === 'ArrowUp'
     ) {
       event.preventDefault();
       openWithDesignerButton?.focus();
+    } else if (
+      event.key === 'ArrowRight' ||
+      event.key === 'ArrowDown'
+    ) {
+      event.preventDefault();
+      openWithTextEditorButton?.focus();
     }
   });
 }


### PR DESCRIPTION
- Add a new button next to "Open with Qt Widgets Designer" to open .ui files in the default text editor.
- Implement frontend and backend logic to handle the new action.
- Improve keyboard navigation between the two buttons.
- Ensure the file is opened in the same tab, replacing the custom editor.
- Use built-in text editor for the below extensions:
    * copilot
    * git-graph
    * git-graph-3


Fixes: [VSCODEEXT-189](https://bugreports.qt.io/browse/VSCODEEXT-189)
Fixes: [VSCODEEXT-149](https://bugreports.qt.io/browse/VSCODEEXT-149)
<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
