### PR TITLE
qt-cli: Clean up stale socket and pid files

### DIFF
--- a/qt-cli/src/server/server.go
+++ b/qt-cli/src/server/server.go
@@ -46,6 +46,8 @@ func getNetListener(o Options) (net.Listener, error) {
 }
 
 func Start(o Options) {
+	ensurePrevRunStopped(pidFile)
+
 	listener, err := getNetListener(o)
 	if err != nil {
 		logrus.Fatalf("Cannot open listener: %v", err)
@@ -57,9 +59,7 @@ func Start(o Options) {
 	}
 
 	go func() {
-		ensurePrevRunStopped(pidFile)
 		savePidToFile(os.Getpid(), pidFile)
-
 		logrus.Infof("Starting server at %s", listener.Addr().String())
 		if err := server.Serve(listener); err != nil {
 			logrus.Fatalf("Server error: %v", err)
@@ -71,12 +71,13 @@ func Start(o Options) {
 	<-quit
 
 	logrus.Info("Shutting down server...")
+	os.Remove(pidFile)
+
 	if err := server.Close(); err != nil {
 		logrus.Fatalf("Server close error: %v", err)
 	}
 
 	logrus.Info("Server stopped")
-	os.Remove(pidFile)
 }
 
 func Stop() {

--- a/qt-cli/src/server/server_others.go
+++ b/qt-cli/src/server/server_others.go
@@ -8,6 +8,7 @@ package server
 import (
 	"net"
 	"os"
+	"path/filepath"
 )
 
 const TempDir = "/tmp/qtcli"
@@ -17,7 +18,7 @@ func getPidFilePath() string {
 		return ""
 	}
 
-	return TempDir + "/qtcli-server.pid"
+	return filepath.Join(TempDir, "qtcli-server.pid")
 }
 
 func getLocalIpcListener() (net.Listener, error) {
@@ -25,5 +26,14 @@ func getLocalIpcListener() (net.Listener, error) {
 		return nil, err
 	}
 
-	return net.Listen("unix", TempDir+"/qtcli-server.sock")
+	fullPath := filepath.Join(TempDir, "qtcli-server.sock")
+	_, err := os.Stat(fullPath)
+	if !os.IsNotExist(err) {
+		err := os.Remove(fullPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return net.Listen("unix", fullPath)
 }


### PR DESCRIPTION
If qt-cli is killed during server mode,
the UDS socket file may remain and block future starts. 
This patch removes the socket file before binding
to avoid a potential startup failure caused by stale sockets.

The pid file is also deleted early to avoid leaving stale files on unexpected exits.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
