### PR TITLE
qt-cli: Include license information in package

### DIFF
--- a/.github/actions/build-qtcli/action.yml
+++ b/.github/actions/build-qtcli/action.yml
@@ -65,5 +65,7 @@ runs:
       run: |
         mkdir -p ${{ inputs.deploy-target }}
         cp -r ${{ inputs.working-directory }}/dist/bin/qtcli-* ${{ inputs.deploy-target }}
+        cp ${{ inputs.working-directory }}/LICENSE ${{ inputs.deploy-target }}
+        cp ${{ inputs.working-directory }}/ThirdPartyNotices.txt ${{ inputs.deploy-target }}
         echo "---------------------------------"
         cd ${{ inputs.deploy-target }} && find . && du -h


### PR DESCRIPTION
The following files are now included in the package:
- `LICENSE`
- `ThirdPartyNotices.txt`

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
