### PR TITLE
qt-core/webview: Fix to include option changes in the request

### DIFF
--- a/qt-core/webview-ui/src/app/viewlogic.svelte.ts
+++ b/qt-core/webview-ui/src/app/viewlogic.svelte.ts
@@ -112,6 +112,7 @@ export async function createItemFromSelectedPreset() {
       name: input.name,
       workingDir: input.workingDir,
       presetId: data.selected.preset?.id,
+      options: $state.snapshot(ui.unsavedOptionChanges),
       saveProjectDir: input.saveProjectDir
     });
   } catch (e) {


### PR DESCRIPTION
The 'options' field was missing when requesting item creation, causing user-selected options to be ignored.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
