### PR TITLE
qt-core/webview: Disable timeout for working directory selection

### DIFF
--- a/qt-core/webview-ui/src/app/viewlogic.svelte.ts
+++ b/qt-core/webview-ui/src/app/viewlogic.svelte.ts
@@ -32,8 +32,9 @@ export function onModalClosed() {
 }
 
 export function onWorkingDirBrowseClicked() {
+  const timeout = -1;
   void vscode
-    .post(CommandId.UiSelectWorkingDir, input.workingDir)
+    .post(CommandId.UiSelectWorkingDir, input.workingDir, timeout)
     .then((data) => {
       if (typeof data === 'string' && input.workingDir != data) {
         input.workingDir = data;


### PR DESCRIPTION
There’s a default timeout for frontend-backend communication. 
Since selecting a working directory can take longer, this patch disables the timeout for this specific request.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
