### PR TITLE
qt-core: Set default URI for Qt installation root in registerQt command

### DIFF
--- a/qt-core/src/installation-root.ts
+++ b/qt-core/src/installation-root.ts
@@ -65,16 +65,7 @@ function getConfiguration() {
   return vscode.workspace.getConfiguration(EXTENSION_ID);
 }
 
-export function checkDefaultQtInsRootPath() {
-  if (getDoNotAskForDefaultQtInstallationRoot()) {
-    return;
-  }
-
-  if (getCurrentGlobalQtInstallationRoot()) {
-    // Qt installation root is already set. No need to check for default path
-    return;
-  }
-
+function getPossibleDefaultQtInstallationRoot() {
   if (!IsUnix && !IsWindows) {
     const errorMessage = 'Unsupported OS';
     logger.error(errorMessage);
@@ -131,6 +122,20 @@ export function checkDefaultQtInsRootPath() {
   const foundDefaultPath = defaultPaths.find((defPath) =>
     fs.existsSync(defPath)
   );
+  return foundDefaultPath;
+}
+
+export function checkDefaultQtInsRootPath() {
+  if (getDoNotAskForDefaultQtInstallationRoot()) {
+    return;
+  }
+
+  if (getCurrentGlobalQtInstallationRoot()) {
+    // Qt installation root is already set. No need to check for default path
+    return;
+  }
+
+  const foundDefaultPath = getPossibleDefaultQtInstallationRoot();
   if (!foundDefaultPath) {
     return;
   }

--- a/qt-core/src/installation-root.ts
+++ b/qt-core/src/installation-root.ts
@@ -166,6 +166,10 @@ export async function registerQt() {
     canSelectFiles: false,
     canSelectFolders: true
   };
+  const defaultQtInsRoot = getPossibleDefaultQtInstallationRoot();
+  if (defaultQtInsRoot) {
+    options.defaultUri = vscode.Uri.file(defaultQtInsRoot);
+  }
   const selectedQtInsRootUri = await vscode.window.showOpenDialog(options);
   if (selectedQtInsRootUri?.[0] === undefined) {
     return;


### PR DESCRIPTION
* [qt-core: Set default URI for Qt installation root in registerQt command](https://github.com/qt-labs/vscodeext/commit/025c606da4faca4e4fa09420aaeffcddfb1ed416)
* [Factor out finding the default Qt installation root](https://github.com/qt-labs/vscodeext/commit/77849bc3cc22a00b49f80ec4f5fa620049af8c01)

Fixes: [VSCODEEXT-157](https://bugreports.qt.io/browse/VSCODEEXT-157)
<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
