### PR TITLE
qt-core/webview: Increase retry duration for /ready check to qtcli

### DIFF
--- a/qt-core/src/qtcli/rest.ts
+++ b/qt-core/src/qtcli/rest.ts
@@ -17,7 +17,7 @@ export class QtcliRestClient {
         : String.raw`\\.\pipe\qtcli\qtcli-server.pipe`
   });
 
-  private readonly _maxRetries = 20;
+  private readonly _maxRetries = 75;
   private readonly _retryDelay = 200;
 
   // convenients


### PR DESCRIPTION
When webview starts, it launches qtcli as a REST server 
and waits for it to become ready by polling the /ready endpoint.

This patch increases the retry limit to allow more time for startup, 
extending the wait window from 4 to 15 seconds.
It is to make it safer to use in slower enviornments.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
