### PR TITLE
qt-cpp: qt-qml: Add `sourceFileMap` to launch configurations

### DIFF
--- a/qt-cpp/package.json
+++ b/qt-cpp/package.json
@@ -73,6 +73,11 @@
           "default": false,
           "markdownDescription": "Do not ask for setting [`#cmake.cmakePath#`](https://vector-of-bool.github.io/docs/vscode-cmake-tools/settings.html#cmake-cmakepath).\n\nCMake Tools search the PATH environment variable, and make some \n\neducated guesses on where to find CMake.",
           "scope": "machine"
+        },
+        "qt-cpp.doNotWarnMissingSourceDir": {
+          "type": "boolean",
+          "default": false,
+          "description": "Do not show a warning when the source directory cannot be determined from the selected kit."
         }
       }
     },
@@ -102,12 +107,25 @@
               "showDisplayString": true,
               "linux": {
                 "MIMode": "gdb",
-                "miDebuggerPath": "/usr/bin/gdb"
+                "miDebuggerPath": "/usr/bin/gdb",
+                "sourceFileMap": {
+                  "/home/qt/work/qt": "^\"\\${command:qt-cpp.sourceDirectory}\""
+                }
               },
               "osx": {
-                "MIMode": "lldb"
+                "MIMode": "lldb",
+                "sourceFileMap": {
+                  "/Users/qt/work/qt": "^\"\\${command:qt-cpp.sourceDirectory}\""
+                }
               },
               "windows": {
+                "sourceFileMap": {
+                  "Q:/qt5_workdir/w/s": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "C:/work/build/qt5_workdir/w/s": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "c:/users/qt/work/qt": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "c:/Users/qt/work/install": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "/Users/qt/work/qt": "^\"\\${command:qt-cpp.sourceDirectory}\""
+                },
                 "environment": [
                   {
                     "name": "PATH",
@@ -141,12 +159,25 @@
               "showDisplayString": true,
               "linux": {
                 "MIMode": "lldb",
-                "miDebuggerPath": "/usr/bin/lldb"
+                "miDebuggerPath": "/usr/bin/lldb",
+                "sourceFileMap": {
+                  "/home/qt/work/qt": "^\"\\${command:qt-cpp.sourceDirectory}\""
+                }
               },
               "osx": {
-                "MIMode": "lldb"
+                "MIMode": "lldb",
+                "sourceFileMap": {
+                  "/Users/qt/work/qt": "^\"\\${command:qt-cpp.sourceDirectory}\""
+                }
               },
               "windows": {
+                "sourceFileMap": {
+                  "Q:/qt5_workdir/w/s": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "C:/work/build/qt5_workdir/w/s": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "c:/users/qt/work/qt": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "c:/Users/qt/work/install": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "/Users/qt/work/qt": "^\"\\${command:qt-cpp.sourceDirectory}\""
+                },
                 "environment": [
                   {
                     "name": "PATH",
@@ -177,6 +208,13 @@
               "cwd": "^\"\\${workspaceFolder}\"",
               "visualizerFile": "^\"\\${command:qt-cpp.natvis}\"",
               "windows": {
+                "sourceFileMap": {
+                  "Q:/qt5_workdir/w/s": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "C:/work/build/qt5_workdir/w/s": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "c:/users/qt/work/qt": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "c:/Users/qt/work/install": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "/Users/qt/work/qt": "^\"\\${command:qt-cpp.sourceDirectory}\""
+                },
                 "environment": [
                   {
                     "name": "PATH",

--- a/qt-cpp/src/commands/source-directory.ts
+++ b/qt-cpp/src/commands/source-directory.ts
@@ -1,0 +1,56 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+import { createLogger, telemetry } from 'qt-lib';
+import { getQtInsRoot, getSelectedKit } from '@cmd/register-qt-path';
+import { EXTENSION_ID } from '@/constants';
+
+const logger = createLogger('source-directory');
+
+export function registerSourceDirectoryCommand() {
+  return vscode.commands.registerCommand(
+    `${EXTENSION_ID}.sourceDirectory`,
+    async () => {
+      telemetry.sendAction('sourceDirectory');
+      const kit = await getSelectedKit();
+      if (!kit) {
+        return undefined;
+      }
+      const insRoot = getQtInsRoot(kit);
+      if (!insRoot) {
+        const config = vscode.workspace.getConfiguration(EXTENSION_ID);
+        const doNotWarn = config.get<boolean>(
+          'doNotWarnMissingSourceDir',
+          false
+        );
+        const message = `Cannot find VSCODE_QT_INSTALLATION in the selected kit: ${kit.name}. Source directory cannot be determined.`;
+        logger.error(message);
+        if (!doNotWarn) {
+          const doNotAskBtn = 'Do not show again';
+          void vscode.window
+            .showWarningMessage(message, doNotAskBtn)
+            .then((result) => {
+              if (result === doNotAskBtn) {
+                void config.update(
+                  'doNotWarnMissingSourceDir',
+                  true,
+                  vscode.ConfigurationTarget.Global
+                );
+              }
+            });
+        }
+        return undefined;
+      }
+      // Remove the last part of the path to get the source directory
+      // For example, if insRoot is '/path/to/Qt/6.5.0/gcc_64', we want to get '/path/to/Qt/6.5.0'
+      const versionDir = path.dirname(insRoot);
+      // Add the 'Src' directory to the path
+      const sourceDir = path.join(versionDir, 'Src');
+      logger.info(`Source directory for kit ${kit.name} is: ${sourceDir}`);
+      return sourceDir;
+    }
+  );
+}

--- a/qt-cpp/src/extension.ts
+++ b/qt-cpp/src/extension.ts
@@ -19,6 +19,7 @@ import { registerMinGWgdbCommand } from '@cmd/mingw-gdb';
 import { registerResetCommand } from '@cmd/reset-qt-ext';
 import { registerNatvisCommand } from '@cmd/natvis';
 import { registerScanForQtKitsCommand } from '@cmd/scan-qt-kits';
+import { registerSourceDirectoryCommand } from '@cmd/source-directory';
 import {
   registerbuildDirectoryName,
   registerlaunchTargetFilenameWithoutExtension,
@@ -67,7 +68,8 @@ export async function activate(context: vscode.ExtensionContext) {
     ...registerNatvisCommand(),
     registerScanForQtKitsCommand(),
     registerlaunchTargetFilenameWithoutExtension(),
-    registerbuildDirectoryName()
+    registerbuildDirectoryName(),
+    registerSourceDirectoryCommand()
   );
   telemetry.sendEvent(`activated`);
 

--- a/qt-qml/package.json
+++ b/qt-qml/package.json
@@ -293,12 +293,25 @@
               ],
               "linux": {
                 "MIMode": "gdb",
-                "miDebuggerPath": "/usr/bin/gdb"
+                "miDebuggerPath": "/usr/bin/gdb",
+                "sourceFileMap": {
+                  "/home/qt/work/qt": "^\"\\${command:qt-cpp.sourceDirectory}\""
+                }
               },
               "osx": {
-                "MIMode": "lldb"
+                "MIMode": "lldb",
+                "sourceFileMap": {
+                  "/Users/qt/work/qt": "^\"\\${command:qt-cpp.sourceDirectory}\""
+                }
               },
               "windows": {
+                "sourceFileMap": {
+                  "Q:/qt5_workdir/w/s": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "C:/work/build/qt5_workdir/w/s": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "c:/users/qt/work/qt": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "c:/Users/qt/work/install": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "/Users/qt/work/qt": "^\"\\${command:qt-cpp.sourceDirectory}\""
+                },
                 "environment": [
                   {
                     "name": "PATH",
@@ -333,6 +346,13 @@
                 "^\"-qmljsdebugger=host:localhost,port:\\${command:qt-qml.debugPort},block,services:DebugMessages,QmlDebugger,V8Debugger\""
               ],
               "windows": {
+                "sourceFileMap": {
+                  "Q:/qt5_workdir/w/s": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "C:/work/build/qt5_workdir/w/s": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "c:/users/qt/work/qt": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "c:/Users/qt/work/install": "^\"\\${command:qt-cpp.sourceDirectory}\"",
+                  "/Users/qt/work/qt": "^\"\\${command:qt-cpp.sourceDirectory}\""
+                },
                 "environment": [
                   {
                     "name": "PATH",


### PR DESCRIPTION
* Introduce `qt-cpp.sourceDirectory` command to retrieve the Qt source directory.
* Update `package.json` to include `sourceFileMap` for both GDB and LLDB configurations.
* Modify `extension.ts` to register the new command.
* Introduce `qt-cpp.doNotWarnMissingSourceDir` setting to suppress warnings.

Fixes: [VSCODEEXT-10](https://bugreports.qt.io/browse/VSCODEEXT-10)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
