### PR TITLE
qt-qml: Add Debugger to categories

### DIFF
--- a/qt-qml/package.json
+++ b/qt-qml/package.json
@@ -19,7 +19,8 @@
   "categories": [
     "Programming Languages",
     "Formatters",
-    "Snippets"
+    "Snippets",
+    "Debuggers"
   ],
   "keywords": [
     "Qt",


### PR DESCRIPTION
Since the qml debugger is now included in the extension, it makes sense to add "Debuggers" to the categories.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
