### PR TITLE
Doc: Switch tutorial app download link targets to github.com

### DIFF
--- a/doc/src/externallinks.qdoc
+++ b/doc/src/externallinks.qdoc
@@ -4,12 +4,12 @@
 ***************************************************************************************************/
 
 /*!
-\externalpage https://code.qt.io/cgit/qt-labs/vscodeext.git/tree/doc/tutorials/AddressBook
+\externalpage https://github.com/qt-labs/vscodeext/tree/dev/doc/tutorials/AddressBook
 \title Code: AddressBook
 */
 
 /*!
-\externalpage https://code.qt.io/cgit/qt-labs/vscodeext.git/tree/doc/tutorials/QuickAddressBook
+\externalpage https://github.com/qt-labs/vscodeext/tree/dev/doc/tutorials/QuickAddressBook
 \title Code: QuickAddressBook
 */
 


### PR DESCRIPTION
The project is no longer mirrored at
https://code.qt.io/cgit/qt-labs/vscodeext.git/
and the official dev repo is
https://github.com/qt-labs/vscodeext/