### PR TITLE
qt-lib: qt-core: qt-cpp: qt-qml: qt-ui: Introduce configuration resolver for variable substitution

### DIFF
--- a/qt-core/package-lock.json
+++ b/qt-core/package-lock.json
@@ -15,7 +15,6 @@
         "module-alias": "^2.2.3",
         "qt-lib": "file:../qt-lib",
         "typescript": "^5.6.3",
-        "untildify": "^5.0.0",
         "which": "^5.0.0"
       },
       "devDependencies": {
@@ -47,6 +46,7 @@
         "async": "^3.2.6",
         "module-alias": "^2.2.3",
         "typescript": "^5.6.3",
+        "untildify": "^5.0.0",
         "winston": "^3.15.0",
         "winston-transport-vscode": "^0.1.0"
       },
@@ -4628,15 +4628,6 @@
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/untildify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-5.0.0.tgz",
-      "integrity": "sha512-bOgQLUnd2G5rhzaTvh1VCI9Fo6bC5cLTpH17T5aFfamyXFYDbbdzN6IXdeoc3jBS7T9hNTmJtYUzJCJ2Xlc9gA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/qt-core/package.json
+++ b/qt-core/package.json
@@ -237,7 +237,6 @@
     "module-alias": "^2.2.3",
     "qt-lib": "file:../qt-lib",
     "typescript": "^5.6.3",
-    "untildify": "^5.0.0",
     "which": "^5.0.0"
   }
 }

--- a/qt-core/src/installation-root.ts
+++ b/qt-core/src/installation-root.ts
@@ -4,7 +4,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import untildify from 'untildify';
 
 import {
   Home,
@@ -17,7 +16,8 @@ import {
   QtWorkspaceConfigMessage,
   QtAdditionalPath,
   IsMacOS,
-  telemetry
+  telemetry,
+  resolveConfiguration
 } from 'qt-lib';
 import { EXTENSION_ID } from '@/constants';
 import { coreAPI } from '@/extension';
@@ -47,7 +47,7 @@ export function getCurrentGlobalQtInstallationRoot(): string {
   const qtInsRootConfig =
     getConfiguration().inspect<string>(QtInsRootConfigName);
   const insRoot = qtInsRootConfig?.globalValue;
-  return insRoot ? untildify(insRoot) : '';
+  return insRoot ? resolveConfiguration(insRoot) : '';
 }
 
 export function getCurrentGlobalAdditionalQtPaths(): QtAdditionalPath[] {

--- a/qt-core/src/project.ts
+++ b/qt-core/src/project.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 import * as vscode from 'vscode';
-import untildify from 'untildify';
 import { isEmpty, isEqual } from 'lodash';
 
 import {
@@ -12,7 +11,8 @@ import {
   QtInsRootConfigName,
   QtAdditionalPath,
   compareQtAdditionalPath,
-  telemetry
+  telemetry,
+  resolveConfiguration
 } from 'qt-lib';
 import { Project, ProjectManager } from 'qt-lib';
 import { convertAdditionalQtPaths, getConfiguration } from '@/util';
@@ -173,7 +173,9 @@ export class CoreProjectManager extends ProjectManager<CoreProject> {
     const qtInsRootConfig =
       getConfiguration(folder).inspect<string>(QtInsRootConfigName);
     const workspaceFolderValue = qtInsRootConfig?.workspaceFolderValue;
-    return workspaceFolderValue ? untildify(workspaceFolderValue) : '';
+    return workspaceFolderValue
+      ? resolveConfiguration(workspaceFolderValue)
+      : '';
   }
 
   public static getWorkspaceFolderAdditionalQtPaths(

--- a/qt-core/src/util.ts
+++ b/qt-core/src/util.ts
@@ -4,9 +4,8 @@
 import * as vscode from 'vscode';
 import { spawnSync } from 'child_process';
 
-import { QtAdditionalPath, inVCPKGRoot } from 'qt-lib';
+import { QtAdditionalPath, inVCPKGRoot, resolveConfiguration } from 'qt-lib';
 import { EXTENSION_ID } from '@/constants';
-import untildify from 'untildify';
 
 export function getConfiguration(scope?: vscode.ConfigurationScope) {
   return vscode.workspace.getConfiguration(EXTENSION_ID, scope);
@@ -17,11 +16,14 @@ export function convertAdditionalQtPaths(
 ): QtAdditionalPath[] {
   return value.map((element) => {
     if (typeof element === 'string') {
-      return { path: untildify(element), isVCPKG: inVCPKGRoot(element) };
+      return {
+        path: resolveConfiguration(element),
+        isVCPKG: inVCPKGRoot(element)
+      };
     }
     const ret = element as QtAdditionalPath;
     ret.isVCPKG = inVCPKGRoot(ret.path);
-    ret.path = untildify(ret.path);
+    ret.path = resolveConfiguration(ret.path);
     return ret;
   });
 }

--- a/qt-cpp/ThirdPartyNotices.txt
+++ b/qt-cpp/ThirdPartyNotices.txt
@@ -1921,6 +1921,23 @@ END OF TERMS AND CONDITIONS
 
 ---------------------------------------------------------
 
+untildify 5.0.0 - MIT
+https://github.com/sindresorhus/untildify#readme
+
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 util-deprecate 1.0.2 - MIT
 https://github.com/TooTallNate/util-deprecate#readme
 

--- a/qt-cpp/package-lock.json
+++ b/qt-cpp/package-lock.json
@@ -50,6 +50,7 @@
         "async": "^3.2.6",
         "module-alias": "^2.2.3",
         "typescript": "^5.6.3",
+        "untildify": "^5.0.0",
         "winston": "^3.15.0",
         "winston-transport-vscode": "^0.1.0"
       },

--- a/qt-lib/package-lock.json
+++ b/qt-lib/package-lock.json
@@ -12,6 +12,7 @@
         "async": "^3.2.6",
         "module-alias": "^2.2.3",
         "typescript": "^5.6.3",
+        "untildify": "^5.0.0",
         "winston": "^3.15.0",
         "winston-transport-vscode": "^0.1.0"
       },
@@ -2956,6 +2957,15 @@
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/untildify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-5.0.0.tgz",
+      "integrity": "sha512-bOgQLUnd2G5rhzaTvh1VCI9Fo6bC5cLTpH17T5aFfamyXFYDbbdzN6IXdeoc3jBS7T9hNTmJtYUzJCJ2Xlc9gA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/qt-lib/package.json
+++ b/qt-lib/package.json
@@ -34,6 +34,7 @@
     "async": "^3.2.6",
     "module-alias": "^2.2.3",
     "typescript": "^5.6.3",
+    "untildify": "^5.0.0",
     "winston": "^3.15.0",
     "winston-transport-vscode": "^0.1.0"
   }

--- a/qt-lib/src/configuration-resolver.ts
+++ b/qt-lib/src/configuration-resolver.ts
@@ -1,0 +1,44 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+import untildify from 'untildify';
+
+import { Home } from './util';
+
+/**
+ * Resolves configuration in a string, such as ${workspaceFolder}
+ */
+export function resolveConfiguration(input: string): string {
+  let result = input;
+  const configurationResolvers: Record<string, () => string | undefined> = {
+    workspaceFolder: () =>
+      vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? undefined,
+    userHome: () => Home
+  };
+
+  // Resolve keys in configurationResolvers with values from the configurationResolvers object
+  for (const key in configurationResolvers) {
+    const callable = configurationResolvers[key];
+    if (callable === undefined) {
+      continue; // Skip if not a function
+    }
+    const val = callable();
+    if (val === undefined) {
+      continue; // Skip if the callable returns undefined
+    }
+    const regex = new RegExp(`\\$\\{${key}\\}`, 'g');
+    result = result.replace(regex, val);
+  }
+
+  // Resolve environment variables in the format ${env:VAR_NAME}
+  result = result.replace(
+    /\$\{env:([A-Za-z0-9_]+)\}/g,
+    (_match, varName: string) => {
+      return process.env[varName] ?? '';
+    }
+  );
+
+  result = untildify(result);
+  return result;
+}

--- a/qt-lib/src/index.ts
+++ b/qt-lib/src/index.ts
@@ -6,3 +6,4 @@ export * from './constants';
 export * from './state';
 export * from './telemetry';
 export * from './color-provider';
+export * from './configuration-resolver';

--- a/qt-qml/package-lock.json
+++ b/qt-qml/package-lock.json
@@ -18,7 +18,6 @@
         "promise-socket": "^8.0.0",
         "qt-lib": "file:../qt-lib",
         "typescript": "^5.6.3",
-        "untildify": "^5.0.0",
         "vscode-languageclient": "^9.0.1",
         "yauzl": "^3.1.3"
       },
@@ -56,6 +55,7 @@
         "async": "^3.2.6",
         "module-alias": "^2.2.3",
         "typescript": "^5.6.3",
+        "untildify": "^5.0.0",
         "winston": "^3.15.0",
         "winston-transport-vscode": "^0.1.0"
       },
@@ -6655,15 +6655,6 @@
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/untildify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-5.0.0.tgz",
-      "integrity": "sha512-bOgQLUnd2G5rhzaTvh1VCI9Fo6bC5cLTpH17T5aFfamyXFYDbbdzN6IXdeoc3jBS7T9hNTmJtYUzJCJ2Xlc9gA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/qt-qml/package.json
+++ b/qt-qml/package.json
@@ -428,7 +428,6 @@
     "promise-socket": "^8.0.0",
     "qt-lib": "file:../qt-lib",
     "typescript": "^5.6.3",
-    "untildify": "^5.0.0",
     "vscode-languageclient": "^9.0.1",
     "yauzl": "^3.1.3"
   }

--- a/qt-qml/src/qmlls.ts
+++ b/qt-qml/src/qmlls.ts
@@ -10,7 +10,6 @@ import {
   LanguageClient,
   LanguageClientOptions
 } from 'vscode-languageclient/node';
-import untildify from 'untildify';
 
 import {
   createLogger,
@@ -21,7 +20,8 @@ import {
   QtInsRootConfigName,
   compareVersions,
   GlobalWorkspace,
-  telemetry
+  telemetry,
+  resolveConfiguration
 } from 'qt-lib';
 import { coreAPI, projectManager } from '@/extension';
 import { EXTENSION_ID } from '@/constants';
@@ -210,7 +210,7 @@ export class Qmlls {
     try {
       if (configs.get<string>('customExePath')) {
         const customPath = configs.get<string>('customExePath') ?? '';
-        const untildifiedCustomPath = untildify(customPath);
+        const untildifiedCustomPath = resolveConfiguration(customPath);
         const res = spawnSync(untildifiedCustomPath, ['--help'], {
           timeout: 1000
         });
@@ -269,7 +269,9 @@ export class Qmlls {
     let args: string[] = [];
     const customArgs = configs.get<string[]>('customArgs', []);
     if (customArgs.length > 0) {
-      args = customArgs;
+      args = customArgs.map((arg) => {
+        return resolveConfiguration(arg);
+      });
     } else {
       if (verboseOutput) {
         args.push('--verbose');
@@ -295,7 +297,7 @@ export class Qmlls {
       let docsPath = configs.get<string>('customDocsPath', '');
       if (docsPath) {
         // If qt-qml.qmlls.customDocsPath is set, use it instead of the path from the kit
-        docsPath = untildify(docsPath);
+        docsPath = resolveConfiguration(docsPath);
       } else {
         docsPath = this.docsPath ?? '';
       }
@@ -308,7 +310,13 @@ export class Qmlls {
         return `-I${p}`;
       };
 
-      additionalImportPaths.forEach((importPath) => {
+      const resolvedAdditionalImportPaths = additionalImportPaths.map(
+        (importPath) => {
+          return resolveConfiguration(importPath);
+        }
+      );
+
+      resolvedAdditionalImportPaths.forEach((importPath) => {
         args.push(toImportParam(importPath));
       });
 

--- a/qt-ui/package-lock.json
+++ b/qt-ui/package-lock.json
@@ -12,8 +12,7 @@
         "@vscode/webview-ui-toolkit": "^1.4.0",
         "module-alias": "^2.2.3",
         "qt-lib": "file:../qt-lib",
-        "typescript": "^5.6.3",
-        "untildify": "^5.0.0"
+        "typescript": "^5.6.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.0",
@@ -43,6 +42,7 @@
         "async": "^3.2.6",
         "module-alias": "^2.2.3",
         "typescript": "^5.6.3",
+        "untildify": "^5.0.0",
         "winston": "^3.15.0",
         "winston-transport-vscode": "^0.1.0"
       },
@@ -5156,15 +5156,6 @@
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/untildify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-5.0.0.tgz",
-      "integrity": "sha512-bOgQLUnd2G5rhzaTvh1VCI9Fo6bC5cLTpH17T5aFfamyXFYDbbdzN6IXdeoc3jBS7T9hNTmJtYUzJCJ2Xlc9gA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/qt-ui/package.json
+++ b/qt-ui/package.json
@@ -136,7 +136,6 @@
     "@vscode/webview-ui-toolkit": "^1.4.0",
     "module-alias": "^2.2.3",
     "qt-lib": "file:../qt-lib",
-    "typescript": "^5.6.3",
-    "untildify": "^5.0.0"
+    "typescript": "^5.6.3"
   }
 }

--- a/qt-ui/src/project.ts
+++ b/qt-ui/src/project.ts
@@ -3,11 +3,15 @@
 
 import * as vscode from 'vscode';
 import * as fs from 'fs';
-import untildify from 'untildify';
 
 import { DesignerClient } from '@/designer-client';
 import { DesignerServer } from '@/designer-server';
-import { createLogger, QtWorkspaceType, Project } from 'qt-lib';
+import {
+  createLogger,
+  QtWorkspaceType,
+  Project,
+  resolveConfiguration
+} from 'qt-lib';
 import {
   getConfig,
   affectsConfig,
@@ -108,7 +112,7 @@ export class UIProject implements Project {
     this._disposables.push(eventHandler);
   }
   getQtCustomDesignerPath() {
-    return untildify(
+    return resolveConfiguration(
       getConfig<string>(CONF_CUSTOM_WIDGETS_DESIGNER_EXE_PATH, '', this._folder)
     );
   }


### PR DESCRIPTION
Introduce variable substitution in configuration paths across the Qt
extension.

Variables to be substituted include:
- `${workspaceFolder}` for the workspace root directory
- `${userHome}` for the user's home directory

[ChangeLog][qt-lib][qt-core][qt-cpp][qt-qml][qt-ui]
- Introduce variable substitution in configuration paths
- Supported variables for substitution:
  - `${workspaceFolder}` for the workspace root directory
  - `${userHome}` for the user's home directory

Fixes: [VSCODEEXT-103](https://bugreports.qt.io/browse/VSCODEEXT-103)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
