### PR TITLE
qt-core/webview: Replace icon library

### DIFF
--- a/qt-core/webview-ui/package-lock.json
+++ b/qt-core/webview-ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "qt-core-webview",
       "version": "0.0.0",
       "dependencies": {
+        "@lucide/svelte": "^0.525.0",
         "@types/vscode-webview": "^1.57.5",
         "marked": "^15.0.7",
         "nanoid": "^5.1.5",
@@ -25,7 +26,6 @@
         "eslint-plugin-svelte": "^3.8.1",
         "flowbite": "^3.1.2",
         "flowbite-svelte": "^0.47.4",
-        "flowbite-svelte-icons": "^2.0.2",
         "prettier": "^3.5.3",
         "prettier-plugin-svelte": "^3.4.0",
         "sass": "^1.85.1",
@@ -41,7 +41,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -715,7 +714,6 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
       "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -730,7 +728,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -740,7 +737,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -750,18 +746,25 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lucide/svelte": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-0.525.0.tgz",
+      "integrity": "sha512-dyUxkXzepagLUzL8jHQNdeH286nC66ClLACsg+Neu/bjkRJWPWMzkT+H0DKlE70QdkicGCfs1ZGmXCc351hmZA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "svelte": "^5"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1469,7 +1472,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
       "integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -1795,7 +1797,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -2045,7 +2046,6 @@
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2124,7 +2124,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
       "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -2153,7 +2152,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -2251,7 +2249,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2667,7 +2664,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/espree": {
@@ -2705,7 +2701,6 @@
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.6.tgz",
       "integrity": "sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -2941,17 +2936,6 @@
       },
       "peerDependencies": {
         "svelte": "^3.55.1 || ^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/flowbite-svelte-icons": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/flowbite-svelte-icons/-/flowbite-svelte-icons-2.1.1.tgz",
-      "integrity": "sha512-VNNMcekjbM1bQEGgbdGsdYR9mRdTj/L0A5ba0P1tiFv5QB9GvbvJMABJoiD80eqpZUkfR2QVOmiZfgCwHicT/Q==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "svelte": "^5.0.0",
-        "tailwind-merge": "^3.0.0"
       }
     },
     "node_modules/flowbite-svelte/node_modules/flowbite": {
@@ -3287,7 +3271,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
       "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -3638,7 +3621,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -3668,7 +3650,6 @@
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
       "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
@@ -4413,7 +4394,6 @@
       "version": "5.28.2",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.28.2.tgz",
       "integrity": "sha512-FbWBxgWOpQfhKvoGJv/TFwzqb4EhJbwCD17dB0tEpQiw1XyUEKZJtgm4nA4xq3LLsMo7hu5UY/BOFmroAxKTMg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
@@ -4585,18 +4565,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/tailwind-merge": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.2.0.tgz",
-      "integrity": "sha512-FQT/OVqCD+7edmmJpsgCsY820RTD5AkBryuG5IUqR5YQZSdj5xlH5nLgH7YPths7WsLPSpSBNneJdM8aS8aeFA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {
@@ -4855,7 +4823,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
       "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/zod": {

--- a/qt-core/webview-ui/package.json
+++ b/qt-core/webview-ui/package.json
@@ -26,7 +26,6 @@
     "eslint-plugin-svelte": "^3.8.1",
     "flowbite": "^3.1.2",
     "flowbite-svelte": "^0.47.4",
-    "flowbite-svelte-icons": "^2.0.2",
     "prettier": "^3.5.3",
     "prettier-plugin-svelte": "^3.4.0",
     "sass": "^1.85.1",
@@ -38,6 +37,7 @@
     "vite": "^6.1.0"
   },
   "dependencies": {
+    "@lucide/svelte": "^0.525.0",
     "@types/vscode-webview": "^1.57.5",
     "marked": "^15.0.7",
     "nanoid": "^5.1.5",

--- a/qt-core/webview-ui/src/apps/new-item/PresetListItem.svelte
+++ b/qt-core/webview-ui/src/apps/new-item/PresetListItem.svelte
@@ -5,7 +5,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 <script lang="ts">
   import { ListgroupItem, Tooltip } from 'flowbite-svelte';
-  import { DotsHorizontalOutline } from 'flowbite-svelte-icons';
+  import { Ellipsis } from '@lucide/svelte';
 
   import TruncatableLabel from '@/comps/TruncatableLabel.svelte';
   import PresetListItemMenu from './PresetListItemMenu.svelte';
@@ -33,7 +33,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   {#if preset.isCustomPreset()}
     <div class="ml-auto mr-0.5 flex flex-row gap-1">
       <div class="qt-badge">{preset.title}</div>
-      <DotsHorizontalOutline
+      <Ellipsis
         class='qt-button-contentOnly'
         style={selected ? 'color: var(--qt-primary-foreground);' : '' }
         onclick={() => {

--- a/qt-core/webview-ui/src/apps/new-item/PresetListItemMenu.svelte
+++ b/qt-core/webview-ui/src/apps/new-item/PresetListItemMenu.svelte
@@ -4,7 +4,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
-  import { EditOutline, TrashBinOutline } from 'flowbite-svelte-icons';
+  import { SquarePen, Trash2 } from '@lucide/svelte';
 
   import * as texts from '@/apps/texts';
   import { ui } from './states.svelte';
@@ -13,8 +13,8 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   let { open = false, onClosed = () => {} } = $props();
 
   const items = [
-    { icon: TrashBinOutline, text: texts.wizard.buttons.delete },
-    { icon: EditOutline, text: texts.wizard.buttons.rename }
+    { icon: Trash2, text: texts.wizard.buttons.delete },
+    { icon: SquarePen, text: texts.wizard.buttons.rename }
   ];
 
   function onItemClickedAt(index: number) {

--- a/qt-core/webview-ui/src/apps/new-item/PresetOptionsHeader.svelte
+++ b/qt-core/webview-ui/src/apps/new-item/PresetOptionsHeader.svelte
@@ -4,7 +4,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
-  import { PlusOutline, FloppyDiskOutline } from 'flowbite-svelte-icons';
+  import { Plus, Save } from '@lucide/svelte';
 
   import IconButton from '@/comps/IconButton.svelte';
   import SectionLabel from '@/comps/SectionLabel.svelte';
@@ -40,7 +40,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
       `}
   >
     <IconButton
-      icon={PlusOutline}
+      icon={Plus}
       tooltip={texts.wizard.buttonTooltips.create}
       tooltipPlacement="left"
       visible={createEnabled}
@@ -51,7 +51,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
     />
 
     <IconButton
-      icon={FloppyDiskOutline}
+      icon={Save}
       tooltip={texts.wizard.buttonTooltips.save}
       tooltipPlacement="left"
       visible={saveEnabled}

--- a/qt-core/webview-ui/src/apps/new-item/PresetTypeSelector.svelte
+++ b/qt-core/webview-ui/src/apps/new-item/PresetTypeSelector.svelte
@@ -4,15 +4,15 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
-  import { FolderOpenOutline, FileOutline } from 'flowbite-svelte-icons';
+  import { FolderGit2, File } from '@lucide/svelte';
 
   import VerticalTabs from '@/comps/VerticalTabs.svelte';
   import { wizard } from '@/apps/texts';
   import { setPresetType } from './viewlogic.svelte';
 
   const items = [
-    { label: wizard.types.project, icon: FolderOpenOutline, data: 'project' },
-    { label: wizard.types.file, icon: FileOutline, data: 'file' }
+    { label: wizard.types.project, icon: FolderGit2, data: 'project' },
+    { label: wizard.types.file, icon: File, data: 'file' }
   ];
 
   function onCurrentIndexChanged(i: number) {

--- a/qt-core/webview-ui/src/apps/new-item/WizardSectionInput.svelte
+++ b/qt-core/webview-ui/src/apps/new-item/WizardSectionInput.svelte
@@ -5,7 +5,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 <script lang="ts">
   import { Checkbox, P } from 'flowbite-svelte';
-  import { CheckOutline, FolderOpenOutline } from 'flowbite-svelte-icons';
+  import { Check, FolderOpen } from '@lucide/svelte';
 
   import IconButton from '@/comps/IconButton.svelte';
   import SectionLabel from '@/comps/SectionLabel.svelte';
@@ -41,8 +41,8 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   <P class="qt-label pl-4">{texts.wizard.workingDir}</P>
   <div class="w-full grid grid-cols-[min-content_1fr] gap-0">
     <IconButton
-      icon={FolderOpenOutline}
-      class="qt-button px-2 py-0 rounded-r-none! -mr-0.5 focus:z-1"
+      icon={FolderOpen}
+      class="qt-button px-2 py-0 rounded-r-none! -mr-0.5 focus:z-1 min-w-[36px]"
       tooltip={texts.wizard.workingDirTooltip}
       onClicked={onWorkingDirBrowseClicked}
       />
@@ -70,7 +70,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
     <IconButton
       text={texts.wizard.buttons.create}
-      icon={CheckOutline}
+      icon={Check}
       disabled={!ui.canCreate}
       onClicked={createItemFromSelectedPreset}
     ></IconButton>

--- a/qt-core/webview-ui/src/comps/IconButton.svelte
+++ b/qt-core/webview-ui/src/comps/IconButton.svelte
@@ -6,14 +6,14 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 <script lang="ts">
   import type { Placement } from '@floating-ui/dom';
   import { Button, Tooltip } from 'flowbite-svelte';
-  import { CheckOutline } from 'flowbite-svelte-icons';
+  import { Check } from '@lucide/svelte';
 
   let {
     id = '',
     text = '',
     tooltip = '',
     tooltipPlacement = 'top' as Placement,
-    icon = CheckOutline,
+    icon = Check,
     flat = false,
     square = false,
     visible = true,

--- a/qt-core/webview-ui/src/comps/InputWithIssue.svelte
+++ b/qt-core/webview-ui/src/comps/InputWithIssue.svelte
@@ -6,7 +6,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 <script lang="ts">
   import { nanoid } from 'nanoid';
   import { Input, Button, Alert } from 'flowbite-svelte';
-  import { CircleMinusSolid, InfoCircleOutline } from 'flowbite-svelte-icons';
+  import { CircleMinus, Info } from '@lucide/svelte';
 
   let {
     value = $bindable(''),
@@ -79,9 +79,9 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
       }}
     >
       {#if level === 'error'}
-        <CircleMinusSolid />
+        <CircleMinus />
       {:else}
-        <InfoCircleOutline />
+        <Info />
       {/if}
     </Button>
   </Input>

--- a/qt-core/webview-ui/src/comps/PickerTrigger.svelte
+++ b/qt-core/webview-ui/src/comps/PickerTrigger.svelte
@@ -4,7 +4,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
-  import { ChevronDownOutline } from 'flowbite-svelte-icons';
+  import { ChevronDown } from '@lucide/svelte';
 
   import { textOrFallback } from '@/utils/utils';
 
@@ -30,5 +30,5 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   onclick={onClicked}
 >
   <div class="truncate">{textOrFallback(text)}</div>
-  <ChevronDownOutline class="w-4 h-4" />
+  <ChevronDown class="w-4 h-4" />
 </button>

--- a/qt-core/webview-ui/src/comps/SectionLabel.svelte
+++ b/qt-core/webview-ui/src/comps/SectionLabel.svelte
@@ -1,18 +1,18 @@
 <!--
 Copyright (C) 2025 The Qt Company Ltd.
-SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only 
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
   import { P } from 'flowbite-svelte';
-  import { AngleRightOutline } from 'flowbite-svelte-icons';
+  import { ChevronRight } from '@lucide/svelte';
 
   let { text, icon = true, class: className = '' } = $props();
 </script>
 
 <div class={`flex flex-row w-full mb-1 ${className} *:self-center gap-0.5`}>
   {#if icon}
-    <AngleRightOutline class="qt-label highlight" size="sm" />
+    <ChevronRight class="qt-label highlight" size="sm" />
   {/if}
   <P class="qt-label highlight">{text}</P>
 </div>

--- a/qt-core/webview-ui/src/comps/types.svelte.ts
+++ b/qt-core/webview-ui/src/comps/types.svelte.ts
@@ -1,9 +1,9 @@
 // Copyright (C) 2025 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-onl
 
-import { FileCloneOutline } from 'flowbite-svelte-icons';
+import { File } from '@lucide/svelte';
 
 export interface PickerItem {
   text: string;
-  icon?: typeof FileCloneOutline | undefined;
+  icon?: typeof File | undefined;
 }

--- a/qt-core/webview-ui/src/styles/styles.css
+++ b/qt-core/webview-ui/src/styles/styles.css
@@ -437,3 +437,23 @@ body.vscode-high-contrast .qt-item:hover {
   background: none;
   font-size: 1.2rem;
 }
+
+/*
+  styles for lucide icons
+  https://lucide.dev/guide/advanced/global-styling
+*/
+.lucide {
+  width: 18px;
+  height: 18px;
+  stroke-width: 1.0;
+}
+
+.lucide * {
+  vector-effect: non-scaling-stroke;
+}
+
+.lucide.large {
+  width: 36px;
+  height: 36px;
+  stroke-width: 2.0;
+}


### PR DESCRIPTION
Replace `flowbite-svelte-icons` with `Lucide` icons. 
Lucide offers more icons and allows easier customization with css.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
