### PR TITLE
qt-core/webview: Add web app for QRC editing

### DIFF
--- a/qt-core/ThirdPartyNotices.txt
+++ b/qt-core/ThirdPartyNotices.txt
@@ -66,6 +66,818 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------------------------
 
+core 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+diff 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+file-ops 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+js-bmp 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+js-gif 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+js-jpeg 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+js-png 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+js-tiff 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-blit 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-blur 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-circle 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-color 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-contain 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-cover 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-crop 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-displace 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-dither 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-fisheye 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-flip 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-hash 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-mask 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-print 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-quantize 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-resize 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-rotate 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+plugin-threshold 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+types 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+utils 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 1ds-core-js 4.3.3 - MIT
 https://github.com/microsoft/ApplicationInsights-JS/tree/main/shared/1ds-core-js#readme
 
@@ -354,6 +1166,61 @@ SOFTWARE.
 
 ---------------------------------------------------------
 
+token 0.3.0 - MIT
+https://github.com/Borewit/tokenizer-token#readme
+
+This software is released under the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+node 16.9.1 - MIT
+https://github.com/DefinitelyTyped/DefinitelyTyped#readme
+
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 triple-beam 1.3.5 - MIT
 https://github.com/DefinitelyTyped/DefinitelyTyped#readme
 
@@ -442,6 +1309,34 @@ SOFTWARE.
 
 ---------------------------------------------------------
 
+any-base 1.1.0 - MIT
+https://github.com/HarasimowiczKamil/any-base#readme
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Kamil Harasimowicz and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 async 3.2.6 - MIT
 https://github.com/caolan/async#readme
 
@@ -498,6 +1393,21 @@ SOFTWARE.
 
 ---------------------------------------------------------
 
+await-to-js 3.0.0 - MIT
+https://github.com/scopsy/await-to-js#readme
+
+Copyright 2017 Dima Grossman <dima@grossman.io>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 axios 1.9.0 - MIT
 https://github.com/axios/axios#readme
 
@@ -537,6 +1447,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+bmp-ts 1.0.9 - MIT
+https://github.com/hipstersmoothie/bmp-ts#readme
+
+The MIT License (MIT)
+
+Copyright (c) 2019 Andrew Lisowski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ---------------------------------------------------------
 
@@ -1093,6 +2032,65 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------------------------
 
+exif-parser 0.1.12 - MIT*
+https://github.com/bwindels/exif-parser#readme
+
+The MIT License
+===============
+
+Copyright (c) 2010 Bruno Windels <bruno.windels@gmail.com>, Daniel Leinich <leinich@gmx.net>.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+fast-xml-parser 5.2.5 - MIT
+https://github.com/NaturalIntelligence/fast-xml-parser#readme
+
+MIT License
+
+Copyright (c) 2017 Amit Kumar Gupta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 fecha 4.2.3 - MIT
 git+https://taylorhakes@github.com/taylorhakes/fecha#readme
 
@@ -1118,6 +2116,23 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+file-type 16.5.4 - MIT
+https://github.com/sindresorhus/file-type#readme
+
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------------------------
 
@@ -1292,6 +2307,35 @@ SOFTWARE.
 
 ---------------------------------------------------------
 
+gifwrap 0.10.1 - MIT
+https://github.com/jtlapp/gifwrap#readme
+
+MIT License
+
+Copyright © 2017 Joseph T. Lapp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 gopd 1.2.0 - MIT
 https://github.com/ljharb/gopd#readme
 
@@ -1427,6 +2471,63 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 ---------------------------------------------------------
 
+image-q 4.0.0 - MIT
+https://github.com/ibezkrovnyi/image-quantization#readme
+
+# image-quantization (https://github.com/igor-bezkrovny/image-quantization)
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Igor Bezkrovny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+# http://members.ozemail.com.au/~dekker/NEUQUANT.HTML
+
+NeuQuant Neural-Net Quantization Algorithm
+------------------------------------------
+
+Copyright (c) 1994 Anthony Dekker
+
+NEUQUANT Neural-Net quantization algorithm by Anthony Dekker, 1994. See
+"Kohonen neural networks for optimal colour quantization" in "Network:
+Computation in Neural Systems" Vol. 5 (1994) pp 351-367. for a discussion of
+the algorithm.
+
+Any party obtaining a copy of these files from the author, directly or
+indirectly, is granted, free of charge, a full and unrestricted irrevocable,
+world-wide, paid up, royalty-free, nonexclusive right and license to deal in
+this software and documentation files (the "Software"), including without
+limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons who
+receive copies from any such party to do so, with the only requirement being
+that this copyright notice remain intact.
+
+# https://github.com/leeoniya/RgbQuant.js
+
+Copyright (c) 2015, Leon Sorokin
+All rights reserved. (MIT Licensed)
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 inherits 2.0.4 - ISC
 https://github.com/isaacs/inherits#readme
 
@@ -1515,6 +2616,68 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+jimp 1.6.0 - MIT
+https://github.com/jimp-dev/jimp#readme
+
+MIT License
+
+Copyright (c) 2018 Oliver Moran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+jpeg-js 0.4.4 - BSD-3-Clause
+https://github.com/eugeneware/jpeg-js#readme
+
+Copyright (c) 2014, Eugene Ware
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of Eugene Ware nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY EUGENE WARE ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL EUGENE WARE BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ---------------------------------------------------------
 
@@ -1710,6 +2873,35 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------------------------
 
+mime 3.0.0 - MIT
+https://github.com/broofa/mime#readme
+
+The MIT License (MIT)
+
+Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 module-alias 2.2.3 - MIT
 https://github.com/ilearnio/module-alias#readme
 
@@ -1767,6 +2959,32 @@ SOFTWARE.
 
 ---------------------------------------------------------
 
+omggif 1.0.10 - MIT
+https://github.com/deanm/omggif#readme
+
+This software is released under the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 one-time 1.0.0 - MIT
 https://github.com/3rd-Eden/one-time#readme
 
@@ -1792,6 +3010,230 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+pako 1.0.11 - (MIT AND Zlib)
+https://github.com/nodeca/pako#readme
+
+(The MIT License)
+
+Copyright (C) 2014-2017 by Vitaly Puzrin and Andrei Tuputcyn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+parse-bmfont-ascii 1.0.6 - MIT
+https://github.com/mattdesl/parse-bmfont-ascii#readme
+
+The MIT License (MIT)
+Copyright (c) 2015 Matt DesLauriers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+parse-bmfont-binary 1.0.6 - MIT
+https://github.com/Jam3/parse-bmfont-binary#readme
+
+The MIT License (MIT)
+Copyright (c) 2015 Jam3
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+parse-bmfont-xml 1.1.6 - MIT
+https://github.com/mattdesl/parse-bmfont-xml#readme
+
+The MIT License (MIT)
+Copyright (c) 2015 Matt DesLauriers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+peek-readable 4.1.0 - MIT
+https://github.com/Borewit/peek-readable#readme
+
+The MIT License
+
+Copyright (c) 2010-2017 Borewit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+pixelmatch 5.3.0 - ISC
+https://github.com/mapbox/pixelmatch#readme
+
+ISC License
+
+Copyright (c) 2019, Mapbox
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+pngjs 6.0.0 - MIT
+https://github.com/lukeapage/pngjs#readme
+
+pngjs2 original work Copyright (c) 2015 Luke Page & Original Contributors
+pngjs derived work Copyright (c) 2012 Kuba Niegowski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+pngjs 7.0.0 - MIT
+https://github.com/pngjs/pngjs#readme
+
+pngjs original work Copyright (c) 2015 Luke Page & Original Contributors
+pngjs derived work Copyright (c) 2012 Kuba Niegowski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 ---------------------------------------------------------
 
@@ -1965,6 +3407,87 @@ IN THE SOFTWARE.
 
 ---------------------------------------------------------
 
+readable-stream 4.7.0 - MIT
+https://github.com/nodejs/readable-stream#readme
+
+Node.js is licensed for use as follows:
+
+"""
+Copyright Node.js contributors. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+"""
+
+This license applies to parts of Node.js originating from the
+https://github.com/joyent/node repository:
+
+"""
+Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+"""
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+readable-web-to-node-stream 3.0.4 - MIT
+https://github.com/Borewit/readable-web-to-node-stream#readme
+
+This software is released under the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 safe-buffer 5.2.1 - MIT
 https://github.com/feross/safe-buffer#readme
 
@@ -2023,6 +3546,55 @@ SOFTWARE.
 
 ---------------------------------------------------------
 
+sax 1.4.1 - ISC
+https://github.com/isaacs/sax-js#readme
+
+The ISC License
+
+Copyright (c) 2010-2024 Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+====
+
+`String.fromCodePoint` by Mathias Bynens used according to terms of MIT
+License, as follows:
+
+Copyright (c) 2010-2024 Mathias Bynens <https://mathiasbynens.be/>
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 simple-swizzle 0.2.2 - MIT
 https://github.com/qix-/node-simple-swizzle#readme
 
@@ -2047,6 +3619,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+simple-xml-to-json 1.2.3 - MIT
+https://github.com/nirgit/simple-xml-to-json#readme
+
+MIT License
+
+Copyright (c) 2022 Nir Moav
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ---------------------------------------------------------
 
@@ -2135,6 +3736,57 @@ IN THE SOFTWARE.
 
 ---------------------------------------------------------
 
+strnum 2.1.1 - MIT
+https://github.com/NaturalIntelligence/strnum#readme
+
+MIT License
+
+Copyright (c) 2021 Natural Intelligence
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+strtok3 6.3.0 - MIT
+https://github.com/Borewit/strtok3#readme
+
+Copyright (c) 2017, Borewit
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 text-hex 1.0.0 - MIT
 https://github.com/3rd-Eden/text-hex#readme
 
@@ -2160,6 +3812,47 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+tinycolor2 1.6.0 - MIT
+https://github.com/bgrins/TinyColor#readme
+
+Copyright (c), Brian Grinstead, http://briangrinstead.com
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+token-types 4.2.1 - MIT
+https://github.com/Borewit/token-types#readme
+
+Copyright 2017 Borewit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ---------------------------------------------------------
 
 ---------------------------------------------------------
@@ -2287,6 +3980,35 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+utif2 4.1.0 - MIT
+https://github.com/photopea/UTIF.js#readme
+
+MIT License
+
+Copyright (c) 2017 Photopea
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ---------------------------------------------------------
 
@@ -2582,4 +4304,118 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+xml-parse-from-string 1.0.1 - MIT
+https://github.com/Jam3/xml-parse-from-string#readme
+
+The MIT License (MIT)
+Copyright (c) 2015 Jam3
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+xml2js 0.5.0 - MIT
+https://github.com/Leonidas-from-XIV/node-xml2js#readme
+
+Copyright 2010, 2011, 2012, 2013. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+xmlbuilder 11.0.1 - MIT
+https://github.com/oozcitak/xmlbuilder-js#readme
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Ozgur Ozcitak
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+zod 3.25.76 - MIT
+https://github.com/colinhacks/zod#readme
+
+MIT License
+
+Copyright (c) 2025 Colin McDonnell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 ---------------------------------------------------------

--- a/qt-core/package-lock.json
+++ b/qt-core/package-lock.json
@@ -11,6 +11,8 @@
         "axios": "^1.9.0",
         "command-exists": "^1.2.9",
         "dotenv": "^16.5.0",
+        "fast-xml-parser": "^5.2.5",
+        "jimp": "^1.6.0",
         "lodash": "^4.17.21",
         "module-alias": "^2.2.3",
         "qt-lib": "file:../qt-lib",
@@ -21,8 +23,10 @@
         "@eslint/eslintrc": "^3.3.0",
         "@eslint/js": "^9.21.0",
         "@types/command-exists": "^1.2.3",
+        "@types/jimp": "^0.2.1",
         "@types/lodash": "^4.17.12",
         "@types/node": "^20.17.0",
+        "@types/pngjs": "^6.0.5",
         "@types/vscode": "^1.94.0",
         "@types/which": "^3.0.4",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -864,6 +868,430 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@jimp/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/file-ops": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "await-to-js": "^3.0.0",
+        "exif-parser": "^0.1.12",
+        "file-type": "^16.0.0",
+        "mime": "3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/core/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@jimp/diff": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/diff/-/diff-1.6.0.tgz",
+      "integrity": "sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "pixelmatch": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/file-ops": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/file-ops/-/file-ops-1.6.0.tgz",
+      "integrity": "sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-bmp": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-bmp/-/js-bmp-1.6.0.tgz",
+      "integrity": "sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "bmp-ts": "^1.0.9"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-gif": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-gif/-/js-gif-1.6.0.tgz",
+      "integrity": "sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "gifwrap": "^0.10.1",
+        "omggif": "^1.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-jpeg": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-jpeg/-/js-jpeg-1.6.0.tgz",
+      "integrity": "sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "jpeg-js": "^0.4.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-png": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-png/-/js-png-1.6.0.tgz",
+      "integrity": "sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "pngjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-tiff": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-tiff/-/js-tiff-1.6.0.tgz",
+      "integrity": "sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "utif2": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-blit": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-1.6.0.tgz",
+      "integrity": "sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-blur": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-1.6.0.tgz",
+      "integrity": "sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/utils": "1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-circle": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-1.6.0.tgz",
+      "integrity": "sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-color": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-1.6.0.tgz",
+      "integrity": "sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "tinycolor2": "^1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-contain": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-1.6.0.tgz",
+      "integrity": "sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/plugin-blit": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-cover": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-1.6.0.tgz",
+      "integrity": "sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/plugin-crop": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-crop": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-1.6.0.tgz",
+      "integrity": "sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-displace": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-1.6.0.tgz",
+      "integrity": "sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-dither": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-1.6.0.tgz",
+      "integrity": "sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-fisheye": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-1.6.0.tgz",
+      "integrity": "sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-flip": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-1.6.0.tgz",
+      "integrity": "sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-hash": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-hash/-/plugin-hash-1.6.0.tgz",
+      "integrity": "sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/js-bmp": "1.6.0",
+        "@jimp/js-jpeg": "1.6.0",
+        "@jimp/js-png": "1.6.0",
+        "@jimp/js-tiff": "1.6.0",
+        "@jimp/plugin-color": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "any-base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-mask": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-1.6.0.tgz",
+      "integrity": "sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-print": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-1.6.0.tgz",
+      "integrity": "sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/js-jpeg": "1.6.0",
+        "@jimp/js-png": "1.6.0",
+        "@jimp/plugin-blit": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "parse-bmfont-ascii": "^1.0.6",
+        "parse-bmfont-binary": "^1.0.6",
+        "parse-bmfont-xml": "^1.1.6",
+        "simple-xml-to-json": "^1.2.2",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-quantize": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-quantize/-/plugin-quantize-1.6.0.tgz",
+      "integrity": "sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg==",
+      "license": "MIT",
+      "dependencies": {
+        "image-q": "^4.0.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-resize": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.0.tgz",
+      "integrity": "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-rotate": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-1.6.0.tgz",
+      "integrity": "sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/plugin-crop": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-threshold": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-1.6.0.tgz",
+      "integrity": "sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/plugin-color": "1.6.0",
+        "@jimp/plugin-hash": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/types": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-1.6.0.tgz",
+      "integrity": "sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/utils": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-1.6.0.tgz",
+      "integrity": "sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -930,6 +1358,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -965,6 +1399,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jimp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@types/jimp/-/jimp-0.2.1.tgz",
+      "integrity": "sha512-UiMzF9Foi3MtfyKrUlx6xjRzBy23S13INyGLhYLg2BHZM+lf17k0W8qni123mKgRqn3jEx13ryqc/JHQo1l2Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -987,6 +1431,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/pngjs": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
+      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/semver": {
@@ -1426,6 +1880,18 @@
         "node": "*"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -1515,6 +1981,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/any-base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
+      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -1544,6 +2016,15 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/await-to-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-3.0.0.tgz",
+      "integrity": "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/axios": {
       "version": "1.9.0",
@@ -1578,7 +2059,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1593,8 +2073,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -1608,6 +2087,12 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/bmp-ts": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bmp-ts/-/bmp-ts-1.0.9.tgz",
+      "integrity": "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==",
+      "license": "MIT"
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -2039,9 +2524,9 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -2612,15 +3097,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
       }
+    },
+    "node_modules/exif-parser": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
+      "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
     },
     "node_modules/expand-template": {
       "version": "2.0.3",
@@ -2684,6 +3182,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -2715,6 +3231,23 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/fill-range": {
@@ -2864,6 +3397,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/gifwrap": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.10.1.tgz",
+      "integrity": "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==",
+      "license": "MIT",
+      "dependencies": {
+        "image-q": "^4.0.0",
+        "omggif": "^1.0.10"
       }
     },
     "node_modules/github-from-package": {
@@ -3129,7 +3672,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3144,8 +3686,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3156,6 +3697,21 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/image-q": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
+      "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "16.9.1"
+      }
+    },
+    "node_modules/image-q/node_modules/@types/node": {
+      "version": "16.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -3291,6 +3847,50 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/jimp": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.0.tgz",
+      "integrity": "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/diff": "1.6.0",
+        "@jimp/js-bmp": "1.6.0",
+        "@jimp/js-gif": "1.6.0",
+        "@jimp/js-jpeg": "1.6.0",
+        "@jimp/js-png": "1.6.0",
+        "@jimp/js-tiff": "1.6.0",
+        "@jimp/plugin-blit": "1.6.0",
+        "@jimp/plugin-blur": "1.6.0",
+        "@jimp/plugin-circle": "1.6.0",
+        "@jimp/plugin-color": "1.6.0",
+        "@jimp/plugin-contain": "1.6.0",
+        "@jimp/plugin-cover": "1.6.0",
+        "@jimp/plugin-crop": "1.6.0",
+        "@jimp/plugin-displace": "1.6.0",
+        "@jimp/plugin-dither": "1.6.0",
+        "@jimp/plugin-fisheye": "1.6.0",
+        "@jimp/plugin-flip": "1.6.0",
+        "@jimp/plugin-hash": "1.6.0",
+        "@jimp/plugin-mask": "1.6.0",
+        "@jimp/plugin-print": "1.6.0",
+        "@jimp/plugin-quantize": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/plugin-rotate": "1.6.0",
+        "@jimp/plugin-threshold": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3790,6 +4390,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/omggif": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3868,6 +4474,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3879,6 +4491,28 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-bmfont-ascii": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
+      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-bmfont-binary": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
+      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-bmfont-xml": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
+      "integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-parse-from-string": "^1.0.0",
+        "xml2js": "^0.5.0"
       }
     },
     "node_modules/parse-semver": {
@@ -3981,6 +4615,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -3999,6 +4646,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pixelmatch": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
+      "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^6.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/pixelmatch/node_modules/pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/prebuild-install": {
@@ -4053,6 +4730,15 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/proxy-from-env": {
@@ -4181,6 +4867,62 @@
         "node": ">= 6"
       }
     },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
+      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/readable-web-to-node-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4247,7 +4989,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4275,13 +5016,12 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4400,6 +5140,15 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/simple-xml-to-json": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.3.tgz",
+      "integrity": "sha512-kWJDCr9EWtZ+/EYYM5MareWj2cRnZGF93YDNpH4jQiHB+hBIZnfPFSQiVMzZOdk+zXWqTZ/9fTeQNu2DqeiudA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.12.2"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4425,9 +5174,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -4456,6 +5203,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/supports-color": {
@@ -4510,6 +5286,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
@@ -4531,6 +5313,23 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4721,6 +5520,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/utif2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
+      "integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.11"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4801,11 +5609,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/xml-parse-from-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
+      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
+      "license": "MIT"
+    },
     "node_modules/xml2js": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
       "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
@@ -4819,7 +5632,6 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
@@ -4874,6 +5686,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/qt-core/package.json
+++ b/qt-core/package.json
@@ -30,6 +30,9 @@
   ],
   "qna": "marketplace",
   "pricing": "Free",
+  "activationEvents": [
+    "workspaceContains:*.qrc"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
@@ -77,6 +80,21 @@
         "command": "qt-core.createNewItem",
         "title": "%qt-core.command.createNewItem.title%",
         "category": "Qt"
+      }
+    ],
+    "customEditors": [
+      {
+        "viewType": "qt-core.qrcEditor",
+        "displayName": "QRC editor",
+        "extensions": [
+          ".qrc"
+        ],
+        "priority": "default",
+        "selector": [
+          {
+            "filenamePattern": "*.qrc"
+          }
+        ]
       }
     ],
     "languages": [
@@ -215,8 +233,10 @@
     "@eslint/eslintrc": "^3.3.0",
     "@eslint/js": "^9.21.0",
     "@types/command-exists": "^1.2.3",
+    "@types/jimp": "^0.2.1",
     "@types/lodash": "^4.17.12",
     "@types/node": "^20.17.0",
+    "@types/pngjs": "^6.0.5",
     "@types/vscode": "^1.94.0",
     "@types/which": "^3.0.4",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -233,6 +253,8 @@
     "axios": "^1.9.0",
     "command-exists": "^1.2.9",
     "dotenv": "^16.5.0",
+    "fast-xml-parser": "^5.2.5",
+    "jimp": "^1.6.0",
     "lodash": "^4.17.21",
     "module-alias": "^2.2.3",
     "qt-lib": "file:../qt-lib",

--- a/qt-core/src/extension.ts
+++ b/qt-core/src/extension.ts
@@ -28,6 +28,7 @@ import { resetCommand } from '@/reset';
 import { checkQtpathsInEnvPath, registerQtByQtpaths } from '@/qtpaths';
 import { checkVcpkg } from '@/vcpkg';
 import { NewItemPanel } from '@/webview/new-item/panel';
+import { registerQrcEditorProvider } from '@/webview/qrc-editor/editor-provider';
 
 const logger = createLogger('extension');
 
@@ -73,6 +74,8 @@ export async function activate(context: vscode.ExtensionContext) {
       NewItemPanel.render(context);
     })
   );
+
+  registerQrcEditorProvider(context);
 
   telemetry.sendEvent(`activated`);
 

--- a/qt-core/src/webview/qrc-editor/controller.ts
+++ b/qt-core/src/webview/qrc-editor/controller.ts
@@ -1,0 +1,437 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import _ from 'lodash';
+import { Jimp, ResizeStrategy } from 'jimp';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import { createLogger } from 'qt-lib';
+import { WebviewChannel } from '@/webview/channel';
+import {
+  Command,
+  CommandId,
+  CommandHandler,
+  IsCommand
+} from '@/webview/shared/message';
+import {
+  RccTag,
+  QResourceTag,
+  FileTag,
+  QrcDocChangeEvent,
+  QrcCommandReplyType
+} from '@/webview/shared/qrc-types';
+import { QrcNode } from './node';
+import { makeUniqueName } from './utils';
+import { QrcDocsManager } from './docs-manager';
+
+const logger = createLogger('qrc-editor-controller');
+
+export class QrcEditorController {
+  private readonly _comm: WebviewChannel;
+  private readonly _routes: Map<CommandId, CommandHandler>;
+  private readonly _docPath: string;
+  private readonly _docManager: QrcDocsManager;
+  private readonly _disposables: vscode.Disposable[] = [];
+
+  public constructor(
+    view: vscode.Webview,
+    docManager: QrcDocsManager,
+    docPath: string
+  ) {
+    this._comm = new WebviewChannel(view);
+    this._docPath = docPath;
+    this._docManager = docManager;
+
+    this._disposables.push(
+      this._comm,
+      this._comm.onDidReceiveMessage(this._dispatch),
+      this._docManager.onChange(this._onDocChange)
+    );
+
+    this._routes = new Map<CommandId, CommandHandler>([
+      [CommandId.QrcAddFiles, this._onAddFiles],
+      [CommandId.QrcAddNewGroup, this._onAddNewGroup],
+      [CommandId.QrcGetRccTag, this._onGetRccTag],
+      [CommandId.QrcGetFileInfo, this._onGetFileInfo],
+      [CommandId.QrcClean, this._onClean],
+      [CommandId.QrcRemove, this._onRemove],
+      [CommandId.QrcSetProp, this._onSetProp],
+      [CommandId.QrcSortAll, this._onSortAll],
+      [CommandId.QrcRunVscodeUiAction, this._onRunActionInVscode],
+      [CommandId.QrcRunClipboardAction, this._onRunClipboardAction]
+    ]);
+  }
+
+  public dispose() {
+    this._disposables.forEach((d) => {
+      d.dispose();
+    });
+    this._disposables.length = 0;
+  }
+
+  private readonly _dispatch = async (cmd: unknown) => {
+    if (!IsCommand(cmd)) {
+      return;
+    }
+
+    const handler = this._routes.get(cmd.id);
+    if (!handler) {
+      logger.warn(`unhandled command: id = ${cmd.id}`);
+      return;
+    }
+
+    try {
+      await handler(cmd);
+    } catch (e) {
+      logger.error(`Error while handling command '${cmd.id}': ${String(e)}`);
+    }
+  };
+
+  private readonly _onDocChange = (e: QrcDocChangeEvent) => {
+    if (this._docPath === e.key) {
+      this._comm.post(CommandId.QrcDocChanged, e);
+    }
+  };
+
+  private readonly _onAddFiles = async (cmd: Command) => {
+    const node = this._findQrcNodeOrThrow(cmd.payload);
+    if (!node.qrcUri) {
+      return;
+    }
+
+    const paths = await extractOrAskAbsPaths(cmd.payload, node.qrcUri);
+    const fileIndexes = (
+      await Promise.all(
+        paths.map(async (p) =>
+          collectAllFiles(p).then((found) => node.addFiles(found))
+        )
+      )
+    ).flat();
+
+    if (fileIndexes.length !== 0) {
+      await this._applyAndPostData(cmd, {
+        action: 'add',
+        groupKey: node.pos.groupKey,
+        fileIndexes
+      });
+    }
+  };
+
+  private readonly _onAddNewGroup = async (cmd: Command) => {
+    const node = this._findQrcNodeOrThrow(cmd.payload);
+    const name = createNewPrefixName(node.rcc);
+    const group = node.addGroup(name);
+
+    await this._applyAndPostData(cmd, {
+      action: 'add',
+      groupKey: group.attributes.__groupKey ?? '',
+      fileIndexes: [-1]
+    });
+  };
+
+  private readonly _onGetRccTag = (cmd: Command) => {
+    const doc = this._docManager.find(this._docPath);
+    if (doc?.rccTag) {
+      this._comm.postDataReply(cmd, doc.rccTag);
+    }
+  };
+
+  private readonly _onGetFileInfo = async (cmd: Command) => {
+    const node = this._findQrcNodeOrThrow(cmd.payload);
+    const fsPath = node.fileUri?.fsPath ?? '';
+    const size = _.get(cmd.payload, 'thumbnailSize', 24) as number;
+    const info = await createFileInfo(fsPath, size);
+
+    this._comm.postDataReply(cmd, info);
+  };
+
+  private readonly _onClean = async (cmd: Command) => {
+    const doc = this._docManager.find(this._docPath);
+    const rcc = doc?.rccTag;
+    if (!rcc?.qresource) {
+      return;
+    }
+
+    removeEmptyGroups(rcc);
+
+    const baseDir = path.dirname(this._docPath);
+    for (const g of rcc.qresource) {
+      await removeInvalidFiles(g, baseDir);
+    }
+
+    await this._applyAndPostData(cmd, { status: 'done' });
+  };
+
+  private readonly _onRemove = async (cmd: Command) => {
+    const node = this._findQrcNodeOrThrow(cmd.payload);
+    if (node.remove()) {
+      await this._applyAndPostData(cmd, { status: 'done' });
+    }
+  };
+
+  private readonly _onSetProp = async (cmd: Command) => {
+    const node = this._findQrcNodeOrThrow(cmd.payload);
+    const name = _.get(cmd.payload, 'name', '') as string;
+    const value = _.get(cmd.payload, 'value', '') as string;
+
+    if (node.setAttribute(name, value)) {
+      await this._applyAndPostData(cmd, { status: 'done' });
+    }
+  };
+
+  private readonly _onSortAll = async (cmd: Command) => {
+    const doc = this._docManager.find(this._docPath);
+    const rcc = doc?.rccTag;
+    if (!rcc?.qresource) {
+      return;
+    }
+
+    const order = _.get(cmd.payload, 'order', 'asc') as string;
+    if (sortGroups(rcc, order)) {
+      rcc.qresource.forEach((g) => sortFiles(g, order));
+      await this._applyAndPostData(cmd, { status: 'done' });
+    }
+  };
+
+  private readonly _onRunActionInVscode = async (cmd: Command) => {
+    const action = _.get(cmd.payload, 'action', '') as string;
+
+    if (action === 'openQrcInTextEditor') {
+      void vscode.window.showTextDocument(vscode.Uri.file(this._docPath));
+      this._comm.postDataReply(cmd, { status: 'done' });
+      return;
+    }
+
+    const node = this._findQrcNodeOrThrow(cmd.payload);
+    if (!node.file || !node.fileUri) {
+      return;
+    }
+
+    if (!(await fileExists(node.fileUri.fsPath))) {
+      return;
+    }
+
+    if (action === 'openFile') {
+      void vscode.commands.executeCommand('vscode.open', node.fileUri, {
+        preview: true,
+        viewColumn: vscode.ViewColumn.Beside
+      });
+    } else if (action === 'revealFileInExplorer') {
+      void vscode.commands.executeCommand('revealInExplorer', node.fileUri);
+    } else {
+      return;
+    }
+
+    this._comm.postDataReply(cmd, { status: 'done' });
+  };
+
+  private readonly _onRunClipboardAction = async (cmd: Command) => {
+    const node = this._findQrcNodeOrThrow(cmd.payload);
+    const action = _.get(cmd.payload, 'action', '') as string;
+
+    switch (action) {
+      case 'copy':
+        if (await node.copy()) {
+          await this._applyAndPostData(cmd, { status: 'done' });
+        }
+        break;
+
+      case 'cut':
+        if ((await node.copy()) && node.remove()) {
+          await this._applyAndPostData(cmd, { status: 'done' });
+        }
+        break;
+
+      case 'paste': {
+        const r = await node.paste();
+        if (r) {
+          await this._applyAndPostData(cmd, { action: 'paste', ...r });
+        }
+        return;
+      }
+    }
+  };
+
+  private async _applyAndPostData(cmd: Command, data: QrcCommandReplyType) {
+    const doc = this._docManager.find(this._docPath);
+    if (doc) {
+      this._docManager.setRecentCommandId(this._docPath, cmd.id);
+      await doc.updateXmlVsdoc();
+      this._comm.postDataReply(cmd, data);
+    }
+  }
+
+  private _findQrcNodeOrThrow(data: unknown): QrcNode {
+    const doc = this._docManager.find(this._docPath);
+    if (!doc) {
+      throw new Error('Invalid QRC file');
+    }
+
+    const g = _.get(data, 'groupKey', '') as string;
+    const f = toInteger(_.get(data, 'fileIndex', -1), -1);
+    return new QrcNode(doc, g, f);
+  }
+}
+
+// helpers
+async function createFileInfo(absPath: string, thumbnailSize: number) {
+  let exists = false;
+  let thumbnail: number[] | undefined;
+
+  try {
+    if (await fileExists(absPath)) {
+      exists = true;
+
+      const image = await Jimp.read(absPath);
+      const resized = image.resize({
+        w: thumbnailSize,
+        mode: ResizeStrategy.NEAREST_NEIGHBOR
+      });
+
+      const buffer = await resized.getBuffer('image/png');
+      thumbnail = Array.from(new Uint8Array(buffer));
+    }
+  } catch {
+    // do nothing on purpose
+  }
+
+  return { exists, ...(thumbnail && { thumbnail }) };
+}
+
+function createNewPrefixName(rcc: RccTag) {
+  if (rcc.qresource.length === 0) {
+    return '/';
+  }
+
+  const base = '/new/prefix';
+  const taken = rcc.qresource.map((g) => g.attributes.prefix ?? '');
+  return makeUniqueName(base, new Set(taken));
+}
+
+function toInteger(value: unknown, defaultValue = 0): number {
+  const num = Number(value);
+  if (Number.isNaN(num)) {
+    return defaultValue;
+  }
+
+  const safe = Math.floor(num);
+  if (safe < Number.MIN_SAFE_INTEGER) {
+    return Number.MIN_SAFE_INTEGER;
+  }
+  if (safe > Number.MAX_SAFE_INTEGER) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+
+  return safe;
+}
+
+async function collectAllFiles(dir: string) {
+  const s = await fs.stat(dir);
+  if (s.isFile()) {
+    return [dir];
+  }
+
+  let found: string[] = [];
+  const list = await fs.readdir(dir);
+
+  for (const file of list) {
+    const filePath = path.join(dir, file);
+    const stat = await fs.stat(filePath);
+
+    if (stat.isDirectory()) {
+      found = found.concat(await collectAllFiles(filePath));
+    } else {
+      found.push(filePath);
+    }
+  }
+
+  return found;
+}
+
+async function fileExists(fsPath: string) {
+  try {
+    const s = await fs.stat(fsPath);
+    return s.isFile();
+  } catch {
+    return false;
+  }
+}
+
+function sortGroups(rcc: RccTag, order: string): boolean {
+  rcc.qresource.sort((a, b) => {
+    const ap = a.attributes.prefix ?? '';
+    const bp = b.attributes.prefix ?? '';
+    return order === 'asc' ? ap.localeCompare(bp) : bp.localeCompare(ap);
+  });
+
+  return true;
+}
+
+function sortFiles(group: QResourceTag, order: string): boolean {
+  group.file.sort((a, b) =>
+    order === 'asc'
+      ? a.text.localeCompare(b.text)
+      : b.text.localeCompare(a.text)
+  );
+
+  return true;
+}
+
+function removeEmptyGroups(rcc: RccTag) {
+  if (rcc.qresource.length === 0) {
+    return false;
+  }
+
+  const retained = rcc.qresource.filter((g) => g.file.length > 0);
+  if (rcc.qresource.length !== retained.length) {
+    rcc.qresource = retained;
+    return true;
+  }
+
+  return false;
+}
+
+async function removeInvalidFiles(group: QResourceTag, baseDir: string) {
+  if (group.file.length === 0) {
+    return false;
+  }
+
+  const retained: FileTag[] = [];
+
+  for (const f of group.file) {
+    const emptyAttr = f.attributes.empty ?? '';
+    const isEmptyEntry = 'true' === emptyAttr.trim().toLowerCase();
+    if (isEmptyEntry || (await fileExists(path.join(baseDir, f.text)))) {
+      retained.push(f);
+    }
+  }
+
+  if (group.file.length !== retained.length) {
+    group.file = retained;
+    return true;
+  }
+
+  return false;
+}
+
+async function extractOrAskAbsPaths(cmdPayload: unknown, qrcUri: vscode.Uri) {
+  if (_.isPlainObject(cmdPayload) && _.has(cmdPayload, 'files')) {
+    const files = _.get(cmdPayload, 'files', []);
+    if (Array.isArray(files) && files.every((s) => typeof s === 'string')) {
+      return files;
+    }
+
+    return [];
+  }
+
+  const selected = await vscode.window.showOpenDialog({
+    canSelectFiles: true,
+    canSelectMany: true,
+    openLabel: 'Select files to add',
+    defaultUri: qrcUri
+  });
+
+  return selected?.map((url) => url.fsPath) ?? [];
+}

--- a/qt-core/src/webview/qrc-editor/doc.ts
+++ b/qt-core/src/webview/qrc-editor/doc.ts
@@ -1,0 +1,133 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+
+import { type RccTag, QResourceTag } from '@/webview/shared/qrc-types';
+import { parseXml, generateXml } from './xml-io';
+import { updateGroupHashes, generateKey } from './utils';
+
+export class QrcDoc {
+  private readonly _vsdoc: vscode.TextDocument;
+  private _rccTag: RccTag | undefined;
+
+  constructor(doc: vscode.TextDocument) {
+    this._vsdoc = doc;
+    this.reloadXmlVsdoc();
+  }
+
+  get uri() {
+    return this._vsdoc.uri;
+  }
+
+  get rccTag() {
+    return this._rccTag;
+  }
+
+  public reloadXmlVsdoc() {
+    const rcc = parseXml(this._vsdoc.getText());
+    if (!rcc) {
+      return;
+    }
+
+    if (rcc.qresource.length !== 0) {
+      rcc.qresource.forEach((g) => {
+        updateGroupHashes(g);
+      });
+      migrateGroupKeys(rcc, this._rccTag);
+      ensureGroupKeysValid(rcc);
+    }
+
+    this._rccTag = rcc;
+  }
+
+  public async updateXmlVsdoc() {
+    if (!this._rccTag) {
+      return undefined;
+    }
+
+    const xml = generateXml(this._rccTag);
+    const whole = new vscode.Range(0, 0, this._vsdoc.lineCount, 0);
+    const edit = new vscode.WorkspaceEdit();
+    edit.replace(this._vsdoc.uri, whole, xml);
+
+    await vscode.workspace.applyEdit(edit);
+  }
+}
+
+// helpers
+type GroupCompareMode = 'hash' | 'files' | 'both';
+
+function migrateGroupKeys(destRcc: RccTag, srcRcc: RccTag | undefined) {
+  if (!srcRcc || srcRcc.qresource.length === 0) {
+    return;
+  }
+
+  const compareModes: GroupCompareMode[] = ['both', 'hash', 'files'];
+
+  for (const mode of compareModes) {
+    destRcc.qresource.forEach((destGroup) => {
+      matchAndTransferGroupKey(destGroup, srcRcc, mode);
+    });
+  }
+}
+
+function compareGroupHashes(
+  first: QResourceTag,
+  second: QResourceTag,
+  mode: GroupCompareMode
+) {
+  const a = first.attributes;
+  const b = second.attributes;
+
+  if (!a.__hash || !a.__groupFilesHash) {
+    return false;
+  }
+  if (!b.__hash || !b.__groupFilesHash) {
+    return false;
+  }
+
+  switch (mode) {
+    case 'hash':
+      return a.__hash === b.__hash;
+
+    case 'files':
+      return a.__groupFilesHash === b.__groupFilesHash;
+
+    case 'both':
+    default:
+      return a.__hash === b.__hash && a.__groupFilesHash === b.__groupFilesHash;
+  }
+}
+
+function matchAndTransferGroupKey(
+  destGroup: QResourceTag,
+  srcRcc: RccTag,
+  mode: GroupCompareMode
+) {
+  const srcGroups = srcRcc.qresource;
+  if (!srcGroups.length) {
+    return;
+  }
+
+  const matchIndex = srcGroups.findIndex((sourceGroup) => {
+    return compareGroupHashes(destGroup, sourceGroup, mode);
+  });
+
+  const matchGroup = matchIndex === -1 ? undefined : srcGroups[matchIndex];
+  const matchedKey = matchGroup?.attributes.__groupKey;
+  if (matchedKey) {
+    destGroup.attributes.__groupKey = matchedKey;
+
+    // Prevent duplicated migration by consuming the matched group.
+    srcGroups.splice(matchIndex, 1);
+  }
+}
+
+function ensureGroupKeysValid(rcc: RccTag) {
+  rcc.qresource.forEach((group) => {
+    if ((group.attributes.__groupKey ?? '') === '') {
+      group.attributes.__groupKey = generateKey();
+    }
+  });
+}

--- a/qt-core/src/webview/qrc-editor/docs-manager.ts
+++ b/qt-core/src/webview/qrc-editor/docs-manager.ts
@@ -1,0 +1,114 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+
+import { QrcDocChangeEvent } from '@/webview/shared/qrc-types';
+import { defaultQrcLines } from './xml-io';
+import { QrcDoc } from './doc';
+import { CommandId } from '../shared/message';
+
+export class QrcDocsManager {
+  private readonly _allDocs = new Map<string, QrcDoc>();
+  private readonly _recentCommandIds = new Map<string, CommandId>();
+  private readonly _changeEmitter =
+    new vscode.EventEmitter<QrcDocChangeEvent>();
+  private readonly _disposables: vscode.Disposable[] = [];
+
+  constructor() {
+    this._disposables.push(
+      vscode.workspace.onDidCloseTextDocument(this._onDocClosed.bind(this)),
+      vscode.workspace.onDidChangeTextDocument(this._onDocChanged.bind(this))
+    );
+  }
+
+  public dispose() {
+    this._allDocs.clear();
+    this._disposables.forEach((e) => {
+      e.dispose();
+    });
+  }
+
+  public get onChange() {
+    return this._changeEmitter.event;
+  }
+
+  public find(key: string): QrcDoc | undefined {
+    return this._allDocs.get(key);
+  }
+
+  public add(doc: vscode.TextDocument) {
+    const key = doc.uri.fsPath;
+
+    if (!this._allDocs.has(key)) {
+      this._allDocs.set(key, new QrcDoc(doc));
+      void ensureNotEmpty(doc);
+    }
+  }
+
+  public setRecentCommandId(key: string, commandId: CommandId) {
+    this._recentCommandIds.set(key, commandId);
+  }
+
+  private _onDocClosed(vsdoc: vscode.TextDocument) {
+    const key = vsdoc.uri.fsPath;
+    const doc = this._allDocs.get(key);
+    if (doc) {
+      this._allDocs.delete(key);
+    }
+  }
+
+  private _onDocChanged(e: vscode.TextDocumentChangeEvent) {
+    const key = e.document.uri.fsPath;
+    const doc = this._allDocs.get(key);
+    if (doc) {
+      const ev = this._createChangeEvent(key, e);
+      if (ev.reason !== 'command') {
+        doc.reloadXmlVsdoc();
+      }
+
+      this._changeEmitter.fire(ev);
+    }
+  }
+
+  private _createChangeEvent(
+    key: string,
+    e: vscode.TextDocumentChangeEvent
+  ): QrcDocChangeEvent {
+    const commandId = this._recentCommandIds.get(key);
+    if (commandId) {
+      this._recentCommandIds.delete(key);
+      return { key, reason: 'command', commandId };
+    }
+
+    if (
+      e.reason === vscode.TextDocumentChangeReason.Undo ||
+      e.reason === vscode.TextDocumentChangeReason.Redo
+    ) {
+      return { key, reason: 'undo/redo' };
+    }
+
+    return { key, reason: 'not-specified' };
+  }
+}
+
+// helpers
+async function ensureNotEmpty(doc: vscode.TextDocument) {
+  const nolines = doc.lineCount === 0;
+  const oneLineButEmpty =
+    doc.lineCount === 1 &&
+    doc
+      .getText()
+      .replace(/^\uFEFF/, '')
+      .trim().length === 0;
+
+  if (!nolines && !oneLineButEmpty) {
+    return undefined;
+  }
+
+  const edit = new vscode.WorkspaceEdit();
+  const range = new vscode.Range(0, 0, doc.lineCount, 0);
+  edit.replace(doc.uri, range, defaultQrcLines().join('\n'));
+
+  return vscode.workspace.applyEdit(edit);
+}

--- a/qt-core/src/webview/qrc-editor/editor-provider.ts
+++ b/qt-core/src/webview/qrc-editor/editor-provider.ts
@@ -1,0 +1,85 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import {
+  window,
+  Disposable,
+  WebviewPanel,
+  TextDocument,
+  ExtensionContext,
+  CancellationToken,
+  CustomTextEditorProvider
+} from 'vscode';
+
+import { EXTENSION_ID } from '@/constants';
+import {
+  createWebviewHtml,
+  createWebviewOptions,
+  basicWebviewAppConfig
+} from '@/webview/utils';
+import { QrcDocsManager } from './docs-manager';
+import { QrcEditorController } from './controller';
+
+export function registerQrcEditorProvider(context: ExtensionContext) {
+  const type = `${EXTENSION_ID}.qrcEditor`;
+  const provider = new QrcEditorProvider(context);
+  const reg = window.registerCustomEditorProvider(type, provider);
+
+  context.subscriptions.push(...[provider, reg]);
+}
+
+class QrcEditorProvider implements CustomTextEditorProvider {
+  private readonly _context: ExtensionContext;
+  private readonly _docsManager = new QrcDocsManager();
+  private readonly _controllers = new Map<WebviewPanel, QrcEditorController>();
+  private readonly _disposables: Disposable[] = [];
+
+  constructor(context: ExtensionContext) {
+    this._context = context;
+    this._disposables.push(this._docsManager);
+  }
+
+  public dispose() {
+    this._disposables.forEach((e) => {
+      e.dispose();
+    });
+  }
+
+  public async resolveCustomTextEditor(
+    doc: TextDocument,
+    panel: WebviewPanel,
+    token: CancellationToken
+  ): Promise<void> {
+    void token;
+
+    // view
+    const config = {
+      app: 'qrc-editor',
+      title: 'QRC editor',
+      context: this._context,
+      ...basicWebviewAppConfig
+    };
+
+    const view = panel.webview;
+    view.html = createWebviewHtml(view, config);
+    view.options = createWebviewOptions(config);
+
+    // doc
+    this._docsManager.add(doc);
+
+    // controller
+    const controller = new QrcEditorController(
+      view,
+      this._docsManager,
+      doc.uri.fsPath
+    );
+
+    this._controllers.set(panel, controller);
+    panel.onDidDispose(() => {
+      controller.dispose();
+      this._controllers.delete(panel);
+    });
+
+    return Promise.resolve();
+  }
+}

--- a/qt-core/src/webview/qrc-editor/node.ts
+++ b/qt-core/src/webview/qrc-editor/node.ts
@@ -1,0 +1,298 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import _ from 'lodash';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import { EXTENSION_ID } from '@/constants';
+import {
+  RccTag,
+  QResourceTag,
+  isQResourceTag,
+  FileTag,
+  isFileTag,
+  QrcNodePos
+} from '@/webview/shared/qrc-types';
+import { QrcDoc } from './doc';
+import * as utils from './utils';
+
+// Represents a single node in QRC data
+export class QrcNode {
+  public rcc: RccTag = { qresource: [], attributes: {} };
+  public group: QResourceTag | undefined;
+  public file: FileTag | undefined;
+  public pos: QrcNodePos;
+
+  public qrcDir = '';
+  public qrcUri: vscode.Uri | undefined;
+  public fileUri: vscode.Uri | undefined;
+
+  constructor(
+    public doc: QrcDoc,
+    groupKey: string,
+    fileIndex: number
+  ) {
+    this.pos = new QrcNodePos(groupKey, fileIndex);
+    this._update(doc, this.pos);
+  }
+
+  public addGroup(prefix: string): QResourceTag {
+    const group = {
+      file: [],
+      attributes: { prefix }
+    } as QResourceTag;
+
+    utils.updateGroupHashes(group);
+    group.attributes.__groupKey = utils.generateKey();
+    this.rcc.qresource.push(group);
+
+    return group;
+  }
+
+  public addFiles(absFilePaths: string[]): number[] {
+    if (!this.qrcUri || !this.group) {
+      return [];
+    }
+
+    const existingPaths = this.group.file.map((f) => f.text);
+    const added: FileTag[] = [];
+
+    absFilePaths
+      .filter((p) => p.startsWith(this.qrcDir))
+      .forEach((p) => {
+        const text = normalizeFilePath(this.qrcDir, p);
+        if (!existingPaths.includes(text)) {
+          added.push({
+            text,
+            attributes: {}
+          });
+        }
+      });
+
+    if (added.length !== 0) {
+      const prevLength = this.group.file.length;
+      this.group.file.push(...added);
+      utils.updateGroupHashes(this.group);
+
+      return _.range(prevLength, this.group.file.length);
+    }
+
+    return [];
+  }
+
+  public remove(): boolean {
+    if (!this.group) {
+      return false;
+    }
+
+    if (this.pos.fileIndex === -1) {
+      const groupIndex = this._findGroupIndex();
+      if (groupIndex >= 0) {
+        this.rcc.qresource.splice(groupIndex, 1);
+        return true;
+      }
+    } else {
+      this.group.file.splice(this.pos.fileIndex, 1);
+      return true;
+    }
+
+    return false;
+  }
+
+  public setAttribute(name: string, value: string): boolean {
+    name = name.trim();
+    value = value.trim();
+
+    if (name === 'alias' && this.file) {
+      this.file.attributes[name] = value;
+      return true;
+    }
+
+    if ((name === 'prefix' || name === 'lang') && this.group) {
+      this.group.attributes[name] = value;
+      return true;
+    }
+
+    return false;
+  }
+
+  public async copy(): Promise<boolean> {
+    const s = createJson(this.file ?? this.group);
+    if (s.length === 0) {
+      return false;
+    }
+
+    await vscode.env.clipboard.writeText(s);
+    return true;
+  }
+
+  public async paste() {
+    const text = await vscode.env.clipboard.readText();
+    const data = parseClipData(text);
+    if (!data) {
+      return undefined;
+    }
+
+    return this._insertClipData(data);
+  }
+
+  // private methods
+  private _findGroupIndex(): number {
+    if (this.pos.groupKey.length === 0) {
+      return -1;
+    }
+
+    return this.rcc.qresource.findIndex((g) => {
+      return g.attributes.__groupKey === this.pos.groupKey;
+    });
+  }
+
+  private _findGroupFromKey(groupKey: string): QResourceTag | undefined {
+    return this.rcc.qresource.find((g) => {
+      return g.attributes.__groupKey === groupKey;
+    });
+  }
+
+  private _update(doc: QrcDoc, pos: QrcNodePos) {
+    this.rcc = doc.rccTag ?? { qresource: [], attributes: {} };
+    this.group = this._findGroupFromKey(pos.groupKey);
+    this.file = this.group?.file[pos.fileIndex];
+
+    this.qrcDir = path.dirname(doc.uri.fsPath);
+    this.qrcUri = doc.uri;
+    this.fileUri = this.file
+      ? vscode.Uri.file(path.join(this.qrcDir, this.file.text))
+      : undefined;
+  }
+
+  private _insertClipData(data: QrcClipData) {
+    const type = data.header.type;
+    const body = data.body;
+
+    if (type === QrcClipTypeFile && this.group && isFileTag(body)) {
+      utils.updateFileHash(body);
+      const index = insertAfterOrPush(
+        this.group.file,
+        this.pos.fileIndex,
+        body
+      );
+
+      return {
+        groupKey: this.pos.groupKey,
+        fileIndexes: [index]
+      };
+    }
+
+    if (type === QrcClipTypeGroup && isQResourceTag(body)) {
+      utils.resolvePrefixClash(body, this.rcc);
+      utils.updateGroupHashes(body);
+      utils.ensureGroupKey(body);
+      insertAfterOrPush(this.rcc.qresource, this._findGroupIndex(), body);
+
+      return {
+        groupKey: body.attributes.__groupKey ?? '',
+        fileIndexes: [-1, ..._.range(0, body.file.length)]
+      };
+    }
+
+    return undefined;
+  }
+}
+
+// helpers
+function normalizeFilePath(qrcDir: string, absPath: string) {
+  const rel = path.relative(qrcDir, absPath);
+  return rel.replace(/\\/g, '/');
+}
+
+function insertAfterOrPush<T>(array: T[], index: number, item: T): number {
+  // inserts after the given index or appends.
+  // returns inserted index.
+  if (index < 0 || index >= array.length) {
+    array.push(item);
+    return array.length - 1;
+  }
+
+  array.splice(index + 1, 0, item);
+  return index + 1;
+}
+
+// helpers for copy/cut/paste
+const QrcClipSource = `vscode.${EXTENSION_ID}`;
+const QrcClipTypeFile = 'qrc.file';
+const QrcClipTypeGroup = 'qrc.group';
+
+interface QrcClipData {
+  header: {
+    source: typeof QrcClipSource;
+    type: typeof QrcClipTypeFile | typeof QrcClipTypeGroup;
+  };
+  body: FileTag | QResourceTag;
+}
+
+function isQrcClipData(x: unknown): x is QrcClipData {
+  if (
+    typeof x !== 'object' ||
+    x === null ||
+    !('header' in x) ||
+    !('body' in x)
+  ) {
+    return false;
+  }
+
+  // header
+  const h = x.header;
+  if (
+    typeof h !== 'object' ||
+    h === null ||
+    !('source' in h) ||
+    !('type' in h) ||
+    h.source !== QrcClipSource ||
+    (h.type !== QrcClipTypeFile && h.type !== QrcClipTypeGroup)
+  ) {
+    return false;
+  }
+
+  // body
+  const b = x.body;
+  if (typeof b !== 'object' || b === null) {
+    return false;
+  }
+
+  return h.type === QrcClipTypeFile ? isFileTag(b) : isQResourceTag(b);
+}
+
+function createJson(tag: FileTag | QResourceTag | undefined): string {
+  const type = isFileTag(tag)
+    ? QrcClipTypeFile
+    : isQResourceTag(tag)
+      ? QrcClipTypeGroup
+      : undefined;
+
+  if (!type) {
+    return '';
+  }
+
+  const body = _.cloneDeep(tag);
+  utils.cleanTagDeep(body);
+
+  return JSON.stringify({
+    body,
+    header: { source: QrcClipSource, type }
+  });
+}
+
+function parseClipData(text: string): QrcClipData | undefined {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+
+  try {
+    const o: unknown = JSON.parse(trimmed);
+    return isQrcClipData(o) ? o : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/qt-core/src/webview/qrc-editor/utils.ts
+++ b/qt-core/src/webview/qrc-editor/utils.ts
@@ -1,0 +1,107 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import { createHash } from 'crypto';
+
+import {
+  RccTag,
+  QResourceTag,
+  Attributes,
+  isRccTag,
+  isQResourceTag,
+  isFileTag,
+  FileTag
+} from '@/webview/shared/qrc-types';
+
+export function makeUniqueName(name: string, alreadyUsed: Set<string>): string {
+  if (!alreadyUsed.has(name)) {
+    return name;
+  }
+
+  const maxAttempts = 10_000; // arbitrary big number
+
+  for (let c = 1; c < maxAttempts; ++c) {
+    const modified = `${name}${c}`;
+    if (!alreadyUsed.has(modified)) {
+      return modified;
+    }
+  }
+
+  return name;
+}
+
+export function updateFileHash(f: FileTag) {
+  const raw = [f.text, f.attributes.alias ?? '', f.attributes.empty ?? ''].join(
+    '|'
+  );
+
+  f.attributes.__hash = hashString(raw);
+}
+
+export function updateGroupHashes(g: QResourceTag) {
+  const raw = [g.attributes.prefix ?? '', g.attributes.lang ?? ''].join('|');
+
+  g.attributes.__hash = hashString(raw);
+
+  g.file.forEach((f) => {
+    updateFileHash(f);
+  });
+  g.attributes.__groupFilesHash = hashString(
+    g.file.map((f) => f.attributes.__hash).join('|')
+  );
+}
+
+export function resolvePrefixClash(group: QResourceTag, rcc: RccTag) {
+  let prefix = group.attributes.prefix ?? '';
+  prefix = prefix.length === 0 ? '/' : prefix;
+  prefix = makeUniqueName(
+    prefix,
+    new Set(rcc.qresource.map((g) => g.attributes.prefix ?? ''))
+  );
+
+  group.attributes.prefix = prefix;
+}
+
+export function ensureGroupKey(group: QResourceTag) {
+  group.attributes.__groupKey ??= generateKey();
+}
+
+export function generateKey() {
+  return crypto.randomUUID();
+}
+
+export function cleanTagDeep(tag: unknown) {
+  if (isRccTag(tag)) {
+    tag.attributes = cleanAttributes(tag.attributes);
+    tag.qresource.forEach((g) => {
+      cleanTagDeep(g);
+    });
+  } else if (isQResourceTag(tag)) {
+    tag.attributes = cleanAttributes(tag.attributes);
+    tag.file.forEach((f) => {
+      cleanTagDeep(f);
+    });
+  } else if (isFileTag(tag)) {
+    tag.attributes = cleanAttributes(tag.attributes);
+  }
+}
+
+// helpers
+function cleanAttributes(attrs: Attributes): Attributes {
+  // Removes unwanted attributes:
+  // 1) Attributes with an empty string value (e.g., alias='', lang='', ...)
+  // 2) Internal attributes prefixed with '__'
+  const result: Attributes = {};
+
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value !== '' && !key.startsWith('__')) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+function hashString(input: string, length = 12): string {
+  return createHash('md5').update(input).digest('hex').slice(0, length);
+}

--- a/qt-core/src/webview/qrc-editor/xml-io.ts
+++ b/qt-core/src/webview/qrc-editor/xml-io.ts
@@ -1,0 +1,157 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import _ from 'lodash';
+import { XMLParser, XMLBuilder } from 'fast-xml-parser';
+
+import {
+  type RccTag,
+  QResourceTag,
+  FileTag,
+  isRccTag,
+  isAttributes
+} from '@/webview/shared/qrc-types';
+import { cleanTagDeep } from './utils';
+
+const xmlOptions = {
+  // attributes
+  ignoreAttributes: false,
+  attributeNamePrefix: '',
+  attributesGroupName: 'attributes',
+
+  // text
+  textNodeName: 'text',
+  alwaysCreateTextNode: true,
+
+  // tag
+  isArray: (
+    tagName: string,
+    _jPath: string,
+    _isLeafNode: boolean,
+    _isAttribute: boolean
+  ): boolean => {
+    void _jPath;
+    void _isLeafNode;
+    void _isAttribute;
+
+    return tagName === 'file' || tagName === 'qresource';
+  }
+};
+
+export function parseXml(data: string): RccTag | undefined {
+  const parser = new XMLParser(xmlOptions);
+  const asJson: unknown = parser.parse(data);
+  if (typeof asJson !== 'object' || asJson === null || !('RCC' in asJson)) {
+    return undefined;
+  }
+
+  const rcc: unknown = asJson.RCC;
+  normalizeRccTag(rcc);
+  if (!isRccTag(rcc)) {
+    return undefined;
+  }
+
+  return rcc;
+}
+
+export function generateXml(qrc: RccTag): string {
+  const builder = new XMLBuilder({
+    format: true,
+    suppressBooleanAttributes: false,
+    ...xmlOptions
+  });
+
+  const clone = cloneAndClean(qrc);
+  const xmlString = builder.build({ RCC: clone });
+
+  return `<!DOCTYPE RCC>\n${xmlString}`;
+}
+
+export function defaultQrcLines() {
+  return [
+    '<!DOCTYPE RCC>',
+    '<RCC version="1.0">',
+    '  <qresource prefix="/">',
+    '  </qresource>',
+    '<RCC>',
+    ''
+  ];
+}
+
+// helpers
+function cloneAndClean(qrc: RccTag): RccTag {
+  const clone = _.cloneDeep(qrc);
+  cleanTagDeep(clone);
+
+  return clone;
+}
+
+function normalizeRccTag(x: unknown) {
+  if (!isRccTagLike(x)) {
+    return;
+  }
+
+  x.attributes ??= {};
+  x.qresource ??= [];
+  x.qresource.forEach((qres: Partial<QResourceTag>) => {
+    if (isQResourceTagLike(qres)) {
+      qres.attributes ??= {};
+      qres.file ??= [];
+      qres.file.forEach((f: Partial<FileTag>) => {
+        if (isFileTagLike(f)) {
+          const file = f;
+          file.attributes ??= {};
+        }
+      });
+    }
+  });
+}
+
+function isRccTagLike(x: unknown): x is Partial<RccTag> {
+  if (typeof x !== 'object' || x === null) {
+    return false;
+  }
+
+  const o = x as Record<string, unknown>;
+  if ('qresource' in o) {
+    if (!Array.isArray(o.qresource)) {
+      return false;
+    }
+    if (!o.qresource.every(isQResourceTagLike)) {
+      return false;
+    }
+  }
+
+  return !('attributes' in o) || isAttributes(o.attributes);
+}
+
+function isQResourceTagLike(x: unknown): x is Partial<QResourceTag> {
+  if (typeof x !== 'object' || x === null) {
+    return false;
+  }
+
+  const o = x as Record<string, unknown>;
+  if ('file' in o) {
+    if (!Array.isArray(o.file)) {
+      return false;
+    }
+    if (!o.file.every(isFileTagLike)) {
+      return false;
+    }
+  }
+
+  return !('attributes' in o) || isAttributes(o.attributes);
+}
+
+export function isFileTagLike(x: unknown): x is Partial<FileTag> {
+  if (typeof x !== 'object' || x === null) {
+    return false;
+  }
+
+  const o = x as Record<string, unknown>;
+  if (!('text' in o) || typeof o.text !== 'string') {
+    return false;
+  }
+
+  return !('attributes' in o) || isAttributes(o.attributes);
+}

--- a/qt-core/src/webview/shared/message.ts
+++ b/qt-core/src/webview/shared/message.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 export enum CommandId {
+  Invalid = -1,
+
   // new-item wizard
   UiClosed,
   UiItemCreationRequested,
@@ -12,13 +14,27 @@ export enum CommandId {
   UiGetPresetById,
   UiValidateInputs,
   UiManageCustomPreset,
-  UiSelectWorkingDir
+  UiSelectWorkingDir,
+
+  // qrc editor
+  QrcDocChanged,
+  QrcAddFiles,
+  QrcAddNewGroup,
+  QrcGetRccTag,
+  QrcGetFileInfo,
+  QrcClean,
+  QrcRemove,
+  QrcSetProp,
+  QrcSortAll,
+  QrcRunVscodeUiAction,
+  QrcRunClipboardAction
 }
 
 export const OneWayCommandIds = [
   CommandId.UiClosed,
   CommandId.UiItemCreationRequested,
-  CommandId.UiHasError
+  CommandId.UiHasError,
+  CommandId.QrcDocChanged
 ];
 
 export interface Command<T = unknown> {

--- a/qt-core/src/webview/shared/qrc-types.ts
+++ b/qt-core/src/webview/shared/qrc-types.ts
@@ -1,0 +1,225 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import { CommandId } from './message';
+
+// types for xml serialization
+export interface RccTag {
+  qresource: QResourceTag[];
+  attributes: Attributes;
+}
+
+export interface QResourceTag {
+  file: FileTag[];
+  attributes: Attributes;
+}
+
+export interface FileTag {
+  text: string;
+  attributes: Attributes;
+}
+
+export interface Attributes {
+  version?: string; // <RCC>
+  lang?: string; // <qresource>
+  prefix?: string; // <qresource>
+  alias?: string; // <file>
+  empty?: string; // <file>
+
+  // internal use
+  __hash?: string;
+  __groupKey?: string;
+  __groupFilesHash?: string;
+
+  // to preserve unknown attributes
+  [key: string]: string;
+}
+
+export function isRccTag(x: unknown): x is RccTag {
+  if (typeof x !== 'object' || x === null) {
+    return false;
+  }
+
+  const o = x as Record<string, unknown>;
+  if (!('qresource' in o)) {
+    return false;
+  }
+  if (!Array.isArray(o.qresource)) {
+    return false;
+  }
+  if (!o.qresource.every(isQResourceTag)) {
+    return false;
+  }
+
+  return 'attributes' in o && isAttributes(o.attributes);
+}
+
+export function isQResourceTag(x: unknown): x is QResourceTag {
+  if (typeof x !== 'object' || x === null) {
+    return false;
+  }
+
+  const o = x as Record<string, unknown>;
+  if (!('file' in o)) {
+    return false;
+  }
+  if (!Array.isArray(o.file)) {
+    return false;
+  }
+  if (!o.file.every(isFileTag)) {
+    return false;
+  }
+
+  return 'attributes' in o && isAttributes(o.attributes);
+}
+
+export function isFileTag(x: unknown): x is FileTag {
+  if (typeof x !== 'object' || x === null) {
+    return false;
+  }
+
+  const o = x as Record<string, unknown>;
+  if (!('text' in o) || typeof o.text !== 'string') {
+    return false;
+  }
+
+  return 'attributes' in o && isAttributes(o.attributes);
+}
+
+export function isAttributes(x: unknown): x is Attributes {
+  if (typeof x !== 'object' || x === null) {
+    return false;
+  }
+
+  for (const v of Object.values(x)) {
+    if (typeof v !== 'string') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export type QrcCommandPayloadType =
+  | QrcNodePosData
+  | (QrcNodePosData & { files: string[] })
+  | (QrcNodePosData & { action: string })
+  | (QrcNodePosData & { thumbnailSize: number })
+  | (QrcNodePosData & { name: string; value: string });
+
+export type QrcCommandReplyType =
+  | RccTag
+  | { status: 'done' }
+  | { exists: boolean; thumbnail?: number[] }
+  | { action: 'add' | 'paste'; groupKey: string; fileIndexes: number[] };
+
+export interface QrcDocChangeEvent {
+  key: string;
+  reason: 'command' | 'undo/redo' | 'not-specified';
+  commandId?: CommandId;
+}
+
+export function isQrcDocChangeEvent(x: unknown): x is QrcDocChangeEvent {
+  if (typeof x !== 'object' || x === null) {
+    return false;
+  }
+
+  const o = x as Record<string, unknown>;
+  if (!('key' in o) || typeof o.key !== 'string') {
+    return false;
+  }
+
+  if (!('reason' in o) || typeof o.reason !== 'string') {
+    return false;
+  }
+
+  if (
+    o.reason !== 'command' &&
+    o.reason !== 'undo/read' &&
+    o.reason !== 'not-specified'
+  ) {
+    return false;
+  }
+
+  if ('commandId' in o && typeof o.commandId !== 'number') {
+    return false;
+  }
+
+  return true;
+}
+
+// node position data and a wrapper class
+interface QrcNodePosData {
+  groupKey: string;
+  fileIndex: number;
+}
+
+export class QrcNodePos implements QrcNodePosData {
+  public groupKey = '';
+  public fileIndex = -1;
+
+  constructor(groupKey = '', fileIndex = -1) {
+    this.setData(groupKey, fileIndex);
+  }
+
+  public equals(rhs: QrcNodePos): boolean {
+    return this.groupKey === rhs.groupKey && this.fileIndex === rhs.fileIndex;
+  }
+
+  public isValid() {
+    return this.groupKey.length !== 0;
+  }
+
+  public isGroup() {
+    return this.groupKey.length !== 0 && this.fileIndex === -1;
+  }
+
+  public isFile() {
+    return this.groupKey.length !== 0 && this.fileIndex !== -1;
+  }
+
+  public toJson() {
+    return {
+      groupKey: this.groupKey,
+      fileIndex: this.fileIndex
+    };
+  }
+
+  public toString(): string {
+    return QrcNodePos._createId(this.groupKey, this.fileIndex);
+  }
+
+  public setData(groupKey: string, fileIndex: number): boolean {
+    if (this.groupKey !== groupKey || this.fileIndex !== fileIndex) {
+      this.groupKey = groupKey;
+      this.fileIndex = fileIndex;
+      return true;
+    }
+
+    return false;
+  }
+
+  public setDataFromId(id: string) {
+    const n = QrcNodePos._parseId(id);
+    if (n) {
+      return this.setData(n.groupKey, n.fileIndex);
+    }
+
+    return false;
+  }
+
+  private static _createId(groupKey: string, fileIndex: number) {
+    return `qrcnode|${groupKey}|${fileIndex}`;
+  }
+
+  private static _parseId(id: string) {
+    const match = id.match(/^qrcnode\|(.+)\|(-?\d+)$/);
+    if (match) {
+      const groupKey = match[1];
+      const file = Number(match[2]);
+      return new QrcNodePos(groupKey, file);
+    }
+
+    return undefined;
+  }
+}

--- a/qt-core/tsconfig.json
+++ b/qt-core/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "target": "ES2020",
     "types": ["node"],
     "outDir": "out",

--- a/qt-core/webview-ui/src/apps/main.ts
+++ b/qt-core/webview-ui/src/apps/main.ts
@@ -3,8 +3,12 @@
 
 import { mount } from 'svelte';
 import NewItem from './new-item/NewItemApp.svelte';
+import QrcEditor from './qrc-editor/QrcEditorApp.svelte';
 
-const app = mount(NewItem, {
+const appType = document.body.dataset.app;
+const appComp = appType === 'qrc-editor' ? QrcEditor : NewItem
+
+const app = mount(appComp, {
   target: document.getElementById('app')!
 });
 

--- a/qt-core/webview-ui/src/apps/qrc-editor/QrcEditorApp.svelte
+++ b/qt-core/webview-ui/src/apps/qrc-editor/QrcEditorApp.svelte
@@ -1,0 +1,61 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+
+  import '@/styles/app.css';
+  import * as texts from '@/apps/texts';
+  import DropMask from '@/comps/DropMask.svelte';
+  import { DragDropHandler } from '@/comps/DragDropHandler.svelte';
+
+  import QrcView from './QrcView.svelte';
+  import QrcPropInput from './QrcPropInput.svelte';
+  import QrcEditorHeader from './QrcEditorHeader.svelte';
+  import { data } from './states.svelte';
+  import * as viewlogic from './viewlogic.svelte';
+  import type { GroupNodeWrapper } from './types.svelte';
+
+  let numGroups = $derived(data.groups.length);
+  let numFiles = $derived.by(() => {
+    return data.groups.reduce(
+      (sum: number, g: GroupNodeWrapper) => sum + (g.numFiles()), 0
+    );
+  });
+
+  let dnd = $state(undefined as DragDropHandler | undefined);
+  let dropTarget: HTMLElement;;
+
+  onMount(() => {
+    dnd = new DragDropHandler(dropTarget);
+    dnd.onDrop = (files: string[]) => { viewlogic.addFiles(files); };
+    dnd.attach();
+
+    viewlogic.onAppMount();
+  });
+
+  onDestroy(() => dnd?.detach());
+</script>
+
+<div class='w-screen h-screen p-2 flex flex-col gap-2'>
+  <!-- header -->
+  <QrcEditorHeader />
+
+  <!-- list with drop mask -->
+  <div class="flex-1 p-2 qt-surface flex flex-col gap-2 min-h-0">
+    {texts.qrc.stats(numGroups, numFiles)}
+
+    <div bind:this={dropTarget} class="flex-1 min-h-0 relative">
+      <QrcView />
+
+      {#if dnd && dnd.dragging}
+        <DropMask />
+      {/if}
+    </div>
+  </div>
+
+  <!-- input panel -->
+  <QrcPropInput />
+</div>

--- a/qt-core/webview-ui/src/apps/qrc-editor/QrcEditorHeader.svelte
+++ b/qt-core/webview-ui/src/apps/qrc-editor/QrcEditorHeader.svelte
@@ -1,0 +1,97 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import {
+    Trash2,
+    FilePlus,
+    FolderPlus,
+    ArrowDownAZ,
+    ExternalLink,
+    ChevronsDown,
+    BrushCleaning
+  } from '@lucide/svelte';
+
+  import * as texts from '@/apps/texts';
+  import IconButton from '@/comps/IconButton.svelte';
+  import { data, ui } from './states.svelte';
+  import * as viewlogic from './viewlogic.svelte';
+
+  let empty = $derived(data.groups.length === 0);
+  let hasOpenedGroup = $derived.by(() => {
+    for (const g of data.groups) {
+      if (g.opened) {
+        return true;
+      }
+    }
+
+    return false;
+  })
+</script>
+
+<div class="w-full mt-2 flex flex-row items-center gap-2">
+   <IconButton
+    icon={FolderPlus}
+    text={texts.qrc.buttons.addGroup}
+    tooltip={texts.qrc.tooltips.addGroup}
+    tooltipPlacement='bottom-start'
+    onClicked={viewlogic.addNewGroup}
+  />
+
+  <IconButton
+    icon={FilePlus}
+    text={texts.qrc.buttons.addFiles}
+    tooltip={texts.qrc.tooltips.addFiles}
+    tooltipPlacement='bottom'
+    disabled={empty}
+    onClicked={viewlogic.addFilesFromDialog}
+  />
+
+  <IconButton
+    icon={Trash2}
+    text={texts.qrc.buttons.delete}
+    tooltip={texts.qrc.tooltips.delete}
+    tooltipPlacement='bottom'
+    disabled={empty}
+    onClicked={viewlogic.removeCurrent}
+  />
+
+  <div class="grow"></div>
+
+  <IconButton flat square class="w-1"
+    icon={ChevronsDown}
+    iconClass={`
+      transition-transform duration-200
+      ${hasOpenedGroup ? 'rotate-180' : ''}
+    `}
+    tooltip={texts.qrc.tooltips.expandCollaps}
+    tooltipPlacement='bottom-end'
+    disabled={empty}
+    onClicked={() => viewlogic.setAllGroupsOpened(!hasOpenedGroup)}
+  />
+
+  <IconButton flat square class="w-1"
+    icon={ArrowDownAZ}
+    tooltip={texts.qrc.tooltips.sort}
+    tooltipPlacement='bottom-end'
+    disabled={empty}
+    onClicked={viewlogic.sortAll}
+  />
+
+  <IconButton flat square class="w-1"
+    icon={BrushCleaning}
+    tooltip={texts.qrc.tooltips.clean}
+    tooltipPlacement="bottom-end"
+    disabled={empty}
+    onClicked={viewlogic.clean}
+  />
+
+  <IconButton flat square class="w-1"
+    icon={ExternalLink}
+    tooltip={texts.qrc.tooltips.openInTextEditor}
+    tooltipPlacement='bottom-end'
+    onClicked={() => viewlogic.runVscodeUiAction('openQrcInTextEditor')}
+  />
+</div>

--- a/qt-core/webview-ui/src/apps/qrc-editor/QrcFileItem.svelte
+++ b/qt-core/webview-ui/src/apps/qrc-editor/QrcFileItem.svelte
@@ -1,0 +1,78 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { TriangleAlert } from '@lucide/svelte';
+
+  import * as texts from '@/apps/texts';
+  import { data, ui } from './states.svelte';
+  import * as viewlogic from './viewlogic.svelte';
+  import { FileNodeWrapper } from './types.svelte';
+  import QrcFileItemThumbnail from './QrcFileItemThumbnail.svelte';
+
+  let {
+    file = new FileNodeWrapper()
+  }: {
+    file: FileNodeWrapper
+  } = $props();
+
+  let id = $derived.by(() => file.pos.toString());
+  let loaded = $derived.by(() => data.fileInfo[file.text]);
+  let exists = $derived.by(() => loaded?.exists ?? false);
+  let okay = $derived.by(() => (exists || (!exists && file.empty)));
+  let current = $derived.by(() => ui.cursor.currentPos.equals(file.pos));
+</script>
+
+<button
+  {id}
+  class={`w-full qt-item${current ? '-selected' : ''} !p-0 relative`}
+  onclick={() => ui.cursor.moveToPos(file.pos)}
+  ondblclick={() => viewlogic.runVscodeUiAction('openFile')}
+>
+  {#if file.highlighted}
+    <div class="absolute w-full h-full top-0 left-0
+      bg-[var(--qt-primary-hoverBackground)] opacity-25
+      pointer-events-none"
+    >
+    </div>
+  {/if}
+
+  <div class='ml-12 flex flex-row gap-2 items-center p-0'>
+    <!-- thumbnail -->
+    <QrcFileItemThumbnail {file} />
+
+    <!-- text -->
+    <div class={`${(loaded && !okay) ? 'line-through' : ''} text-left p-0.5`}>
+      {file.text}
+    </div>
+
+    <!-- alias badge -->
+    {#if file.alias.length !== 0}
+      <div class={`qt-badge${current ? '' : '-primary'} `}>
+        {texts.qrc.annotation.alias(file.alias)}
+      </div>
+    {/if}
+
+    {#if loaded}
+      <!-- empty-attribute badge -->
+      {#if file.empty}
+        <div class={`qt-badge${current ? '' : '-primary'} `}>
+          {texts.qrc.annotation.empty}
+        </div>
+      {/if}
+
+      <!-- not-found warning -->
+      {#if !okay}
+        <div class={`
+          flex flex-row gap-2 items-center
+          ${current ? '' : 'qt-warning-color'}
+        `}>
+          <TriangleAlert />
+          {texts.qrc.annotation.notFound}
+        </div>
+      {/if}
+    {/if}
+  </div>
+</button>

--- a/qt-core/webview-ui/src/apps/qrc-editor/QrcFileItemThumbnail.svelte
+++ b/qt-core/webview-ui/src/apps/qrc-editor/QrcFileItemThumbnail.svelte
@@ -1,0 +1,38 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { File } from '@lucide/svelte';
+
+  import { data } from './states.svelte';
+  import { FileNodeWrapper } from './types.svelte';
+  import * as viewlogic from './viewlogic.svelte';
+
+  let {
+    file = new FileNodeWrapper()
+  }: {
+    file: FileNodeWrapper
+  } = $props();
+
+  let info = $derived.by(() => { return data.fileInfo[file.text]; });
+  let url = $derived.by(() => { return info?.thumbnailUrl; });
+  const sizeClass = 'w-[16px] h-[16px]';
+
+  onMount(() => {
+    viewlogic.updateFileInfo(file);
+  });
+</script>
+
+{#if info && info.thumbnailUrl.length !== 0}
+  <img src={url} alt="thumbnail"
+    class={`${sizeClass} object-contain qt-checker-4px`}
+  />
+{:else}
+  <div class={`flex items-center justify-center ${sizeClass}`}>
+    {#if info?.exists}
+      <File />
+    {/if}
+  </div>
+{/if}

--- a/qt-core/webview-ui/src/apps/qrc-editor/QrcGroupItem.svelte
+++ b/qt-core/webview-ui/src/apps/qrc-editor/QrcGroupItem.svelte
@@ -1,0 +1,76 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { ChevronRight } from '@lucide/svelte';
+
+  import { ui } from './states.svelte';
+  import { GroupNodeWrapper } from './types.svelte';
+  import QrcFileItem from './QrcFileItem.svelte';
+
+  let {
+    group = new GroupNodeWrapper()
+  }: {
+    group: GroupNodeWrapper
+  } = $props();
+
+  let id = $derived.by(() => { return group.pos.toString(); });
+  let files = $derived.by(() => group.allFiles());
+  let current = $derived.by(() => ui.cursor.currentPos.equals(group.pos));
+
+  const select = () => ui.cursor.moveToPos(group.pos);
+  const toggleOpened = () => group.setOpened(!group.opened);
+</script>
+
+<button
+  {id}
+  class={`w-full qt-item${current ? '-selected' : ''} !p-0 relative`}
+  onclick={select}
+  ondblclick={toggleOpened}
+>
+  {#if group.highlighted}
+    <div class="absolute w-full h-full top-0 left-0
+      bg-[var(--qt-primary-hoverBackground)] opacity-25
+      pointer-events-none"
+    >
+    </div>
+  {/if}
+
+  <div class="w-full flex flex-row gap-2 items-center text-left p-0.5">
+    <!-- expand/collapse icon -->
+    <ChevronRight
+      class={`${group.opened ? 'rotate-90' : ''}`}
+      onclick={(e) => {
+        select();
+        toggleOpened();
+        e.stopPropagation();
+      }}
+    />
+
+    <!-- text -->
+    {group.prefix}
+
+    <!-- language -->
+    {#if group.language.length !== 0}
+      <div class={`qt-badge${current ? '' : '-primary'} `}>
+        {group.language}
+      </div>
+    {/if}
+
+    <!-- spacer, annotation -->
+    <div class="grow"></div>
+    <div class="text-sm px-1.5 bg-gray-500/25 mr-0.5 qt-border-radius">
+      {group.numFiles()}
+    </div>
+  </div>
+</button>
+
+<!-- children for files in group -->
+{#if group.opened && (files.length !== 0)}
+  {#each files as file (file)}
+    <QrcFileItem {file} />
+  {/each}
+{/if}
+

--- a/qt-core/webview-ui/src/apps/qrc-editor/QrcPropInput.svelte
+++ b/qt-core/webview-ui/src/apps/qrc-editor/QrcPropInput.svelte
@@ -1,0 +1,57 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { P } from 'flowbite-svelte';
+  import { List } from '@lucide/svelte';
+
+  import * as texts from '@/apps/texts';
+  import InputWithIssue from '@/comps/InputWithIssue.svelte';
+  import { ui } from './states.svelte';
+  import * as viewlogic from './viewlogic.svelte';
+  import type { QrcPropName } from './types.svelte';
+
+  const fields = [
+    {
+      name: 'alias' as QrcPropName,
+      label: texts.qrc.props.alias,
+      input: ui.inputs.alias,
+      isEnabled: () => { return ui.cursor.currentPos.isFile() ?? false; }
+    },
+    {
+      name: 'prefix' as QrcPropName,
+      label: texts.qrc.props.prefix,
+      input: ui.inputs.prefix,
+      isEnabled: () => { return ui.cursor.currentPos.isGroup() ?? false; }
+    },
+    {
+      name: 'lang' as QrcPropName,
+      label: texts.qrc.props.language,
+      input: ui.inputs.language,
+      isEnabled: () => { return ui.cursor.currentPos.isGroup() ?? false; }
+    }
+  ];
+</script>
+
+<div class="flex flex-col gap-2 qt-surface p-2">
+  <div class="flex flex-row gap-2 items-center qt-label highlight">
+    <List />
+    {texts.qrc.props.title}
+  </div>
+  <div class="grid grid-cols-[max-content_1fr] gap-2 items-center ml-2">
+    {#each fields as { name, label, input, isEnabled } (name)}
+      <P class={`qt-label ${isEnabled() ? '' : 'dimmed'}`}>
+        {label}:
+      </P>
+      <InputWithIssue
+        bind:value={input.value}
+        level='error'
+        message={input.error}
+        disabled={!isEnabled()}
+        onInput={() => { void viewlogic.setProp(name); }}
+      />
+    {/each}
+  </div>
+</div>

--- a/qt-core/webview-ui/src/apps/qrc-editor/QrcView.svelte
+++ b/qt-core/webview-ui/src/apps/qrc-editor/QrcView.svelte
@@ -1,0 +1,55 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { Plus } from '@lucide/svelte';
+
+  import * as texts from '@/apps/texts';
+  import IconButton from '@/comps/IconButton.svelte';
+  import QrcGroupItem from './QrcGroupItem.svelte';
+  import { data } from './states.svelte';
+  import * as viewlogic from './viewlogic.svelte';
+  import { onMount } from 'svelte';
+
+  let tree: HTMLDivElement;
+
+  onMount(() => {
+    tree.addEventListener('keydown', e => viewlogic.onKeydown(e));
+    tree.addEventListener('contextmenu', // disable default context menu
+      e => e.preventDefault(),
+      { capture: true }
+    );
+  });
+</script>
+
+<div class="w-full h-full qt-surface-bright overflow-y-auto">
+  <!-- data view -->
+  <div
+    bind:this={tree}
+    role="listbox"
+    class="h-full items-center focus:qt-focus-tightRing"
+    tabindex={0}
+  >
+    {#if data.groups.length !== 0}
+      <!-- list view -->
+      {#each data.groups as group, groupIndex (groupIndex)}
+        <QrcGroupItem {group} />
+      {/each}
+    {:else}
+      <!-- when there's no data -->
+      <div class="w-full h-full flex flex-col items-center gap-6 justify-center">
+        <div class="flex flex-row items-center gap-2">
+          {texts.qrc.noItems.info}
+        </div>
+        <IconButton
+          align="row"
+          icon={Plus}
+          text={texts.qrc.noItems.addGroup}
+          onClicked={viewlogic.addNewGroup}
+        />
+      </div>
+    {/if}
+  </div>
+</div>

--- a/qt-core/webview-ui/src/apps/qrc-editor/states.svelte.ts
+++ b/qt-core/webview-ui/src/apps/qrc-editor/states.svelte.ts
@@ -1,0 +1,19 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import {
+  type FileInfo,
+  GroupNodeWrapper,
+  CursorManager,
+  PropInputsManager,
+} from './types.svelte';
+
+export const data = $state({
+  groups: [] as GroupNodeWrapper[],
+  fileInfo: {} as Record<string, FileInfo>,
+})
+
+export const ui = $state({
+  cursor: new CursorManager(),
+  inputs: new PropInputsManager(),
+})

--- a/qt-core/webview-ui/src/apps/qrc-editor/types.svelte.ts
+++ b/qt-core/webview-ui/src/apps/qrc-editor/types.svelte.ts
@@ -1,0 +1,418 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import _ from 'lodash';
+import { z } from "zod";
+
+import {
+  type QResourceTag,
+  type FileTag,
+  QrcNodePos
+} from '@shared/qrc-types';
+import * as texts from '@/apps/texts';
+
+export type QrcPropName =  'alias' | 'prefix' | 'lang';
+export type QrcClipboardAction = 'copy' | 'cut' | 'paste';
+export type QrcVscodeUiAction =
+  | 'openFile'
+  | 'openQrcInTextEditor'
+  | 'revealFileInExplorer';
+
+export interface PropInputConfig {
+  enabled: boolean;
+  value?: string;
+}
+
+export class PropInputField {
+  public value = $state('');
+  public enabled = $state(false);
+  public error = $state('');
+  public schema: z.ZodTypeAny | undefined;
+
+  public validate() {
+    if (this.schema && this.enabled) {
+      const r = this.schema.safeParse(this.value.trim());
+      this.error = r.success ? "" : r.error.errors[0].message;
+    } else {
+      this.error = '';
+    }
+  }
+}
+
+export class PropInputsManager {
+  public alias = new PropInputField();
+  public prefix = new PropInputField();
+  public language = new PropInputField();
+
+  constructor() {
+    this.alias.schema = z.union([
+      z.literal(""),
+      z.string()
+        .max(30, { message: texts.qrc.errors.tooLong })
+    ]);
+
+    this.prefix.schema = z
+      .string()
+      .trim()
+      .nonempty({ message: texts.qrc.errors.prefixEmpty })
+      .max(30, { message: texts.qrc.errors.tooLong })
+      .startsWith("/", { message: texts.qrc.errors.prefixStart });
+
+    this.language.schema = z.union([
+      z.literal(""),
+      z.string().regex(
+        /^[a-z]{2}(_[A-Z]{2})?$/,
+        { message: texts.qrc.errors.invalidLang }
+      )
+    ]);
+  }
+
+  public find(name: QrcPropName) {
+    if (name === "alias") return this.alias;
+    if (name === 'prefix') return this.prefix;
+    if (name === 'lang') return this.language;
+    return undefined;
+  }
+
+  public applyConfig(name: QrcPropName, config: PropInputConfig) {
+    const input = this.find(name);
+    if (!input) {
+      return;
+    }
+
+    input.enabled = config.enabled;
+    input.value = config.value ?? '';
+    if (input.enabled) {
+      input.validate();
+    } else {
+      input.error = '';
+    }
+  }
+
+  public applyConfigs(all: Record<QrcPropName, PropInputConfig>) {
+    for (const key in all) {
+      const name = key as QrcPropName;
+      this.applyConfig(name, all[name]);
+    }
+  }
+
+  public validateAll() {
+    this.alias.validate();
+    this.prefix.validate();
+    this.language.validate();
+  }
+}
+
+export interface FileInfo {
+  exists: boolean,
+  thumbnailUrl: string
+}
+
+export class GroupNodeWrapper {
+  private _group: QResourceTag | undefined;
+  private _files: FileNodeWrapper[] = [];
+  private _highlighted = $state(false);
+  private _opened = $state(false);
+  private _onOpenedChanged?: (opened: boolean) => void;
+
+  constructor(tag?: QResourceTag) {
+    this._group = tag;
+    this._files = tag?.file.map((f, i) => {
+      return new FileNodeWrapper(this, f, i);
+    }) ?? [];
+  }
+
+  get pos(): QrcNodePos {
+    return new QrcNodePos(this.key);
+  }
+
+  get key(): string {
+    return this._group?.attributes.__groupKey ?? '';
+  }
+
+  get hash(): string {
+    return this._group?.attributes.__hash ?? '';
+  }
+
+  get filesHash(): string {
+    return this._group?.attributes.__groupFilesHash ?? '';
+  }
+
+  get prefix(): string {
+    return this._group?.attributes.prefix ?? '';
+  }
+
+  get language(): string {
+    return this._group?.attributes.lang ?? '';
+  }
+
+  get opened(): boolean {
+    return this._opened;
+  }
+
+  get highlighted(): boolean {
+    return this._highlighted;
+  }
+
+  public numFiles(): number {
+    return this._files.length;
+  }
+
+  public fileAt(index: number): FileNodeWrapper | undefined {
+    return this._files[index];
+  }
+
+  public allFiles(): FileNodeWrapper[] {
+    return this._files;
+  }
+
+  public onOpenedChanged(callback: (opened: boolean) => void) {
+    this._onOpenedChanged = callback;
+  }
+
+  public setOpened(open: boolean) {
+    if (this._opened !== open) {
+      this._opened = open;
+      this._onOpenedChanged?.(open);
+    }
+  }
+
+  public setHighlighted(highlight: boolean) {
+    this._highlighted = highlight;
+  }
+
+  public setFilesHighlighted(fileIndexes: number[], highlight: boolean) {
+    fileIndexes.map(i => {
+      const file = this._files[i];
+      if (file) {
+        file.setHighlighted(highlight);
+      }
+    })
+  }
+
+  public setAllFilesHighlighted(highlight: boolean) {
+    this.setFilesHighlighted(_.range(0, this._files.length), highlight);
+  }
+
+  public static createList(tags: QResourceTag[]) {
+    return tags.map(tag => new GroupNodeWrapper(tag));
+  }
+}
+
+export class FileNodeWrapper {
+  private _file: FileTag | undefined;
+  private _index: number = -1;
+  private _pos: QrcNodePos;
+  private _highlighted = $state(false);
+
+  constructor(group?: GroupNodeWrapper, tag?: FileTag, index?: number) {
+    this._file = tag;
+    this._index = index ?? -1;
+    this._pos = new QrcNodePos(group?.pos.groupKey ?? '', this._index);
+  }
+
+  get pos(): QrcNodePos {
+    return this._pos;
+  }
+
+  get hash(): string {
+    return this._file?.attributes.__hash ?? '';
+  }
+
+  get text(): string {
+    return this._file?.text ?? '';
+  }
+
+  get alias(): string {
+    return this._file?.attributes.alias ?? '';
+  }
+
+  get empty(): boolean {
+    const s = this._file?.attributes.empty ?? 'false';
+    return (s.trim().toLowerCase() === 'true');
+  }
+
+  get highlighted(): boolean {
+    return this._highlighted;
+  }
+
+  public setHighlighted(highlight: boolean) {
+    this._highlighted = highlight;
+  }
+}
+
+export class CursorManager {
+  private _groups: GroupNodeWrapper[] = [];
+  private _allVisiblePos: QrcNodePos[] = [];
+  private _currentIndex = $state(-1);
+  private _onCurrentChanged?: () => void;
+
+  public currentIndex = $derived(this._currentIndex);
+  public currentPos = $derived(this._currentPos() ?? new QrcNodePos());
+
+  public refresh(groups: GroupNodeWrapper[]) {
+    this._groups = groups;
+    this._groups.forEach(g => g.onOpenedChanged(() => this._rebuild()));
+    this._rebuild();
+  }
+
+  public moveTo(groupKey: string, fileIndex: number = -1) {
+    this.moveToPos(new QrcNodePos(groupKey, fileIndex));
+  }
+
+  public moveToPos(id: QrcNodePos) {
+    const index = this._allVisiblePos.findIndex(p => p.equals(id));
+    if (index >= 0) {
+      this._setCurrentIndex(index);
+    }
+  }
+
+  public moveDir(dir: 'up' | 'down' | 'left' | 'right'): boolean {
+    if (dir === 'up') return this._moveUp();
+    else if (dir === 'down') return this._moveDown();
+    else if (dir === 'left') return this._moveLeft();
+    else if (dir === 'right') return this._moveRight();
+    return false;
+  }
+
+  public getAllVisiblePos() {
+    return this._allVisiblePos;
+  }
+
+  public unsetCurrent() {
+    this._currentIndex = -1;
+  }
+
+  public onCurrentChanged(callback: () => void) {
+    this._onCurrentChanged = callback;
+  }
+
+  private _setCurrentIndex(i: number): boolean {
+    if (this._currentIndex !== i) {
+      this._currentIndex = i;
+      this._onCurrentChanged?.();
+      return true;
+    }
+
+    return false;
+  }
+
+  private _setCurrentIndexClamped(i: number): boolean {
+    const valid = Math.max(0, Math.min(i, this._allVisiblePos.length - 1));
+    return this._setCurrentIndex(valid);
+  }
+
+  private _currentPos(): QrcNodePos | undefined {
+    return this._allVisiblePos[this._currentIndex];
+  }
+
+  private _currentGroup(): GroupNodeWrapper | undefined {
+    return this._groups.find(g => g.key === this.currentPos.groupKey);
+  }
+
+  private _moveUp(): boolean {
+    return this._setCurrentIndexClamped(this._currentIndex - 1);
+  }
+
+  private _moveDown(): boolean {
+    return this._setCurrentIndexClamped(this._currentIndex + 1);
+  }
+
+  private _moveLeft(): boolean {
+    const pos = this._currentPos();
+    const group = this._currentGroup();
+    if (!pos || !group) return false;
+
+    if (group.opened) {
+      if (pos.isFile()) {
+        this.moveTo(pos.groupKey, -1);
+      } else if (pos.isGroup()) {
+        group.setOpened(false);
+      }
+
+      return true;
+    }
+
+    return this._moveUp();
+  }
+
+  private _moveRight(): boolean {
+    const pos = this._currentPos();
+    const group = this._currentGroup();
+    if (!pos || !group) return false;
+
+    if (pos.isGroup() && !group.opened) {
+      group.setOpened(true);
+      return true;
+    }
+
+    return this._moveDown();
+  }
+
+  private _rebuild() {
+    const result: QrcNodePos[] = [];
+
+    for (const g of this._groups) {
+      result.push(g.pos);
+      if (g.opened) {
+        g.allFiles().forEach(f => result.push(f.pos));
+      }
+    }
+
+    if (result.length === 0) {
+      this._setCurrentIndex(-1);
+      this._allVisiblePos = [];
+      return;
+    }
+
+    this._allVisiblePos = result;
+    this._setCurrentIndexClamped(this._currentIndex);
+  }
+}
+
+export class OpenStateSnapshot {
+  private _openedKeys = new Set<string>();
+
+  public static capture(groups: GroupNodeWrapper[]) {
+    const keys = groups.filter(g => g.opened).map(g => g.key);
+    const instance = new OpenStateSnapshot();
+    instance._openedKeys = new Set(keys);
+
+    return instance;
+  }
+
+  public restoreTo(groups: GroupNodeWrapper[]) {
+    groups.forEach(g => g.setOpened(this._openedKeys.has(g.key)));
+  }
+}
+
+export class CursorStateSnapshot {
+  private _allVisiblePos: QrcNodePos[] = [];
+  private _currentIndex = -1;
+
+  public static capture(cursor: CursorManager) {
+    const instance = new CursorStateSnapshot();
+    instance._allVisiblePos = cursor.getAllVisiblePos();
+    instance._currentIndex = cursor.currentIndex;
+
+    return instance;
+  }
+
+  public restoreTo(cursor: CursorManager) {
+    const allPos = cursor.getAllVisiblePos();
+
+    for (let i = this._currentIndex; i < this._allVisiblePos.length; ++i) {
+      const candidate = this._allVisiblePos.at(i);
+      if (!candidate) {
+        continue;
+      }
+
+      const found = (allPos.findIndex(id => id.equals(candidate)) >= 0);
+      if (found) {
+        cursor.unsetCurrent();
+        cursor.moveToPos(candidate);
+        return;
+      }
+    }
+  }
+}

--- a/qt-core/webview-ui/src/apps/qrc-editor/viewlogic.svelte.ts
+++ b/qt-core/webview-ui/src/apps/qrc-editor/viewlogic.svelte.ts
@@ -1,0 +1,305 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import _ from 'lodash';
+import { tick } from 'svelte';
+
+import { vscode } from '@/apps/vscode';
+import { CommandId, type CommandReply } from '@shared/message';
+import {
+  isRccTag,
+  isQrcDocChangeEvent,
+  type QrcDocChangeEvent
+} from '@shared/qrc-types';
+import {
+  GroupNodeWrapper,
+  FileNodeWrapper,
+  OpenStateSnapshot,
+  CursorStateSnapshot,
+  type PropInputConfig,
+  type QrcPropName,
+  type QrcVscodeUiAction,
+  type QrcClipboardAction,
+} from './types.svelte';
+import { data, ui } from './states.svelte';
+
+let onQrcReloadOnce: (() => void)[] = [];
+
+export async function onAppMount() {
+  vscode.onDidReceiveNotification(onVscodeNotified);
+  ui.cursor.onCurrentChanged(onCursorCurrentChanged);
+
+  await reloadQrcContent();
+  setAllGroupsOpened(true);
+  ui.cursor.moveTo(data.groups[0]?.pos.groupKey ?? '');
+}
+
+export function onKeydown(e: KeyboardEvent) {
+  if (takeCareKeydownEvent(e)) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+}
+
+export async function addFilesFromDialog() {
+  addFiles([]);
+}
+
+export async function addFiles(files: string[]) {
+  const cmdId = CommandId.QrcAddFiles;
+  const nodeId = ui.cursor.currentPos.toJson();
+  const reply = files.length > 0
+    ? await vscode.post(cmdId, { ...nodeId, files })
+    : await vscode.post(cmdId, { ...nodeId }, -1);
+
+  const groupKey = _.get(reply, 'groupKey', '') as string;
+  const fileIndexes = _.get(reply, 'fileIndexes', [] as number[]);
+
+  if (fileIndexes.length > 0) {
+    afterQrcReload(() => {
+      ui.cursor.moveTo(groupKey, fileIndexes[0]);
+      withGroup(groupKey, g => {
+        g.setOpened(true);
+        g.setFilesHighlighted(fileIndexes, true);
+      });
+    });
+  }
+}
+
+export async function addNewGroup() {
+  const reply = await vscode.post(CommandId.QrcAddNewGroup);
+  const groupKey = _.get(reply, 'groupKey', '') as string;
+
+  afterQrcReload(() => {
+    ui.cursor.moveTo(groupKey);
+    withGroup(groupKey, g => g.setOpened(true));
+  });
+}
+
+export async function removeCurrent() {
+  const payload = ui.cursor.currentPos.toJson();
+  await vscode.post(CommandId.QrcRemove, payload);
+}
+
+export async function clean() {
+  await vscode.post(CommandId.QrcClean);
+}
+
+export async function setProp(name: QrcPropName) {
+  const input = ui.inputs.find(name);
+  if (!input || !input.enabled) {
+    return;
+  }
+
+  const payload = {
+    name,
+    value: input.value.trim(),
+    ...ui.cursor.currentPos.toJson()
+  };
+
+  await vscode.post(CommandId.QrcSetProp, payload);
+  ui.inputs.validateAll();
+}
+
+export async function sortAll() {
+  await vscode.post(CommandId.QrcSortAll);
+}
+
+export async function runClipboardAction(action: QrcClipboardAction) {
+  const payload = { action, ...ui.cursor.currentPos.toJson() };
+  const reply = await vscode.post(CommandId.QrcRunClipboardAction, payload);
+
+  if (action === 'paste') {
+    const groupKey = _.get(reply, 'groupKey', '') as string;
+    const fileIndexes = _.get(reply, 'fileIndexes', [] as number[]);
+
+    if (fileIndexes.length > 0) {
+      afterQrcReload(() => {
+        ui.cursor.moveTo(groupKey);
+        withGroup(groupKey, g => {
+          g.setOpened(true);
+          g.setFilesHighlighted(fileIndexes, true);
+        });
+      });
+    }
+  }
+}
+
+export async function runVscodeUiAction(action: QrcVscodeUiAction) {
+  const payload = { action, ...ui.cursor.currentPos.toJson() };
+  await vscode.post(CommandId.QrcRunVscodeUiAction, payload);
+}
+
+export async function updateFileInfo(file: FileNodeWrapper) {
+  const key = file.text;
+  if (key.length === 0 || key in data.fileInfo) {
+    return;
+  }
+
+  const thumbnailSize = 24;
+  const payload = { thumbnailSize, ...file.pos.toJson() };
+  const reply = await vscode.post(CommandId.QrcGetFileInfo, payload);
+
+  let thumbnailUrl = '';
+  const exists = _.get(reply, 'exists', false) as boolean;
+  const thumbnail = _.get(reply, 'thumbnail', []) as Array<number>;
+
+  if (exists && thumbnail && thumbnail.length !== 0) {
+    const byteArray = new Uint8Array(thumbnail);
+    const blob = new Blob([byteArray], { type: 'image/png' });
+    thumbnailUrl = URL.createObjectURL(blob);
+  }
+
+  data.fileInfo = {
+    ...data.fileInfo,
+    [key]: { exists, thumbnailUrl }
+  }
+}
+
+export function setAllGroupsOpened(open: boolean) {
+  data.groups.forEach(g => g.setOpened(open));
+
+  if (!open) {
+    ui.cursor.moveTo(ui.cursor.currentPos.groupKey, -1);
+  }
+}
+
+// helpers
+async function onVscodeNotified(reply: CommandReply) {
+  if (reply.id === CommandId.QrcDocChanged) {
+    const e = isQrcDocChangeEvent(reply.payload)
+      ? reply.payload
+      : undefined;
+
+    await reloadQrcContent(e);
+  }
+}
+
+function onCursorCurrentChanged() {
+  const id = ui.cursor.currentPos;
+  if (id.isFile()) {
+    withGroup(id.groupKey, g => g.setOpened(true));
+  }
+
+  updatePropInputs();
+  document.getElementById(id.toString())?.focus();
+  data.groups.forEach(g => g.setAllFilesHighlighted(false));
+}
+
+async function reloadQrcContent(e?: QrcDocChangeEvent) {
+  const reply = await vscode.post(CommandId.QrcGetRccTag);
+  if (!isRccTag(reply)) {
+    return;
+  }
+
+  const openState = OpenStateSnapshot.capture(data.groups);
+  const cursorState = CursorStateSnapshot.capture(ui.cursor);
+
+  data.groups = GroupNodeWrapper.createList(reply.qresource);
+  openState.restoreTo(data.groups);
+  ui.cursor.refresh(data.groups);
+
+  await tick();
+  requestAnimationFrame(() => {
+    if (e && e.reason === 'command') {
+      if (e.commandId === CommandId.QrcClean
+        || e.commandId === CommandId.QrcRemove
+        || e.commandId === CommandId.QrcSortAll) {
+        cursorState.restoreTo(ui.cursor);
+      }
+    }
+
+    onQrcReloadOnce.forEach(f => f());
+    onQrcReloadOnce = [];
+  });
+}
+
+function afterQrcReload(cb: () => void) {
+  onQrcReloadOnce.push(cb);
+}
+
+function withGroup(groupKey: string, callback: (g: GroupNodeWrapper) => void) {
+  const group = data.groups.find(g => (g.key === groupKey));
+  if (group) {
+    callback(group);
+  }
+}
+
+function updatePropInputs() {
+  const pos = ui.cursor.currentPos;
+  const g = data.groups.find(g => g.key === pos.groupKey);
+  const f = g?.fileAt(pos.fileIndex);
+
+  let lang: PropInputConfig = { enabled: false };
+  let alias: PropInputConfig = { enabled: false };
+  let prefix: PropInputConfig = { enabled: false };
+
+  if (pos.isGroup() && g) {
+    lang = { enabled: true, value: g.language };
+    prefix = { enabled: true, value: g.prefix };
+  }
+
+  if (pos.isFile() && f) {
+    alias = { enabled: true, value: f.alias };
+  }
+
+  ui.inputs.applyConfigs({ prefix, alias, lang });
+  ui.inputs.validateAll();
+}
+
+function takeCareKeydownEvent(e: KeyboardEvent): boolean {
+  if (e.key.startsWith('Arrow')) {
+    return takeCareArrowKeys(e);
+  }
+
+  if (e.key === 'Tab') {
+    return ui.cursor.moveDir(e.shiftKey ? 'up' : 'down');
+  }
+
+  if (e.key === 'Delete') {
+    removeCurrent();
+    return true;
+  }
+
+  if (e.key === 'Escape') {
+    data.groups.forEach(g => g.setAllFilesHighlighted(false));
+    return true;
+  }
+
+  if (e.key === ' ') {
+    if (ui.cursor.currentPos.isGroup()) {
+      withGroup(ui.cursor.currentPos.groupKey, g => g.setOpened(!g.opened));
+      return true;
+    }
+  }
+
+  if (e.key === 'Enter') {
+    if (ui.cursor.currentPos.isGroup()) {
+      withGroup(ui.cursor.currentPos.groupKey, g => g.setOpened(!g.opened));
+    } else {
+      void runVscodeUiAction('openFile');
+    }
+    return true;
+  }
+
+  if (e.ctrlKey || e.metaKey) {
+    const k = e.key.toLowerCase();
+    if (k === 'c') { runClipboardAction('copy'); return true; }
+    if (k === 'x') { runClipboardAction('cut'); return true; }
+    if (k === 'v') { runClipboardAction('paste'); return true; }
+  }
+
+  return false;
+}
+
+function takeCareArrowKeys(e: KeyboardEvent): boolean {
+  if (e.key === 'ArrowDown') ui.cursor.moveDir('down');
+  else if (e.key === 'ArrowUp') ui.cursor.moveDir('up');
+  else if (e.key === 'ArrowLeft') ui.cursor.moveDir('left');
+  else if (e.key === 'ArrowRight') ui.cursor.moveDir('right');
+  else {
+    return false;
+  }
+
+  return true;
+}

--- a/qt-core/webview-ui/src/apps/texts.ts
+++ b/qt-core/webview-ui/src/apps/texts.ts
@@ -50,3 +50,54 @@ export const loading = {
   busy: 'Loading...',
   close: 'Close'
 };
+
+export const qrc = {
+  buttons: {
+    addGroup: 'Group',
+    addFiles: 'Files',
+    delete: 'Delete',
+  },
+
+  tooltips: {
+    addGroup: 'Add a new group',
+    addFiles: 'Add files',
+    delete: 'Delete the selected group or file',
+    clean: 'Delete all the missing files and empty groups',
+    sort: 'Sort all groups and files alphabetically',
+    expandCollaps: 'Expand or collapse all',
+    openInTextEditor: 'Open in a text editor'
+  },
+
+  stats: (groups: number, files: number) => {
+    return [
+      'Total',
+      `${groups} group${(groups === 1 ? '' : 's')},`,
+      `${files} file${(files === 1 ? '' : 's')}`,
+    ].join(' ');
+  },
+
+  noItems: {
+    info: 'No items available',
+    addGroup: 'Add your first group'
+  },
+
+  props: {
+    title: 'Properties',
+    alias: 'Alias',
+    prefix: 'Prefix',
+    language: 'Language',
+  },
+
+  annotation: {
+    alias: (a: string) => `Alias: ${a}`,
+    empty: 'Empty',
+    notFound: 'Not found'
+  },
+
+  errors: {
+    tooLong: 'Enter a shorter name',
+    prefixEmpty: 'Give the prefix a name',
+    prefixStart: 'Must start with /',
+    invalidLang: 'Use a valid language code (de_DE, en_US, de)'
+  }
+}

--- a/qt-core/webview-ui/src/comps/DragDropHandler.svelte.ts
+++ b/qt-core/webview-ui/src/comps/DragDropHandler.svelte.ts
@@ -1,0 +1,99 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+export class DragDropHandler {
+  private _target: HTMLElement;
+  private _dragDepth = 0;
+  private _dragging = $state(false);
+  public dragging = $derived(this._dragging);
+
+  public onEnter: (e: DragEvent) => void = () => {};
+  public onLeave: (e: DragEvent) => void = () => {};
+  public onOver: (e: DragEvent) => void = () => {};
+  public onDrop: (files: string[], e: DragEvent) => void = () => {};
+
+  constructor(target: HTMLElement) {
+    this._target = target;
+  }
+
+  public attach() {
+    this._target.addEventListener('dragenter', this._handleEnter);
+    this._target.addEventListener('dragleave', this._handleLeave);
+    this._target.addEventListener('dragover', this._handleOver);
+    this._target.addEventListener('drop', this._handleDrop);
+  }
+
+  public detach() {
+    this._target.removeEventListener('dragenter', this._handleEnter);
+    this._target.removeEventListener('dragleave', this._handleLeave);
+    this._target.removeEventListener('dragover', this._handleOver);
+    this._target.removeEventListener('drop', this._handleDrop);
+  }
+
+  private _handleEnter = (e: DragEvent) => {
+    e.preventDefault();
+
+    if (++this._dragDepth === 1) {
+      this._setDragging(true);
+      this.onEnter(e);
+    }
+  };
+
+  private _handleLeave = (e: DragEvent) => {
+    e.preventDefault();
+
+    if (--this._dragDepth === 0) {
+      this._setDragging(false);
+      this.onLeave(e);
+    }
+  };
+
+  private _handleOver = (e: DragEvent) => {
+    e.preventDefault();
+    this.onOver(e);
+  };
+
+  private _handleDrop = async (e: DragEvent) => {
+    e.preventDefault();
+
+    this._dragDepth = 0;
+    this._setDragging(false);
+    this.onDrop(await collectDropItems(e), e);
+  };
+
+  private _setDragging(dragging: boolean) {
+    if (this._dragging !== dragging) {
+      this._dragging = dragging;
+    }
+  }
+}
+
+async function collectDropItems(e: DragEvent) {
+  function getItemAsString(item: DataTransferItem): Promise<string> {
+    return new Promise(resolve => {
+      item.getAsString(str => resolve(str));
+    });
+  }
+
+  function parseCodefiles(s: string): string[] {
+    const o = JSON.parse(s);
+    if (!Array.isArray(o)) return [];
+    if (!o.every(e => { return typeof e === 'string'; })) return [];
+
+    return o;
+  }
+
+  const interestedType = 'codefiles';
+  const items = e.dataTransfer?.items ?? [];
+  const all: string[] = [];
+
+  for (const item of items) {
+    if (item.type === interestedType && item.kind === 'string') {
+      const s = await getItemAsString(item);
+      all.push(...parseCodefiles(s));
+    }
+  }
+
+  return all;
+}
+

--- a/qt-core/webview-ui/src/comps/DropMask.svelte
+++ b/qt-core/webview-ui/src/comps/DropMask.svelte
@@ -1,0 +1,16 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { Download } from '@lucide/svelte';
+</script>
+
+<div class='w-full h-full top-0 absolute qt-drop-mask'></div>
+<div class='w-full h-full top-0 absolute
+            flex items-center justify-center'>
+  <div class="qt-surface p-8 opacity-75">
+      <Download class="large" />
+  </div>
+</div>

--- a/qt-core/webview-ui/src/styles/styles.css
+++ b/qt-core/webview-ui/src/styles/styles.css
@@ -5,6 +5,8 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 /* variables */
 body {
+  @apply p-0;
+
   /* panel, popup, ... */
   --qt-surface-foreground: var(--vscode-foreground);
   --qt-surface-background: var(--vscode-sideBar-background);
@@ -25,6 +27,11 @@ body {
   --qt-error-background: var(--vscode-inputValidation-errorBackground);
   --qt-error-border: var(--vscode-inputValidation-errorBorder);
 
+  --qt-warning-foreground: var(--vscode-inputValidation-warningForeground,
+                            var(--vscode-input-foreground));
+  --qt-warning-background: var(--vscode-inputValidation-warningBackground);
+  --qt-warning-border: var(--vscode-inputValidation-warningBorder);
+
   --qt-info-foreground: var(--vscode-inputValidation-infoForeground,
                           var(--vscode-input-foreground));
   --qt-info-background: var(--vscode-inputValidation-infoBackground);
@@ -33,6 +40,14 @@ body {
     /* general */
   --qt-focus-border: var(--vscode-focusBorder);
   --qt-outline: var(--vscode-settings-headerBorder);
+  --qt-checker-color1: var(--color-gray-700);
+  --qt-checker-color2: var(--color-gray-800);
+  --qt-disabled-foreground: var(--vscode-disabledForeground);
+}
+
+body[data-vscode-theme-kind*='light'] {
+  --qt-checker-color1: var(--color-gray-200);
+  --qt-checker-color2: var(--color-gray-300);
 }
 
 /* utilities */
@@ -40,7 +55,13 @@ body {
   border-radius: 2px;
 }
 
-@utility qt-list-base {
+@utility qt-surface {
+  @apply qt-border-radius;
+  background-color: var(--qt-surface-background);
+  border: 1px solid var(--qt-surface-border);
+}
+
+@utility qt-surface-bright {
   @apply qt-border-radius;
   background-color: var(--qt-surfaceBright-background);
   border: 1px solid var(--qt-surfaceBright-border);
@@ -64,6 +85,19 @@ body {
   border: 1px solid var(--vscode-input-border, transparent);
   padding: 5px 0px 5px 10px;
   box-shadow: none;
+}
+
+@utility qt-badge-base {
+  @apply qt-border-radius;
+  font-size: 0.8rem;
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+@utility qt-alert-base {
+  @apply qt-border-radius;
+  @apply text-base font-normal;
+  padding: 10px;
 }
 
 @utility qt-input-selection {
@@ -131,7 +165,7 @@ html {
 
 .qt-button:disabled {
   @apply cursor-not-allowed;
-  color: var(--qt-surface-foreground);
+  color: var(--qt-disabled-foreground);
   background: transparent;
   border-color: var(--qt-outline);
 }
@@ -147,6 +181,11 @@ html {
 .qt-button-flat:hover {
   color: var(--qt-primary-foreground);
   background: var(--qt-primary-hoverBackground);
+}
+
+.qt-button-flat:disabled {
+  @apply cursor-not-allowed;
+  color: var(--qt-disabled-foreground);
 }
 
 /* button variants - content only */
@@ -232,6 +271,11 @@ body.vscode-high-contrast .qt-button-contentOnly:hover {
   @apply qt-input-base;
 }
 
+.qt-input:disabled {
+  @apply cursor-not-allowed;
+  color: var(--qt-disabled-foreground);
+}
+
 .qt-input:focus,
 .qt-input:focus-visible {
   @apply qt-focus-tightRing;
@@ -267,14 +311,14 @@ body.vscode-high-contrast .qt-button-contentOnly:hover {
 
 .qt-inputInset-error {
   @apply cursor-pointer;
-  color: var(--qt-error-foreground);
+  color: var(--qt-error-border);
   background-color: transparent;
   padding: 0px 7px;
 }
 
 .qt-inputInset-warning {
   @apply cursor-pointer;
-  color: var(--qt-info-foreground);
+  color: var(--qt-info-border);
   background-color: transparent;
   padding: 0px 7px;
 }
@@ -302,7 +346,7 @@ body.vscode-high-contrast .qt-button-contentOnly:hover {
 
 /* picker list - combobox, menu etc. */
 .qt-picker-list {
-  @apply qt-list-base;
+  @apply qt-surface-bright;
 }
 
 .qt-picker-list:focus-within {
@@ -315,7 +359,7 @@ body.vscode-high-contrast .qt-button-contentOnly:hover {
 
 /* list */
 .qt-list {
-  @apply qt-list-base;
+  @apply qt-surface-bright;
 }
 
 .qt-list:focus-within {
@@ -324,7 +368,7 @@ body.vscode-high-contrast .qt-button-contentOnly:hover {
 
 /* item - for list, picker etc. */
 .qt-item {
-  @apply pl-3 pr-1 py-2;
+  @apply p-2;
   @apply text-base font-normal cursor-pointer border-none;
   color: var(--qt-surfaceBright-foreground);
   background: transparent;
@@ -349,9 +393,18 @@ body.vscode-high-contrast .qt-item:hover {
 }
 
 .qt-item-selected {
+  @apply p-2;
+  @apply text-base font-normal cursor-pointer border-none;
   color: var(--qt-primary-foreground);
   background: var(--qt-primary-background);
   border-color: var(--qt-primary-border);
+  border: 1px solid var(--qt-primary-border);
+}
+
+.qt-item-selected:focus,
+.qt-item-selected:focus-visible {
+  @apply qt-focus-tightRing;
+  border-radius: 0px;
 }
 
 /* label */
@@ -369,6 +422,10 @@ body.vscode-high-contrast .qt-item:hover {
 .qt-label.dialog {
   color: var(--vscode-settings-headerForeground);
   font-size: 1.05rem;
+}
+
+.qt-label.dimmed {
+  color: var(--qt-disabled-foreground);
 }
 
 .qt-tooltip {
@@ -407,26 +464,31 @@ body.vscode-high-contrast .qt-item:hover {
 }
 
 .qt-alert-error {
-  @apply qt-border-radius;
-  @apply text-base font-normal;
+  @apply qt-alert-base;
   color: var(--qt-error-foreground);
   background-color: var(--qt-error-background);
   border: 1px solid var(--qt-error-border);
-  padding: 10px;
 }
 
 .qt-alert-warning {
-  @apply qt-border-radius;
-  @apply text-base font-normal;
+  @apply qt-alert-base;
   color: var(--qt-info-foreground);
   background-color: var(--qt-info-background);
   border: 1px solid var(--qt-info-border);
-  padding: 10px;
 }
 
 .qt-badge {
-  background-color: transparent;
-  font-size: 0.8rem;
+  @apply qt-badge-base;
+  color: var(--qt-primary-foreground);
+  background: transparent;
+  border: 1px solid var(--qt-outline);
+}
+
+.qt-badge-primary {
+  @apply qt-badge-base;
+  color: var(--qt-primary-foreground);
+  background: var(--qt-primary-background);
+  border: 1px solid var(--qt-primary-border);
 }
 
 .qt-spinner {
@@ -438,6 +500,27 @@ body.vscode-high-contrast .qt-item:hover {
   color: var(--qt-surface-foreground);
   background: none;
   font-size: 1.2rem;
+}
+
+.qt-surface-bright {
+  @apply qt-surface-bright
+}
+
+.qt-drop-mask {
+  background-color: var(--qt-primary-background);
+  border: 1px dashed var(--qt-primary-background);
+  opacity: 0.15;
+}
+
+.qt-gray-background {
+  @apply bg-gray-700;
+}
+
+.qt-checker-4px {
+  background: repeating-conic-gradient(
+    var(--qt-checker-color1) 0 25%,
+    var(--qt-checker-color2) 0 50%
+  ) 50% / 4px 4px
 }
 
 /*


### PR DESCRIPTION

- Introduce new QRC editor Svelte app under `src/apps/qrc-editor/`
- Set up initial panel and webview integration
- Implement message handling and editor state management
- Support drag & drop from VSCode file explorer
- Add copy, cut, and paste functionality
- Add an editor provider implementing `CustomTextEditorProvider`
- Register as the default editor for QRC files

Task-number: [VSCODEEXT-20](https://bugreports.qt.io/browse/VSCODEEXT-20)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
