### PR TITLE
qt-cli: Fix signal declaration in C++ template

### DIFF
--- a/qt-cli/src/assets/templates/cpp/class/cpp-class.h
+++ b/qt-cli/src/assets/templates/cpp/class/cpp-class.h
@@ -21,5 +21,5 @@ class {{ .name }}{{ if .baseClass }}: public {{ .baseClass }}{{ end }}
 public:
     explicit {{ .name }}({{ .parentClass }} *parent = nullptr);
 
-Q_SIGALS:
+signals:
 };


### PR DESCRIPTION
Replace invalid `Q_SIGAL` macro with the `signals` keyword.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
