### PR TITLE
qt-core/webview: Change timing of UI configuration collection

### DIFF
--- a/qt-core/src/webview/new-item/dispatcher.ts
+++ b/qt-core/src/webview/new-item/dispatcher.ts
@@ -9,11 +9,7 @@ import { createLogger } from 'qt-lib';
 import * as texts from '@/texts';
 import { QtcliRestClient, QtcliRestError } from '@/qtcli/rest';
 import { openFilesUnder, openUri } from '@/qtcli/common';
-import {
-  getNewFileBaseDir,
-  getNewProjectBaseDir,
-  setDefaultProjectDir
-} from '@/qtcli/commands';
+import { getNewProjectBaseDir, setDefaultProjectDir } from '@/qtcli/commands';
 import { WebviewChannel } from '@/webview/channel';
 import { Command, CommandId, IsCommand } from '@/webview/shared/message';
 import type { NewItemPanel } from './panel';
@@ -26,6 +22,7 @@ export class NewItemDispatcher {
   private readonly _handlers: Map<CommandId, CommandHandler> | undefined;
   private _comm: WebviewChannel | undefined;
   private _panel: NewItemPanel | undefined = undefined;
+  private _uiConfigs: unknown = {};
 
   public constructor() {
     this._handlers = new Map<CommandId, CommandHandler>([
@@ -52,6 +49,10 @@ export class NewItemDispatcher {
 
   public setComm(c: WebviewChannel) {
     this._comm = c;
+  }
+
+  public setUiConfigs(c: unknown) {
+    this._uiConfigs = c;
   }
 
   public dispatch(cmd: unknown) {
@@ -121,10 +122,7 @@ export class NewItemDispatcher {
   };
 
   private readonly onUiGetConfigs = (cmd: Command) => {
-    this._comm?.postDataReply(cmd, {
-      newFileBaseDir: getNewFileBaseDir(),
-      newProjectBaseDir: getNewProjectBaseDir()
-    });
+    this._comm?.postDataReply(cmd, this._uiConfigs);
   };
 
   private readonly onUiGetAllPresets = async (cmd: Command) => {

--- a/qt-core/src/webview/new-item/panel.ts
+++ b/qt-core/src/webview/new-item/panel.ts
@@ -6,7 +6,11 @@ import * as vscode from 'vscode';
 import { createLogger } from 'qt-lib';
 import { QtcliRunner } from '@/qtcli/runner';
 import { QtcliAction } from '@/qtcli/common';
-import { findQtcliExePath } from '@/qtcli/commands';
+import {
+  findQtcliExePath,
+  getNewFileBaseDir,
+  getNewProjectBaseDir
+} from '@/qtcli/commands';
 import { WebviewChannel } from '@/webview/channel';
 import { NewItemDispatcher } from './dispatcher';
 import * as texts from '@/texts';
@@ -88,6 +92,11 @@ export class NewItemPanel {
     }
 
     void startQtcliServer(uri);
+
+    NewItemPanel.instance._dispatcher.setUiConfigs({
+      newFileBaseDir: getNewFileBaseDir(),
+      newProjectBaseDir: getNewProjectBaseDir()
+    });
     NewItemPanel.instance._panel.reveal(PanelColumn);
   }
 }


### PR DESCRIPTION
When creating a file, the new item UI attempts to extract the base directory from the currently active tab's URI.

This must happen before revealing the Webview panel, 
as doing so may change the active tab and result in an incorrect base directory being selected.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
