### PR TITLE
qt-cpp: Warn user when using CMake presets

### DIFF
--- a/qt-cpp/package.json
+++ b/qt-cpp/package.json
@@ -78,6 +78,11 @@
           "type": "boolean",
           "default": false,
           "description": "Do not show a warning when the source directory cannot be determined from the selected kit."
+        },
+        "qt-cpp.doNotShowCMakePresetWarning": {
+          "type": "boolean",
+          "default": false,
+          "description": "Do not show a warning when the CMake Presets are found in the workspace."
         }
       }
     },

--- a/qt-cpp/src/constants.ts
+++ b/qt-cpp/src/constants.ts
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 export const EXTENSION_ID = 'qt-cpp';
+export const CONFIG_CMAKE_PRESET_WARNING = 'doNotShowCMakePresetWarning';

--- a/qt-cpp/src/project.ts
+++ b/qt-cpp/src/project.ts
@@ -28,6 +28,7 @@ import {
 import { analyzeKit } from '@/kit-manager';
 import * as cmakeFileApi from '@/cmake-file-api';
 import { getMajorQtVersion } from '@/util/util';
+import { CONFIG_CMAKE_PRESET_WARNING, EXTENSION_ID } from '@/constants';
 
 const logger = createLogger('project');
 
@@ -72,8 +73,14 @@ export class CppProject implements Project {
       const onSelectedConfigurationChangedHandler =
         this._cmakeProject.onSelectedConfigurationChanged(
           async (configurationType: cmakeApi.ConfigurationType) => {
-            if (configurationType === cmakeApi.ConfigurationType.Kit) {
-              await this.onKitConfigurationChanged();
+            switch (configurationType) {
+              case cmakeApi.ConfigurationType.Kit:
+                await this.onKitConfigurationChanged();
+                break;
+              case cmakeApi.ConfigurationType.ConfigurePreset:
+              case cmakeApi.ConfigurationType.BuildPreset:
+                CppProject.warnUserForPresetUsage();
+                break;
             }
           }
         );
@@ -104,6 +111,7 @@ export class CppProject implements Project {
           }
         }
       );
+      this.checkCMakePresetInWorkspace();
       this._disposables.push(onCodeModelChangedHandler);
       this._disposables.push(onSelectedConfigurationChangedHandler);
     }
@@ -124,6 +132,60 @@ export class CppProject implements Project {
     logger.info(`Notifying coreAPI with message: ${message.toString()}`);
     coreAPI?.notify(message);
   }
+  private static getDoNotShowCMakePresetWarning() {
+    const configKey = `${EXTENSION_ID}.${CONFIG_CMAKE_PRESET_WARNING}`;
+    const config = vscode.workspace.getConfiguration();
+    return config.get<boolean>(configKey);
+  }
+  private static setDoNotShowCMakePresetWarning(value: boolean) {
+    const configKey = `${EXTENSION_ID}.${CONFIG_CMAKE_PRESET_WARNING}`;
+    const config = vscode.workspace.getConfiguration();
+    void config.update(configKey, value, vscode.ConfigurationTarget.Global);
+  }
+  private static warnUserForPresetUsage() {
+    if (CppProject.getDoNotShowCMakePresetWarning()) {
+      return;
+    }
+
+    const doNotShowAgainButtonMessage = 'Do not show again';
+    void vscode.window
+      .showWarningMessage(
+        'Qt C++ extension does not support CMake Presets yet. Use Kits instead.',
+        doNotShowAgainButtonMessage
+      )
+      .then((result) => {
+        if (result === doNotShowAgainButtonMessage) {
+          CppProject.setDoNotShowCMakePresetWarning(true);
+        }
+      });
+  }
+  private checkCMakePresetInWorkspace() {
+    if (!this._cmakeProject) {
+      throw new Error('CMake project is not defined');
+    }
+    if (CppProject.getDoNotShowCMakePresetWarning()) {
+      return;
+    }
+    // If the project has a CMake Preset, warn the user
+    const presetFiles = ['CMakePresets.json', 'CMakeUserPresets.json'];
+    const presetFileExists = presetFiles.some((file) => {
+      const presetFilePath = path.join(this.folder.uri.fsPath, file);
+      return fs.existsSync(presetFilePath);
+    });
+    // If cmake.useCMakePresets is not never, warn the user
+    const useCMakePresets =
+      vscode.workspace
+        .getConfiguration('cmake')
+        .get<string>('useCMakePresets') !== 'never';
+    if (presetFileExists && useCMakePresets) {
+      // Show warning message after 2 seconds because when the project is opened,
+      // Multiple messages can be shown at once and our message can be lost.
+      setTimeout(() => {
+        CppProject.warnUserForPresetUsage();
+      }, 2000);
+    }
+  }
+
   private async obtainUsedQtModules() {
     if (!this._cmakeProject) {
       throw new Error('CMake project is not defined');

--- a/qt-cpp/src/project.ts
+++ b/qt-cpp/src/project.ts
@@ -73,30 +73,7 @@ export class CppProject implements Project {
         this._cmakeProject.onSelectedConfigurationChanged(
           async (configurationType: cmakeApi.ConfigurationType) => {
             if (configurationType === cmakeApi.ConfigurationType.Kit) {
-              const kit = await getSelectedKit(this.folder);
-              if (vscode.env.isTelemetryEnabled && kit) {
-                analyzeKit(kit);
-              }
-              const selectedKitPath = kit ? getQtInsRoot(kit) : undefined;
-              const message = new QtWorkspaceConfigMessage(this.folder);
-              coreAPI?.setValue(
-                this.folder,
-                'selectedKitPath',
-                selectedKitPath
-              );
-              message.config.add('selectedKitPath');
-
-              const selectedQtPaths = kit ? getQtPathsExe(kit) : undefined;
-              coreAPI?.setValue(
-                this.folder,
-                'selectedQtPaths',
-                selectedQtPaths
-              );
-              message.config.add('selectedQtPaths');
-              logger.info(
-                `Notifying coreAPI with message: ${message.toString()}`
-              );
-              coreAPI?.notify(message);
+              await this.onKitConfigurationChanged();
             }
           }
         );
@@ -130,6 +107,22 @@ export class CppProject implements Project {
       this._disposables.push(onCodeModelChangedHandler);
       this._disposables.push(onSelectedConfigurationChangedHandler);
     }
+  }
+  private async onKitConfigurationChanged() {
+    const kit = await getSelectedKit(this.folder);
+    if (vscode.env.isTelemetryEnabled && kit) {
+      analyzeKit(kit);
+    }
+    const selectedKitPath = kit ? getQtInsRoot(kit) : undefined;
+    const message = new QtWorkspaceConfigMessage(this.folder);
+    coreAPI?.setValue(this.folder, 'selectedKitPath', selectedKitPath);
+    message.config.add('selectedKitPath');
+
+    const selectedQtPaths = kit ? getQtPathsExe(kit) : undefined;
+    coreAPI?.setValue(this.folder, 'selectedQtPaths', selectedQtPaths);
+    message.config.add('selectedQtPaths');
+    logger.info(`Notifying coreAPI with message: ${message.toString()}`);
+    coreAPI?.notify(message);
   }
   private async obtainUsedQtModules() {
     if (!this._cmakeProject) {


### PR DESCRIPTION
- **qt-cpp: Filter out kit configuration changed code**
- **qt-cpp: Warn user when using CMake presets**

Task-number: [VSCODEEXT-64](https://bugreports.qt.io/browse/VSCODEEXT-64)
<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
