### PR TITLE
qt-qml: Fix broken watch expressions when invalid expressions are given

### DIFF
--- a/qt-qml/src/debug/debug-adapter.ts
+++ b/qt-qml/src/debug/debug-adapter.ts
@@ -361,6 +361,7 @@ export class QmlDebugSession extends LoggingDebugSession {
         response.success = false;
         response.message = message;
         logger.warn(message);
+        this.sendResponse(response);
         return;
       }
       const value = QmlEngine.convertQmlTypeToValue(result.body);


### PR DESCRIPTION
Since the handler doesn't return a response, the debug adapter was not sending a response back to the client, causing the watch expressions to appear broken when an invalid expression was given.

Fixes: [VSCODEEXT-206](https://bugreports.qt.io/browse/VSCODEEXT-206)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
