### PR TITLE
qt-ui: Refactor detection of Qt Widgets Designer

### DIFF
--- a/qt-lib/src/util.ts
+++ b/qt-lib/src/util.ts
@@ -76,14 +76,17 @@ export async function existing(filePath: string) {
   }
 }
 
-export function askForKitSelection() {
+export function askForKitSelection({
+  message = 'No CMake kit selected. Please select a CMake kit.',
+  buttonName = 'Select CMake Kit'
+}: {
+  message?: string;
+  buttonName?: string;
+} = {}) {
   void vscode.window
-    .showInformationMessage(
-      'No CMake kit selected. Please select a CMake kit.',
-      ...['Select CMake Kit']
-    )
+    .showInformationMessage(message, ...[buttonName])
     .then((selection) => {
-      if (selection === 'Select CMake Kit') {
+      if (selection === buttonName) {
         telemetry.sendAction('selectCMakeKit');
         void vscode.commands.executeCommand('cmake.selectKit');
       }
@@ -94,15 +97,15 @@ export function isMultiWorkspace(): boolean {
   return vscode.workspace.workspaceFile !== undefined;
 }
 
-export async function locateQmakeExeFilePath(selectedQtPath: string) {
-  const qmakeVersions = ['qmake', 'qmake6'];
+export async function locateQtPathsExeKitPath(kitPath: string) {
+  const qmakeVersions = ['qtpaths', 'qtpaths6'];
   const suffixes = [OSExeSuffix];
   if (IsWindows) {
     suffixes.push('.bat');
   }
   for (const qmake of qmakeVersions) {
     for (const suffix of suffixes) {
-      const qmakePath = path.join(selectedQtPath, 'bin', qmake + suffix);
+      const qmakePath = path.join(kitPath, 'bin', qmake + suffix);
       if (await exists(qmakePath)) {
         return qmakePath;
       }
@@ -272,6 +275,49 @@ export function findQtPathsInKitDir(dir: string): string | undefined {
     const exePath = path.join(dir, 'bin', exeName);
     if (fsSync.existsSync(exePath)) {
       return exePath;
+    }
+  }
+  return undefined;
+}
+// exePathGetter is a function that takes the bin path and returns the path to
+// the executable. Users of this function specify how to find the executable in
+// the bin path
+export async function searchForExeInQtInfo(
+  info: QtInfo,
+  exePathGetter: (p: string) => string
+) {
+  const keysToCheck = [
+    'QT_HOST_BINS',
+    'QT_HOST_LIBEXECS',
+    'QT_INSTALL_LIBEXECS'
+  ];
+
+  const paths = keysToCheck
+    .map((key) => info.get(key))
+    .filter((p) => {
+      return p !== undefined;
+    });
+
+  const addVcpkgPaths = (p: string[]) => {
+    const keys = ['QT_INSTALL_PREFIX', 'QT_HOST_PREFIX'];
+    for (const key of keys) {
+      const value = info.get(key);
+      if (value) {
+        const vcpkgPath = path.join(value, 'tools', 'qttools', 'bin');
+        p.push(vcpkgPath);
+      }
+    }
+  };
+  // It is a special case for vcpkg because on some platforms, Designer is
+  // installed in a different location
+  addVcpkgPaths(paths);
+
+  for (const p of paths) {
+    if (p) {
+      const exePath = exePathGetter(p);
+      if (await exists(exePath)) {
+        return exePath;
+      }
     }
   }
   return undefined;

--- a/qt-ui/src/commands.ts
+++ b/qt-ui/src/commands.ts
@@ -13,7 +13,7 @@ import {
   telemetry
 } from 'qt-lib';
 import { coreAPI, projectManager } from '@/extension';
-import { locateDesigner } from '@/util';
+import { locateDesignerFromKit } from '@/util';
 
 const logger = createLogger('commands');
 
@@ -84,7 +84,7 @@ export async function openWidgetDesigner() {
     }
     groupedQtInstallations[version].push(qtInstallation);
   }
-  // gonvert groupedQtInstallations to array<<version, locatedPath>>
+  // convert groupedQtInstallations to array<<version, locatedPath>>
   const versions: { version: string; locatedPath: string }[] = [];
   for (const version in groupedQtInstallations) {
     if (!groupedQtInstallations[version]) {
@@ -94,7 +94,7 @@ export async function openWidgetDesigner() {
     if (!groupedQtInstallations[version][0]) {
       continue;
     }
-    const locatedPath = await locateDesigner(
+    const locatedPath = await locateDesignerFromKit(
       groupedQtInstallations[version][0]
     );
     if (!locatedPath) {

--- a/qt-ui/src/editors/ui/ui-editor.ts
+++ b/qt-ui/src/editors/ui/ui-editor.ts
@@ -55,7 +55,10 @@ export class UIEditorProvider implements vscode.CustomTextEditorProvider {
             // User may not have selected the kit.
             // We can check and ask for kit selection.
             if (project.workspaceType === QtWorkspaceType.CMakeExt) {
-              askForKitSelection();
+              askForKitSelection({
+                message: 'Cannot find Qt Widgets Designer in the selected kit.',
+                buttonName: 'Select a kit including Qt Widgets Designer'
+              });
             }
             logger.error('Designer client not found');
             return;

--- a/qt-ui/src/extension.ts
+++ b/qt-ui/src/extension.ts
@@ -18,8 +18,6 @@ import { UIEditorProvider } from '@/editors/ui/ui-editor';
 import { createUIProject, UIProject } from '@/project';
 import { EXTENSION_ID } from '@/constants';
 import { openWidgetDesigner } from '@/commands';
-import { locateDesigner } from '@/util';
-import { DesignerClient } from '@/designer-client';
 
 const logger = createLogger('extension');
 
@@ -42,31 +40,12 @@ export async function activate(context: vscode.ExtensionContext) {
   projectManager = new ProjectManager<UIProject>(context, createUIProject);
   projectManager.onProjectAdded(async (project) => {
     logger.info('Adding project:', project.folder.uri.fsPath);
-    const selectedKitPath = coreAPI?.getValue<string>(
-      project.folder,
-      'selectedKitPath'
-    );
-    const selectedQtPaths = coreAPI?.getValue<string>(
-      project.folder,
-      'selectedQtPaths'
-    );
 
     project.workspaceType = coreAPI?.getValue<QtWorkspaceType>(
       project.folder,
       'workspaceType'
     );
-
-    if (selectedKitPath) {
-      await project.setBinDir(selectedKitPath);
-    } else if (selectedQtPaths) {
-      const designer = await locateDesigner(selectedQtPaths);
-      if (designer) {
-        project.designerClient = new DesignerClient(
-          designer,
-          project.designerServer.getPort()
-        );
-      }
-    }
+    await project.tryToGetDesigner();
   });
   projectManager.onProjectRemoved((project) => {
     logger.info('Project removed:', project.folder.uri.fsPath);
@@ -79,7 +58,7 @@ export async function activate(context: vscode.ExtensionContext) {
   }
   coreAPI.onValueChanged((message) => {
     logger.info('Received config change:', message.config as unknown as string);
-    processMessage(message);
+    void processMessage(message);
   });
   context.subscriptions.push(UIEditorProvider.register(context));
   context.subscriptions.push(
@@ -94,7 +73,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 function getConfigValues() {
   for (const project of projectManager.getProjects()) {
-    project.getConfigValues();
+    void project.getConfigValues();
   }
 }
 
@@ -104,7 +83,7 @@ export function deactivate() {
   projectManager.dispose();
 }
 
-function processMessage(message: QtWorkspaceConfigMessage) {
+async function processMessage(message: QtWorkspaceConfigMessage) {
   // check if workspace folder is a string
   if (typeof message.workspaceFolder === 'string') {
     return;
@@ -114,15 +93,14 @@ function processMessage(message: QtWorkspaceConfigMessage) {
     logger.error('Project not found');
     return;
   }
-
   for (const key of message.config.keys()) {
     if (key === 'selectedKitPath') {
       const selectedKitPath = coreAPI?.getValue<string>(
         message.workspaceFolder,
         'selectedKitPath'
       );
-      if (selectedKitPath !== project.binDir) {
-        void project.setBinDir(selectedKitPath);
+      if (selectedKitPath !== project.selectedKitPath) {
+        await project.setSelectedKitPath(selectedKitPath);
       }
       continue;
     }
@@ -132,7 +110,7 @@ function processMessage(message: QtWorkspaceConfigMessage) {
         'selectedQtPaths'
       );
       if (selectedQtPaths !== project.qtpathsExe) {
-        project.qtpathsExe = selectedQtPaths;
+        await project.setQtPathsExe(selectedQtPaths);
       }
       continue;
     }

--- a/qt-ui/src/project.ts
+++ b/qt-ui/src/project.ts
@@ -15,7 +15,7 @@ import {
 import {
   getConfig,
   affectsConfig,
-  locateDesigner,
+  locateDesignerFromKit,
   locateDesignerFromQtPaths
 } from '@/util';
 import { CONF_CUSTOM_WIDGETS_DESIGNER_EXE_PATH } from '@/constants';
@@ -34,7 +34,7 @@ export async function createUIProject(
 export class UIProject implements Project {
   private readonly _disposables: vscode.Disposable[] = [];
   private _workspaceType: QtWorkspaceType | undefined;
-  private _binDir: string | undefined;
+  private _selectedKitPath: string | undefined;
   private _designerClient: DesignerClient | undefined;
   private _qtpathsExe: string | undefined;
   private readonly _designerServer: DesignerServer;
@@ -85,12 +85,14 @@ export class UIProject implements Project {
           } else {
             // That means the user has removed the path.
             // So, we need to detach the client and get the designer from qtpaths
-            // or bin dir.
+            // or from the selected kit.
+            let isDesignerClientSet = false;
             if (this._designerClient) {
-              if (this._binDir) {
+              if (this._selectedKitPath) {
                 this.designerClient = await this.getNewDesignerClient(
-                  this._binDir
+                  this._selectedKitPath
                 );
+                isDesignerClientSet = true;
               } else if (this._qtpathsExe) {
                 const designer = await locateDesignerFromQtPaths(
                   this._qtpathsExe
@@ -100,10 +102,12 @@ export class UIProject implements Project {
                     designer,
                     this.designerServer.getPort()
                   );
+                  isDesignerClientSet = true;
                 }
-              } else {
-                this.designerClient = undefined;
               }
+            }
+            if (!isDesignerClientSet) {
+              this.designerClient = undefined;
             }
           }
         }
@@ -117,8 +121,8 @@ export class UIProject implements Project {
     );
   }
 
-  private async getNewDesignerClient(binDir: string) {
-    const designerExe = await locateDesigner(binDir);
+  private async getNewDesignerClient(selectedKitPath: string) {
+    const designerExe = await locateDesignerFromKit(selectedKitPath);
     if (!designerExe) {
       return undefined;
     }
@@ -135,46 +139,58 @@ export class UIProject implements Project {
     this._workspaceType = workspaceType;
   }
 
-  get binDir() {
-    return this._binDir;
+  get selectedKitPath() {
+    return this._selectedKitPath;
   }
 
   get qtpathsExe() {
     return this._qtpathsExe;
   }
 
-  set qtpathsExe(qtpathsExe: string | undefined) {
-    const setDesignerClient = (designer: string | undefined) => {
-      if (designer) {
-        this.designerClient = new DesignerClient(
-          designer,
-          this.designerServer.getPort()
-        );
-      }
-    };
-
-    if (!this._customWidgetsDesignerExePath) {
-      if (qtpathsExe) {
-        void locateDesignerFromQtPaths(qtpathsExe).then(setDesignerClient);
-      } else {
-        this.designerClient = undefined;
-      }
+  async setQtPathsExe(qtpathsExe: string | undefined) {
+    if (qtpathsExe === this._qtpathsExe) {
+      return;
     }
     this._qtpathsExe = qtpathsExe;
-  }
+    if (this._customWidgetsDesignerExePath) {
+      return;
+    }
+    if (qtpathsExe === undefined) {
+      this.designerClient = undefined;
+      return;
+    } else {
+      this._selectedKitPath = undefined; // Reset selectedKitPath when qtpathsExe is set
+    }
 
-  async setBinDir(binDir: string | undefined) {
-    if (binDir !== this._binDir) {
-      this._binDir = binDir;
-      if (!this._customWidgetsDesignerExePath) {
-        if (binDir) {
-          this.designerClient = await this.getNewDesignerClient(binDir);
-        } else {
-          this.designerClient = undefined;
-        }
-      }
+    const designer = await locateDesignerFromQtPaths(qtpathsExe);
+    if (designer) {
+      this.designerClient = new DesignerClient(
+        designer,
+        this.designerServer.getPort()
+      );
+    } else {
+      this.designerClient = undefined;
     }
   }
+
+  async setSelectedKitPath(selectedKitPath: string | undefined) {
+    if (selectedKitPath === this._selectedKitPath) {
+      return;
+    }
+
+    this._selectedKitPath = selectedKitPath;
+    if (this._customWidgetsDesignerExePath) {
+      return;
+    }
+    if (selectedKitPath === undefined) {
+      this.designerClient = undefined;
+      return;
+    } else {
+      this._qtpathsExe = undefined; // Reset qtpathsExe when a kit is selected
+    }
+    this.designerClient = await this.getNewDesignerClient(selectedKitPath);
+  }
+
   get designerServer() {
     return this._designerServer;
   }
@@ -188,17 +204,34 @@ export class UIProject implements Project {
   get folder() {
     return this._folder;
   }
-  public getConfigValues() {
-    const selectedKitPath = coreAPI?.getValue<string>(
-      this.folder,
-      'selectedKitPath'
-    );
-    void this.setBinDir(selectedKitPath);
-    this.qtpathsExe = coreAPI?.getValue<string>(this.folder, 'selectedQtPaths');
+  public async getConfigValues() {
+    await this.tryToGetDesigner();
     this.workspaceType = coreAPI?.getValue<QtWorkspaceType>(
       this.folder,
       'workspaceType'
     );
+  }
+  public async tryToGetDesigner() {
+    const selectedKitPath = coreAPI?.getValue<string>(
+      this.folder,
+      'selectedKitPath'
+    );
+    const selectedQtPaths = coreAPI?.getValue<string>(
+      this.folder,
+      'selectedQtPaths'
+    );
+
+    if (selectedKitPath) {
+      await this.setSelectedKitPath(selectedKitPath);
+    } else if (selectedQtPaths) {
+      await this.setQtPathsExe(selectedQtPaths);
+    } else {
+      this.designerClient = undefined;
+      logger.warn(
+        'No Qt Widgets Designer found for project:',
+        this.folder.uri.fsPath
+      );
+    }
   }
 
   private static checkCustomDesignerExePath(

--- a/qt-ui/src/util.ts
+++ b/qt-ui/src/util.ts
@@ -3,7 +3,6 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import * as child_process from 'child_process';
 
 import * as constants from '@/constants';
 import {
@@ -11,8 +10,8 @@ import {
   IsWindows,
   OSExeSuffix,
   exists,
-  locateQmakeExeFilePath,
-  QtInfo
+  searchForExeInQtInfo,
+  locateQtPathsExeKitPath
 } from 'qt-lib';
 import { coreAPI } from '@/extension';
 
@@ -40,7 +39,7 @@ export async function delay(ms: number) {
 
 const DesignerExeName = IsMacOS ? 'Designer' : 'designer' + OSExeSuffix;
 
-function getDesignerExePath(selectedQtBinPath: string) {
+function getDesignerExePathFromBin(selectedQtBinPath: string) {
   const macOSPath = path.join(
     'Designer.app',
     'Contents',
@@ -52,18 +51,24 @@ function getDesignerExePath(selectedQtBinPath: string) {
     : path.join(selectedQtBinPath, DesignerExeName);
 }
 
-export async function locateDesigner(selectedQtPath: string) {
-  let designerExePath = getDesignerExePath(path.join(selectedQtPath, 'bin'));
+export async function locateDesignerFromKit(
+  selectedKitPath: string,
+  qtPathsFallback = true
+) {
+  let designerExePath = getDesignerExePathFromBin(
+    path.join(selectedKitPath, 'bin')
+  );
   if (await exists(designerExePath)) {
     return designerExePath;
   }
-  const qmakeExePath = await locateQmakeExeFilePath(selectedQtPath);
-  if (!qmakeExePath) {
-    return '';
-  }
-  const designer = extractDesignerExePathFromQtPath(qmakeExePath);
-  if (await designer) {
-    return designer;
+  if (qtPathsFallback) {
+    const qtPaths = await locateQtPathsExeKitPath(selectedKitPath);
+    if (qtPaths) {
+      const qtPathsExePath = await locateDesignerFromQtPaths(qtPaths);
+      if (qtPathsExePath) {
+        return qtPathsExePath;
+      }
+    }
   }
 
   if (!IsWindows) {
@@ -73,91 +78,20 @@ export async function locateDesigner(selectedQtPath: string) {
     }
   }
 
-  return '';
+  return undefined;
 }
 
 export async function locateDesignerFromQtPaths(qtPaths: string) {
   const info = coreAPI?.getQtInfoFromPath(qtPaths);
   if (!info) {
-    return '';
+    return undefined;
   }
-  const designerExePath = await searchForDesignerInQtInfo(info);
+  const designerExePath = await searchForExeInQtInfo(
+    info,
+    getDesignerExePathFromBin
+  );
   if (designerExePath) {
     return designerExePath;
   }
   return undefined;
-}
-
-async function extractDesignerExePathFromQtPath(qtPathExePath: string) {
-  const hostBinDir = await queryHostBinDirPath(qtPathExePath);
-  const designerExePath = getDesignerExePath(hostBinDir);
-  if (await exists(designerExePath)) {
-    return designerExePath;
-  }
-  return undefined;
-}
-
-async function searchForDesignerInQtInfo(info: QtInfo) {
-  const keysToCheck = [
-    'QT_HOST_BINS',
-    'QT_HOST_LIBEXECS',
-    'QT_INSTALL_LIBEXECS'
-  ];
-
-  const paths = keysToCheck
-    .map((key) => info.get(key))
-    .filter((p) => {
-      return p !== undefined;
-    });
-
-  const addVcpkgPaths = (p: string[]) => {
-    const keys = ['QT_INSTALL_PREFIX', 'QT_HOST_PREFIX'];
-    for (const key of keys) {
-      const value = info.get(key);
-      if (value) {
-        const vcpkgPath = path.join(value, 'tools', 'qttools', 'bin');
-        p.push(vcpkgPath);
-      }
-    }
-  };
-  // It is a special case for vcpkg because on some platforms, Designer is
-  // installed in a different location
-  addVcpkgPaths(paths);
-
-  for (const p of paths) {
-    if (p) {
-      const designerExePath = getDesignerExePath(p);
-      if (await exists(designerExePath)) {
-        return designerExePath;
-      }
-    }
-  }
-  return undefined;
-}
-
-async function queryHostBinDirPath(qtpathsExePath: string): Promise<string> {
-  const childProcess = child_process.exec(
-    qtpathsExePath + ' -query QT_HOST_BINS'
-  );
-  const promiseFirstLineOfOutput = new Promise<string>((resolve, reject) => {
-    childProcess.stdout?.on('data', (data: string) => {
-      resolve(data.toString().trim());
-    });
-    childProcess.stderr?.on('data', (data: string) => {
-      reject(new Error(data.toString().trim()));
-    });
-  });
-  const promiseProcessClose = new Promise<string>((resolve, reject) => {
-    childProcess.on('close', () => {
-      resolve('');
-    });
-    childProcess.on('error', (err) => {
-      reject(err);
-    });
-  });
-  const hostBinDir = await Promise.race([
-    promiseFirstLineOfOutput,
-    promiseProcessClose
-  ]);
-  return hostBinDir;
 }


### PR DESCRIPTION
* In the previous implementation, we were both using `qmake` and
  `qtpaths` to detect the Qt Widgets Designer. Instead, we now use only
  qtpaths, which is more reliable and consistent across different Qt
  versions.

* Move finding executable logic to a separate utility function
  `searchForExeInQtInfo` in `qt-lib/src/util.ts`. We can use logic for
  other executables in the future.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
