### PR TITLE
qt-cpp: qt-qml: qt-ui: Remove waiting for qt-cpp to be activated

### DIFF
--- a/qt-cpp/src/project.ts
+++ b/qt-cpp/src/project.ts
@@ -439,6 +439,12 @@ export class CppProject implements Project {
       `Setting build directory for ${folder.uri.fsPath} to ${this.buildDir}`
     );
     logger.info('Config values initialized for:', folder.uri.fsPath);
+    const message = new QtWorkspaceConfigMessage(folder);
+    message.config.add('selectedKitPath');
+    message.config.add('selectedQtPaths');
+    message.config.add('workspaceType');
+    message.config.add('buildDir');
+    coreAPI.notify(message);
   }
   public getStateManager() {
     return this._stateManager;

--- a/qt-lib/src/util.ts
+++ b/qt-lib/src/util.ts
@@ -97,23 +97,6 @@ export function isMultiWorkspace(): boolean {
   return vscode.workspace.workspaceFile !== undefined;
 }
 
-export async function locateQtPathsExeKitPath(kitPath: string) {
-  const qmakeVersions = ['qtpaths', 'qtpaths6'];
-  const suffixes = [OSExeSuffix];
-  if (IsWindows) {
-    suffixes.push('.bat');
-  }
-  for (const qmake of qmakeVersions) {
-    for (const suffix of suffixes) {
-      const qmakePath = path.join(kitPath, 'bin', qmake + suffix);
-      if (await exists(qmakePath)) {
-        return qmakePath;
-      }
-    }
-  }
-  return undefined;
-}
-
 export function compareVersions(version1: string, version2: string) {
   if (version1 == version2) {
     return 0;
@@ -269,12 +252,17 @@ export async function waitForQtCpp() {
 }
 
 export function findQtPathsInKitDir(dir: string): string | undefined {
-  const exeNames = [`qtpaths${OSExeSuffix}`, `qtpaths6${OSExeSuffix}`];
-
-  for (const exeName of exeNames) {
-    const exePath = path.join(dir, 'bin', exeName);
-    if (fsSync.existsSync(exePath)) {
-      return exePath;
+  const qtpathsVersions = ['qtpaths', 'qtpaths6'];
+  const suffixes = [OSExeSuffix];
+  if (IsWindows) {
+    suffixes.push('.bat');
+  }
+  for (const qtpaths of qtpathsVersions) {
+    for (const suffix of suffixes) {
+      const qtpathsPath = path.join(dir, 'bin', qtpaths + suffix);
+      if (fsSync.existsSync(qtpathsPath)) {
+        return qtpathsPath;
+      }
     }
   }
   return undefined;

--- a/qt-qml/src/extension.ts
+++ b/qt-qml/src/extension.ts
@@ -10,7 +10,6 @@ import {
   initLogger,
   telemetry,
   QtWorkspaceConfigMessage,
-  waitForQtCpp,
   createColorProvider
 } from 'qt-lib';
 import { registerRestartQmllsCommand } from '@cmd/restart-qmlls';
@@ -44,8 +43,6 @@ export async function activate(context: vscode.ExtensionContext) {
     logger.error(err);
     throw new Error(err);
   }
-
-  await waitForDependencies();
 
   if (vscode.workspace.workspaceFolders !== undefined) {
     for (const folder of vscode.workspace.workspaceFolders) {
@@ -157,8 +154,4 @@ function processMessage(message: QtWorkspaceConfigMessage) {
     logger.error(err.message);
     void vscode.window.showErrorMessage(`Error: "${err.message}"`);
   }
-}
-
-async function waitForDependencies() {
-  return waitForQtCpp();
 }

--- a/qt-ui/src/extension.ts
+++ b/qt-ui/src/extension.ts
@@ -11,8 +11,7 @@ import {
   ProjectManager,
   createLogger,
   initLogger,
-  telemetry,
-  waitForQtCpp
+  telemetry
 } from 'qt-lib';
 import { UIEditorProvider } from '@/editors/ui/ui-editor';
 import { createUIProject, UIProject } from '@/project';
@@ -34,8 +33,6 @@ export async function activate(context: vscode.ExtensionContext) {
     logger.error(err);
     throw new Error(err);
   }
-
-  await waitForDependencies();
 
   projectManager = new ProjectManager<UIProject>(context, createUIProject);
   projectManager.onProjectAdded(async (project) => {
@@ -121,8 +118,4 @@ async function processMessage(message: QtWorkspaceConfigMessage) {
       );
     }
   }
-}
-
-async function waitForDependencies() {
-  return waitForQtCpp();
 }

--- a/qt-ui/src/util.ts
+++ b/qt-ui/src/util.ts
@@ -11,7 +11,7 @@ import {
   OSExeSuffix,
   exists,
   searchForExeInQtInfo,
-  locateQtPathsExeKitPath
+  findQtPathsInKitDir
 } from 'qt-lib';
 import { coreAPI } from '@/extension';
 
@@ -62,7 +62,7 @@ export async function locateDesignerFromKit(
     return designerExePath;
   }
   if (qtPathsFallback) {
-    const qtPaths = await locateQtPathsExeKitPath(selectedKitPath);
+    const qtPaths = findQtPathsInKitDir(selectedKitPath);
     if (qtPaths) {
       const qtPathsExePath = await locateDesignerFromQtPaths(qtPaths);
       if (qtPathsExePath) {


### PR DESCRIPTION
When https://bugreports.qt.io/browse/QTBUG-131702 occurred, as a
workaround, we updated the communication between extensions with
https://codereview.qt-project.org/c/%7Bgraveyard%7D/qt-labs/vscodeext/+/609633
and organized the activation order with
https://codereview.qt-project.org/c/%7Bgraveyard%7D/qt-labs/vscodeext/+/609564.
So that qmlls is started only once during the startup. However, we plan
to implement qt-python, and a project will not activate both qt-cpp and
qt-qml due to their nature. The rest of the implementation is being
designed under this condition.

In this situation, if qt-qml activates qt-cpp explicitly, both qt-python
and qt-cpp will be activated for the same project. This breaks our
design. So, we should remove activating qt-cpp from qt-ui and qt-qml
explicitly. If the https://bugreports.qt.io/browse/QTBUG-131702 persists,
it should be fixed on the qmlls side.

* Remove waiting for qt-cpp to be activated in qt-qml and qt-ui
* Send notification via coreAPI during activation of qt-cpp

Fixes: [VSCODE-209](https://bugreports.qt.io/browse/VSCODEEXT-209)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
