### PR TITLE
qt-lib: Also consider uppercase suffixes when checking qtpaths

### DIFF
--- a/qt-lib/src/util.ts
+++ b/qt-lib/src/util.ts
@@ -179,7 +179,9 @@ export function matchesVersionPattern(installationPath: string): boolean {
 }
 
 export function isPathToQtPathsOrQMake(filePath: string): boolean {
-  return filePath.match(/(qtpaths|qmake)[0-9]?(\.(exe|bat))?$/) ? true : false;
+  return filePath.match(/(qtpaths|qmake)[0-9]?(\.(exe|bat|EXE|BAT))?$/)
+    ? true
+    : false;
 }
 
 export function generateDefaultQtPathsName(qtInfo: QtInfo): string {


### PR DESCRIPTION
When `which.sync` returns qtpaths from PATH, it has `.EXE` instead of
`.exe`. We should also consider uppercase suffixes when we check
qtpaths and qmake.

Fixes: [VSCODEEXT-216](https://bugreports.qt.io/browse/VSCODEEXT-216)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
