### PR TITLE
qt-core: Provide clearer hint when Linguist executable is not found

### DIFF
--- a/qt-core/src/translation.ts
+++ b/qt-core/src/translation.ts
@@ -48,7 +48,7 @@ export async function openInLinguistCommand() {
   if (!linguistPath) {
     logger.error('Linguist executable not found');
     void vscode.window.showErrorMessage(
-      'Linguist executable not found. Select a Qt Kit with Linguist installed.'
+      'Cannot find Qt Linguist executable. Check that the Qt version in the kit includes Qt Linguist.'
     );
     return;
   }


### PR DESCRIPTION
<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
