### PR TITLE
qt-core: Fix default QRC content closing tag from QRC editor

### DIFF
--- a/qt-core/src/webview/qrc-editor/xml-io.ts
+++ b/qt-core/src/webview/qrc-editor/xml-io.ts
@@ -73,7 +73,7 @@ export function defaultQrcLines() {
     '<RCC version="1.0">',
     '  <qresource prefix="/">',
     '  </qresource>',
-    '<RCC>',
+    '</RCC>',
     ''
   ];
 }


### PR DESCRIPTION
<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
