### PR TITLE
qt-ui: Refactor around UIProject

### DIFF
--- a/qt-ui/src/extension.ts
+++ b/qt-ui/src/extension.ts
@@ -6,72 +6,37 @@ import * as vscode from 'vscode';
 import {
   CoreAPI,
   getCoreApi,
-  QtWorkspaceConfigMessage,
-  QtWorkspaceType,
-  ProjectManager,
   createLogger,
   initLogger,
   telemetry
 } from 'qt-lib';
-import { UIEditorProvider } from '@/editors/ui/ui-editor';
-import { createUIProject, UIProject } from '@/project';
 import { EXTENSION_ID } from '@/constants';
 import { openWidgetDesigner } from '@/commands';
+import { UIProjectManager } from '@/project-manager';
+import { UIEditorProvider } from '@/editors/ui/ui-editor';
 
 const logger = createLogger('extension');
 
-export let projectManager: ProjectManager<UIProject>;
 export let coreAPI: CoreAPI | undefined;
+export let projectManager: UIProjectManager;
 
 export async function activate(context: vscode.ExtensionContext) {
   initLogger(EXTENSION_ID);
-  telemetry.activate(context);
   logger.info(`Activating ${context.extension.id}`);
-  coreAPI = await getCoreApi();
-  if (!coreAPI) {
-    const err = 'Failed to get CoreAPI';
-    logger.error(err);
-    throw new Error(err);
-  }
+  telemetry.activate(context);
 
-  projectManager = new ProjectManager<UIProject>(context, createUIProject);
-  projectManager.onProjectAdded(async (project) => {
-    logger.info('Adding project:', project.folder.uri.fsPath);
+  await initCoreApi();
+  await initProjectManager(context);
 
-    project.workspaceType = coreAPI?.getValue<QtWorkspaceType>(
-      project.folder,
-      'workspaceType'
-    );
-    await project.tryToGetDesigner();
-  });
-  projectManager.onProjectRemoved((project) => {
-    logger.info('Project removed:', project.folder.uri.fsPath);
-  });
-  if (vscode.workspace.workspaceFolders !== undefined) {
-    for (const folder of vscode.workspace.workspaceFolders) {
-      const project = await createUIProject(folder, context);
-      projectManager.addProject(project);
-    }
-  }
-  coreAPI.onValueChanged((message) => {
-    logger.info('Received config change:', message.config as unknown as string);
-    void processMessage(message);
-  });
-  context.subscriptions.push(UIEditorProvider.register(context));
   context.subscriptions.push(
+    UIEditorProvider.register(context),
     vscode.commands.registerCommand(
       `${EXTENSION_ID}.openWidgetDesigner`,
       openWidgetDesigner
     )
   );
-  getConfigValues();
-  telemetry.sendEvent(`activated`);
-}
 
-function getConfigValues() {
-  for (const project of projectManager.getProjects()) {
-    void project.getConfigValues();
-  }
+  telemetry.sendEvent('activated');
 }
 
 export function deactivate() {
@@ -80,42 +45,16 @@ export function deactivate() {
   projectManager.dispose();
 }
 
-async function processMessage(message: QtWorkspaceConfigMessage) {
-  // check if workspace folder is a string
-  if (typeof message.workspaceFolder === 'string') {
-    return;
+async function initCoreApi() {
+  coreAPI = await getCoreApi();
+  if (!coreAPI) {
+    const msg = 'Failed to get CoreAPI';
+    logger.error(msg);
+    throw new Error(msg);
   }
-  const project = projectManager.getProject(message.workspaceFolder);
-  if (!project) {
-    logger.error('Project not found');
-    return;
-  }
-  for (const key of message.config.keys()) {
-    if (key === 'selectedKitPath') {
-      const selectedKitPath = coreAPI?.getValue<string>(
-        message.workspaceFolder,
-        'selectedKitPath'
-      );
-      if (selectedKitPath !== project.selectedKitPath) {
-        await project.setSelectedKitPath(selectedKitPath);
-      }
-      continue;
-    }
-    if (key === 'selectedQtPaths') {
-      const selectedQtPaths = coreAPI?.getValue<string>(
-        message.workspaceFolder,
-        'selectedQtPaths'
-      );
-      if (selectedQtPaths !== project.qtpathsExe) {
-        await project.setQtPathsExe(selectedQtPaths);
-      }
-      continue;
-    }
-    if (key === 'workspaceType') {
-      project.workspaceType = coreAPI?.getValue<QtWorkspaceType>(
-        message.workspaceFolder,
-        'workspaceType'
-      );
-    }
-  }
+}
+
+async function initProjectManager(context: vscode.ExtensionContext) {
+  projectManager = new UIProjectManager(context);
+  await projectManager.init();
 }

--- a/qt-ui/src/project-manager.ts
+++ b/qt-ui/src/project-manager.ts
@@ -1,0 +1,102 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+
+import {
+  QtWorkspaceConfigMessage,
+  QtWorkspaceType,
+  ProjectManager,
+  createLogger
+} from 'qt-lib';
+import * as consts from '@/constants';
+import { coreAPI } from '@/extension';
+import { createUIProject, UIProject } from '@/project';
+
+const logger = createLogger('project-manager');
+
+export class UIProjectManager extends ProjectManager<UIProject> {
+  public constructor(context: vscode.ExtensionContext) {
+    super(context, createUIProject);
+
+    this._disposables.push(
+      this.onProjectAdded(UIProjectManager._onProjectAdded),
+      this.onProjectRemoved(UIProjectManager._onProjectRemoved),
+      vscode.workspace.onDidChangeConfiguration(this._onWorkspaceConfigChanged)
+    );
+  }
+
+  public async init() {
+    for (const folder of vscode.workspace.workspaceFolders ?? []) {
+      const project = await createUIProject(folder, this.context);
+      await project.init();
+      this.addProject(project);
+    }
+
+    if (coreAPI) {
+      this._disposables.push(
+        coreAPI.onValueChanged(this._onCoreConfigMessasge)
+      );
+    }
+  }
+
+  private readonly _onCoreConfigMessasge = async (
+    msg: QtWorkspaceConfigMessage
+  ) => {
+    logger.info('Received config message:', msg.config as unknown as string);
+
+    if (typeof msg.workspaceFolder === 'string') {
+      // do nothing if workspace folder is a string
+      return;
+    }
+
+    const folder = msg.workspaceFolder;
+    const project = this.getProject(folder);
+    if (!project) {
+      logger.error(`Project not found: folder = ${folder.uri.fsPath}`);
+      return;
+    }
+
+    for (const key of msg.config.keys()) {
+      if (key === 'selectedKitPath') {
+        const value = coreAPI?.getValue<string>(folder, key);
+        await project.setSelectedKitPath(value);
+        continue;
+      }
+
+      if (key === 'selectedQtPaths') {
+        const value = coreAPI?.getValue<string>(folder, key);
+        await project.setSelectedQtPaths(value);
+        continue;
+      }
+
+      if (key === 'workspaceType') {
+        await project.setWorkspaceType(
+          coreAPI?.getValue<QtWorkspaceType>(folder, key)
+        );
+      }
+    }
+  };
+
+  private readonly _onWorkspaceConfigChanged = async (
+    ev: vscode.ConfigurationChangeEvent
+  ) => {
+    const key = consts.CONF_CUSTOM_WIDGETS_DESIGNER_EXE_PATH;
+    const section = `${consts.EXTENSION_ID}.${key}`;
+
+    for (const project of this.getProjects()) {
+      if (ev.affectsConfiguration(section, project.folder)) {
+        await project.tryReloadCustomExePath();
+      }
+    }
+  };
+
+  private static readonly _onProjectAdded = async (project: UIProject) => {
+    logger.info('Adding project:', project.folder.uri.fsPath);
+    await project.init();
+  };
+
+  private static readonly _onProjectRemoved = (project: UIProject) => {
+    logger.info('Project removed:', project.folder.uri.fsPath);
+  };
+}

--- a/qt-ui/src/project.ts
+++ b/qt-ui/src/project.ts
@@ -4,22 +4,24 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 
-import { DesignerClient } from '@/designer-client';
-import { DesignerServer } from '@/designer-server';
 import {
+  Project,
   createLogger,
   QtWorkspaceType,
-  Project,
   resolveConfiguration
 } from 'qt-lib';
-import {
-  getConfig,
-  affectsConfig,
-  locateDesignerFromKit,
-  locateDesignerFromQtPaths
-} from '@/util';
-import { CONF_CUSTOM_WIDGETS_DESIGNER_EXE_PATH } from '@/constants';
+import * as consts from '@/constants';
 import { coreAPI } from '@/extension';
+import { DesignerClient } from '@/designer-client';
+import { DesignerServer } from '@/designer-server';
+import { locateDesignerFromKit, locateDesignerFromQtPaths } from '@/util';
+
+type UpdateReason =
+  | 'init'
+  | 'customExeChanged'
+  | 'workspaceTypeChanged'
+  | 'selectedKitPathChanged'
+  | 'selectedQtPathsChanged';
 
 const logger = createLogger('project');
 
@@ -27,236 +29,164 @@ export async function createUIProject(
   folder: vscode.WorkspaceFolder,
   context: vscode.ExtensionContext
 ) {
-  return Promise.resolve(new UIProject(folder, context));
+  const project = new UIProject(folder, context);
+  return Promise.resolve(project);
 }
 
 // Project class represents a workspace folder in the extension.
 export class UIProject implements Project {
-  private readonly _disposables: vscode.Disposable[] = [];
+  private _customExePath: string | undefined;
   private _workspaceType: QtWorkspaceType | undefined;
   private _selectedKitPath: string | undefined;
+  private _selectedQtPaths: string | undefined;
+
   private _designerClient: DesignerClient | undefined;
-  private _qtpathsExe: string | undefined;
   private readonly _designerServer: DesignerServer;
-  private _customWidgetsDesignerExePath: string | undefined;
+
   public constructor(
     readonly _folder: vscode.WorkspaceFolder,
     readonly _context: vscode.ExtensionContext
   ) {
     this._designerServer = new DesignerServer();
-    this._customWidgetsDesignerExePath = this.getQtCustomDesignerPath();
-    logger.info(
-      `${CONF_CUSTOM_WIDGETS_DESIGNER_EXE_PATH}: "${this._customWidgetsDesignerExePath}"`
-    );
-    if (this._customWidgetsDesignerExePath) {
-      if (
-        UIProject.checkCustomDesignerExePath(this._customWidgetsDesignerExePath)
-      ) {
-        this.designerClient = new DesignerClient(
-          this._customWidgetsDesignerExePath,
-          this._designerServer.getPort()
-        );
-      }
-    }
-    const eventHandler = vscode.workspace.onDidChangeConfiguration(
-      async (event) => {
-        if (
-          affectsConfig(
-            event,
-            CONF_CUSTOM_WIDGETS_DESIGNER_EXE_PATH,
-            this._folder
-          )
-        ) {
-          this._customWidgetsDesignerExePath = this.getQtCustomDesignerPath();
-          logger.info(
-            `new ${CONF_CUSTOM_WIDGETS_DESIGNER_EXE_PATH}:`,
-            this._customWidgetsDesignerExePath
-          );
-          if (
-            this._customWidgetsDesignerExePath &&
-            UIProject.checkCustomDesignerExePath(
-              this._customWidgetsDesignerExePath
-            )
-          ) {
-            this.designerClient = new DesignerClient(
-              this._customWidgetsDesignerExePath,
-              this._designerServer.getPort()
-            );
-          } else {
-            // That means the user has removed the path.
-            // So, we need to detach the client and get the designer from qtpaths
-            // or from the selected kit.
-            let isDesignerClientSet = false;
-            if (this._designerClient) {
-              if (this._selectedKitPath) {
-                this.designerClient = await this.getNewDesignerClient(
-                  this._selectedKitPath
-                );
-                isDesignerClientSet = true;
-              } else if (this._qtpathsExe) {
-                const designer = await locateDesignerFromQtPaths(
-                  this._qtpathsExe
-                );
-                if (designer) {
-                  this.designerClient = new DesignerClient(
-                    designer,
-                    this.designerServer.getPort()
-                  );
-                  isDesignerClientSet = true;
-                }
-              }
-            }
-            if (!isDesignerClientSet) {
-              this.designerClient = undefined;
-            }
-          }
-        }
-      }
-    );
-    this._disposables.push(eventHandler);
-  }
-  getQtCustomDesignerPath() {
-    return resolveConfiguration(
-      getConfig<string>(CONF_CUSTOM_WIDGETS_DESIGNER_EXE_PATH, '', this._folder)
-    );
   }
 
-  private async getNewDesignerClient(selectedKitPath: string) {
-    const designerExe = await locateDesignerFromKit(selectedKitPath);
-    if (!designerExe) {
-      return undefined;
-    }
-    const designerClient = new DesignerClient(
-      designerExe,
-      this.designerServer.getPort()
-    );
-    return designerClient;
-  }
-  get workspaceType() {
-    return this._workspaceType;
-  }
-  set workspaceType(workspaceType: QtWorkspaceType | undefined) {
-    this._workspaceType = workspaceType;
+  dispose() {
+    this._designerServer.dispose();
+    this._designerClient?.dispose();
   }
 
-  get selectedKitPath() {
-    return this._selectedKitPath;
-  }
-
-  get qtpathsExe() {
-    return this._qtpathsExe;
-  }
-
-  async setQtPathsExe(qtpathsExe: string | undefined) {
-    if (qtpathsExe === this._qtpathsExe) {
-      return;
-    }
-    this._qtpathsExe = qtpathsExe;
-    if (this._customWidgetsDesignerExePath) {
-      return;
-    }
-    if (qtpathsExe === undefined) {
-      this.designerClient = undefined;
-      return;
-    } else {
-      this._selectedKitPath = undefined; // Reset selectedKitPath when qtpathsExe is set
-    }
-
-    const designer = await locateDesignerFromQtPaths(qtpathsExe);
-    if (designer) {
-      this.designerClient = new DesignerClient(
-        designer,
-        this.designerServer.getPort()
-      );
-    } else {
-      this.designerClient = undefined;
-    }
-  }
-
-  async setSelectedKitPath(selectedKitPath: string | undefined) {
-    if (selectedKitPath === this._selectedKitPath) {
-      return;
-    }
-
-    this._selectedKitPath = selectedKitPath;
-    if (this._customWidgetsDesignerExePath) {
-      return;
-    }
-    if (selectedKitPath === undefined) {
-      this.designerClient = undefined;
-      return;
-    } else {
-      this._qtpathsExe = undefined; // Reset qtpathsExe when a kit is selected
-    }
-    this.designerClient = await this.getNewDesignerClient(selectedKitPath);
+  get folder() {
+    return this._folder;
   }
 
   get designerServer() {
     return this._designerServer;
   }
+
   get designerClient() {
     return this._designerClient;
   }
-  set designerClient(client: DesignerClient | undefined) {
+
+  get workspaceType() {
+    return this._workspaceType;
+  }
+
+  public async init() {
+    const read = coreAPI?.getValue.bind(coreAPI);
+    if (!read) {
+      return;
+    }
+
+    this._customExePath = this._readCustomExePath();
+    this._workspaceType = read<QtWorkspaceType>(this._folder, 'workspaceType');
+    this._selectedKitPath = read<string>(this._folder, 'selectedKitPath');
+    this._selectedQtPaths = read<string>(this._folder, 'selectedQtPaths');
+
+    await this._updateClient('init');
+  }
+
+  public async tryReloadCustomExePath() {
+    const exe = this._readCustomExePath();
+
+    if (this._customExePath !== exe) {
+      this._customExePath = exe;
+      await this._updateClient('customExeChanged');
+    }
+  }
+
+  public async setWorkspaceType(workspaceType: QtWorkspaceType | undefined) {
+    if (this._workspaceType !== workspaceType) {
+      this._workspaceType = workspaceType;
+      await this._updateClient('workspaceTypeChanged');
+    }
+  }
+
+  public async setSelectedKitPath(selectedKitPath: string | undefined) {
+    if (this._selectedKitPath !== selectedKitPath) {
+      this._selectedKitPath = selectedKitPath;
+      await this._updateClient('selectedKitPathChanged');
+    }
+  }
+
+  public async setSelectedQtPaths(exePath: string | undefined) {
+    if (this._selectedQtPaths !== exePath) {
+      this._selectedQtPaths = exePath;
+      await this._updateClient('selectedQtPathsChanged');
+    }
+  }
+
+  private async _updateClient(reason: UpdateReason) {
+    const exe = await this._resolveDesignerExe();
+    if (!exe) {
+      this._clearClient();
+      return;
+    }
+
+    const prev = this._designerClient?.exe;
+    if (!prev && prev === exe) {
+      return;
+    }
+
+    this._clearClient();
+    this._designerClient = new DesignerClient(
+      exe,
+      this._designerServer.getPort()
+    );
+
+    // clean up
+    if (reason === 'selectedKitPathChanged') {
+      this._selectedQtPaths = undefined;
+    } else if (reason === 'selectedQtPathsChanged') {
+      this._selectedKitPath = undefined;
+    }
+  }
+
+  private _clearClient() {
     this._designerClient?.detach();
-    this._designerClient = client;
-  }
-  get folder() {
-    return this._folder;
-  }
-  public async getConfigValues() {
-    await this.tryToGetDesigner();
-    this.workspaceType = coreAPI?.getValue<QtWorkspaceType>(
-      this.folder,
-      'workspaceType'
-    );
-  }
-  public async tryToGetDesigner() {
-    const selectedKitPath = coreAPI?.getValue<string>(
-      this.folder,
-      'selectedKitPath'
-    );
-    const selectedQtPaths = coreAPI?.getValue<string>(
-      this.folder,
-      'selectedQtPaths'
-    );
-
-    if (selectedKitPath) {
-      await this.setSelectedKitPath(selectedKitPath);
-    } else if (selectedQtPaths) {
-      await this.setQtPathsExe(selectedQtPaths);
-    } else {
-      this.designerClient = undefined;
-      logger.warn(
-        'No Qt Widgets Designer found for project:',
-        this.folder.uri.fsPath
-      );
-    }
-  }
-
-  private static checkCustomDesignerExePath(
-    customWidgetsDesignerExePath: string
-  ) {
-    if (!fs.existsSync(customWidgetsDesignerExePath)) {
-      logger.error(
-        'Qt Widgets Designer executable not found at:"',
-        customWidgetsDesignerExePath,
-        '"'
-      );
-      void vscode.window.showWarningMessage(
-        'Qt Widgets Designer executable not found at:"' +
-          customWidgetsDesignerExePath +
-          '"'
-      );
-      return false;
-    }
-    return true;
-  }
-  dispose() {
-    this._designerServer.dispose();
     this._designerClient?.dispose();
-    for (const d of this._disposables) {
-      d.dispose();
+    this._designerClient = undefined;
+  }
+
+  private async _resolveDesignerExe() {
+    if (this._customExePath) {
+      if (fs.existsSync(this._customExePath)) {
+        return this._customExePath;
+      }
+
+      const msg =
+        'Qt Widgets Designer executable not found at: ' +
+        `"${this._customExePath}"`;
+
+      logger.error(msg);
+      void vscode.window.showWarningMessage(msg);
     }
+
+    if (this._workspaceType === QtWorkspaceType.CMakeExt) {
+      if (this._selectedKitPath) {
+        return locateDesignerFromKit(this._selectedKitPath);
+      }
+
+      if (this._selectedQtPaths) {
+        return locateDesignerFromQtPaths(this._selectedQtPaths);
+      }
+    }
+
+    return undefined;
+  }
+
+  private _readCustomExePath() {
+    const folder = this.folder;
+    const config = vscode.workspace
+      .getConfiguration(consts.EXTENSION_ID, folder)
+      .get<string>(consts.CONF_CUSTOM_WIDGETS_DESIGNER_EXE_PATH, '');
+    const value = resolveConfiguration(config);
+
+    logger.info(
+      'Read custom desinger exe path: ',
+      `value = ${value}, `,
+      `folder = '${folder.uri.fsPath}'`
+    );
+
+    return value;
   }
 }

--- a/qt-ui/src/util.ts
+++ b/qt-ui/src/util.ts
@@ -1,10 +1,8 @@
 // Copyright (C) 2024 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
-import * as vscode from 'vscode';
 import * as path from 'path';
 
-import * as constants from '@/constants';
 import {
   IsMacOS,
   IsWindows,
@@ -15,66 +13,32 @@ import {
 } from 'qt-lib';
 import { coreAPI } from '@/extension';
 
-export function getConfig<T>(
-  key: string,
-  defaultValue: T,
-  folder?: vscode.WorkspaceFolder
-): T {
-  return vscode.workspace
-    .getConfiguration(constants.EXTENSION_ID, folder)
-    .get<T>(key, defaultValue);
-}
-
-export function affectsConfig(
-  event: vscode.ConfigurationChangeEvent,
-  key: string,
-  folder?: vscode.WorkspaceFolder
-): boolean {
-  return event.affectsConfiguration(`${constants.EXTENSION_ID}.${key}`, folder);
-}
-
 export async function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-const DesignerExeName = IsMacOS ? 'Designer' : 'designer' + OSExeSuffix;
-
-function getDesignerExePathFromBin(selectedQtBinPath: string) {
-  const macOSPath = path.join(
-    'Designer.app',
-    'Contents',
-    'MacOS',
-    DesignerExeName
-  );
-  return IsMacOS
-    ? path.join(selectedQtBinPath, macOSPath)
-    : path.join(selectedQtBinPath, DesignerExeName);
 }
 
 export async function locateDesignerFromKit(
   selectedKitPath: string,
   qtPathsFallback = true
 ) {
-  let designerExePath = getDesignerExePathFromBin(
-    path.join(selectedKitPath, 'bin')
-  );
-  if (await exists(designerExePath)) {
-    return designerExePath;
+  let exe = getDesignerExePathFromBin(path.join(selectedKitPath, 'bin'));
+  if (await exists(exe)) {
+    return exe;
   }
+
   if (qtPathsFallback) {
     const qtPaths = findQtPathsInKitDir(selectedKitPath);
-    if (qtPaths) {
-      const qtPathsExePath = await locateDesignerFromQtPaths(qtPaths);
-      if (qtPathsExePath) {
-        return qtPathsExePath;
-      }
+    const exeFromQtPaths =
+      qtPaths && (await locateDesignerFromQtPaths(qtPaths));
+    if (exeFromQtPaths) {
+      return exeFromQtPaths;
     }
   }
 
   if (!IsWindows) {
-    designerExePath = '/usr/bin/designer';
-    if (await exists(designerExePath)) {
-      return designerExePath;
+    exe = '/usr/bin/designer';
+    if (await exists(exe)) {
+      return exe;
     }
   }
 
@@ -86,12 +50,13 @@ export async function locateDesignerFromQtPaths(qtPaths: string) {
   if (!info) {
     return undefined;
   }
-  const designerExePath = await searchForExeInQtInfo(
-    info,
-    getDesignerExePathFromBin
+
+  return searchForExeInQtInfo(info, getDesignerExePathFromBin);
+}
+
+function getDesignerExePathFromBin(selectedQtBinPath: string) {
+  return path.join(
+    selectedQtBinPath,
+    IsMacOS ? 'Designer.app/Contents/MacOS/Designer' : 'designer' + OSExeSuffix
   );
-  if (designerExePath) {
-    return designerExePath;
-  }
-  return undefined;
 }


### PR DESCRIPTION
- Centralize Qt Widgets Designer client handling
- Extract UIProjectManager to clarify project management
- Handle core and workspace events in one place
- Simplify state and update flow
- Remove unused setters and reorder functions

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
