### PR TITLE
Github: Check whether skip-upload is true or not

### DIFF
--- a/.github/actions/build-qtcli/action.yml
+++ b/.github/actions/build-qtcli/action.yml
@@ -8,6 +8,10 @@ inputs:
   deploy-target:
     description: 'Folder where built binaries will be copied'
 
+  skip-upload:
+    description: 'Decide whether to skip upload or not'
+    default: 'false'
+
 outputs:
   artifact-name:
     description: 'Build artifact name'
@@ -53,7 +57,7 @@ runs:
         GORELEASER_CURRENT_TAG: ${{ env.QTCLI_VERSION }}
 
     - name: Upload artifact
-      if: ${{ inputs.skip-upload == 'false' }}
+      if: ${{ inputs.skip-upload != 'true' }}
       id: step-artifacts-upload
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
When we check whether skip-upload is false or not, it does not work as expected if nothing is passed to skip-upload. So, we change the condition to check whether skip-upload is true or not.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
