### PR TITLE
qt-qml: Always restart qmlls when a new version is installed

### DIFF
--- a/qt-qml/src/commands/check-qmlls-update.ts
+++ b/qt-qml/src/commands/check-qmlls-update.ts
@@ -17,7 +17,7 @@ export function registerCheckQmllsUpdateCommand() {
       switch (decision.code) {
         case DecisionCode.NeedToUpdate:
           if (decision.asset) {
-            await Qmlls.install(decision.asset, { restart: true });
+            await Qmlls.install(decision.asset);
           }
           break;
 

--- a/qt-qml/src/commands/download-qmlls.ts
+++ b/qt-qml/src/commands/download-qmlls.ts
@@ -18,7 +18,7 @@ export function registerDownloadQmllsCommand() {
         case DecisionCode.NeedToUpdate:
         case DecisionCode.AlreadyUpToDate:
           if (decision.asset) {
-            await Qmlls.install(decision.asset, { restart: true });
+            await Qmlls.install(decision.asset);
           }
           break;
 

--- a/qt-qml/src/installer.ts
+++ b/qt-qml/src/installer.ts
@@ -7,7 +7,12 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { spawnSync } from 'child_process';
 
-import { UserLocalDir, OSExeSuffix, fetchWithAbort } from 'qt-lib';
+import {
+  UserLocalDir,
+  OSExeSuffix,
+  fetchWithAbort,
+  createLogger
+} from 'qt-lib';
 import * as unzipper from '@/unzipper';
 import * as downloader from '@/downloader';
 import { setDoNotAskForDownloadingQmlls } from '@/qmlls';
@@ -19,6 +24,8 @@ const InstallDir = installerDir();
 const ExtractDir = path.join(InstallDir, 'files');
 const QmllsExePath = path.join(InstallDir, 'files', 'qmlls' + OSExeSuffix);
 const ReleaseJsonPath = path.join(InstallDir, 'release.json');
+
+const logger = createLogger('installer.ts');
 
 interface Asset {
   id: string;
@@ -108,10 +115,13 @@ export async function install(asset: AssetWithTag) {
   const tmpPath = path.join(DownloadDir, asset.name);
 
   // download, unzip
+  logger.info(`Downloading from: ${asset.browser_download_url}`);
   await downloadWithProgress(asset.browser_download_url, tmpPath);
+  logger.info(`Unzipping to: ${ExtractDir}`);
   await unzipWithProgress(tmpPath);
 
   // follow up
+  logger.info(`QML language server installed to: ${QmllsExePath}`);
   fs.chmodSync(QmllsExePath, 0o755);
   fs.unlinkSync(tmpPath);
   fs.writeFileSync(

--- a/qt-qml/src/qmlls.ts
+++ b/qt-qml/src/qmlls.ts
@@ -167,14 +167,10 @@ export class Qmlls {
     this._importPaths.clear();
   }
 
-  public static async install(
-    asset: installer.AssetWithTag,
-    options?: { restart: true }
-  ) {
+  public static async install(asset: installer.AssetWithTag) {
     try {
-      if (options?.restart) {
-        await projectManager.stopQmlls();
-      }
+      logger.info('Stopping QML language server to install new version');
+      await projectManager.stopQmlls();
 
       logger.info(`Installing: ${asset.name}, ${asset.tag_name}`);
       await installer.install(asset);
@@ -183,16 +179,14 @@ export class Qmlls {
       logger.warn(isError(error) ? error.message : String(error));
     }
 
-    if (options?.restart) {
-      void projectManager.startQmlls();
-      return QmllsStatus.running;
-    }
-    return QmllsStatus.stopped;
+    void projectManager.startQmlls();
+    return QmllsStatus.running;
   }
   public static async checkAssetAndDecide() {
     // Do not show the progress bar during the startup
     const result = await fetchAssetAndDecide({ silent: true });
     if (result.code === DecisionCode.NeedToUpdate && result.asset) {
+      logger.info('Updating QML language server');
       return Qmlls.install(result.asset);
     }
     return QmllsStatus.stopped;
@@ -203,6 +197,9 @@ export class Qmlls {
       QMLLS_CONFIG,
       this._folder
     );
+    if (this._client?.isRunning()) {
+      return;
+    }
     if (!configs.get<boolean>('enabled', false)) {
       return;
     }
@@ -373,13 +370,16 @@ export class Qmlls {
   public async stop() {
     if (this._client) {
       if (this._client.isRunning()) {
+        logger.info(`Stopping QML Language Server: "${this._folder.name}"`);
         await this._client
           .stop()
           .then(() => {
-            logger.info('QML Language Server stopped');
+            logger.info(`QML Language Server stopped: "${this._folder.name}"`);
           })
           .catch((e) => {
-            logger.info(`QML Language Server stop failed, ${e}`);
+            logger.error(
+              `QML Language Server stop failed: "${this._folder.name}", ${String(e)}`
+            );
           });
       }
 


### PR DESCRIPTION
If we install a new version of qmlls without stopping the currently running instance, the old version remains active and cannot be replaced. To fix this, qmlls should always be stopped before installing a new version.

The root cause of [VSCODEEXT-244](https://bugreports.qt.io/browse/VSCODEEXT-244) is that [commit 884feba](https://github.com/qt-labs/vscodeext/pull/200/commits/884febaab490d0f33e7e786bbbabf52427ca4ce0) removed waiting for `qt-cpp` activation and notifying other extensions. This caused qmlls to start immediately when VS Code starts while the popup for updating qmlls is still open.

Before that change, when a new qmlls version was published, a popup was shown to the user and qmlls was not started until the user made a choice.

After the change, qmlls starts immediately, which causes the old version to keep running and block the update.

This commit fixes the issue by always stopping qmlls before installing a new version and restarting it before the user makes a choice.

* Improve log messages

Fixes: [VSCODEEXT-242](https://bugreports.qt.io/browse/VSCODEEXT-242)
Fixes: [VSCODEEXT-244](https://bugreports.qt.io/browse/VSCODEEXT-244)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
