### PR TITLE
qt-qml: Fix file finding in QML/JS debugger on Windows

### DIFF
--- a/qt-qml/src/debug/file-finder.ts
+++ b/qt-qml/src/debug/file-finder.ts
@@ -72,7 +72,8 @@ export class FileFinder {
     }
     const files = this.filesWithSameFileName(lastSegment);
     matches.push(...files.map((file) => file.fsPath));
-    const matchedFilePaths = FileFinder.bestMatches(matches, originalPath);
+    const filePathToFind = vscode.Uri.parse(originalPath).fsPath;
+    const matchedFilePaths = FileFinder.bestMatches(matches, filePathToFind);
     if (matchedFilePaths.length === 0) {
       return undefined;
     }


### PR DESCRIPTION
Handle directory separators correctly in best-match searches for QML or JavaScript files.
Previously, incorrect separators could cause the QML/JS debugger to open the wrong file when hitting breakpoints.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
