### PR TITLE
qt-qml: Support user-supplied QRC file in QML debugger

### DIFF
--- a/qt-qml/src/debug/qrc-parser.ts
+++ b/qt-qml/src/debug/qrc-parser.ts
@@ -3,6 +3,7 @@
 
 import { XMLParser } from 'fast-xml-parser';
 import * as fs from 'fs';
+import * as path from 'path';
 
 // Define the structure for the QRC XML
 interface QRCFile {
@@ -28,7 +29,8 @@ export class QRCParser {
   constructor() {
     this.parser = new XMLParser({
       ignoreAttributes: false,
-      parseAttributeValue: true
+      parseAttributeValue: true,
+      alwaysCreateTextNode: true
     });
   }
 
@@ -41,7 +43,7 @@ export class QRCParser {
       return cachedContent;
     }
     const xmlContent = fs.readFileSync(filePath, 'utf8');
-    const fileMapping = this.parseQRC(xmlContent);
+    const fileMapping = this.parseQRC(xmlContent, path.dirname(filePath));
     if (!fileMapping) {
       return undefined;
     }
@@ -49,7 +51,7 @@ export class QRCParser {
     return fileMapping;
   }
 
-  parseQRC(xmlContent: string) {
+  parseQRC(xmlContent: string, qrcDir: string) {
     try {
       // Parse the XML content into the defined structure
       const jsonObj = this.parser.parse(xmlContent) as QRCParsed; // Type assertion to QRCParsed
@@ -75,16 +77,16 @@ export class QRCParser {
           : [resource.file];
 
         files.forEach((file) => {
-          const fileAlias = file['@_alias']; // Use the alias as the key
-          const filePath = file['#text'];
-          if (!fileAlias || !filePath) {
+          // Only keep .qml and .js files
+          const text = file['#text'];
+          if (!text || (!text.endsWith('.qml') && !text.endsWith('.js'))) {
             return;
           }
-          // Only keep .qml and .js files
-          if (filePath.endsWith('.qml') || filePath.endsWith('.js')) {
-            const alias = prefix + fileAlias; // Combine the prefix and alias
-            resourceMap.set(alias, filePath); // Store alias as key, file path as value
-          }
+
+          resourceMap.set(
+            path.join(prefix, file['@_alias'] ?? text).replace(/\\/g, '/'),
+            path.isAbsolute(text) ? text : path.join(qrcDir, text)
+          );
         });
       });
 


### PR DESCRIPTION
The previous implementation was designed to support QRC files
generated during the CMake build process.

This commit adds support for custom QRC files provided by the user.
In this case, the `<file>` tag may not have an alias attribute, and
file paths are likely to be relative to the directory of the QRC file.

This is important for non-CMake projects such as PySide projects and
the C++ projects that do not use `qt_add_qml_module()` CMake command.
It also supports projects that use `qt_add_resource()` CMake command.

Task-number: [VSCODEEXT-241](https://bugreports.qt.io/browse/VSCODEEXT-241)
Task-number: [VSCODEEXT-251](https://bugreports.qt.io/browse/VSCODEEXT-251)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
