### PR TITLE
qt-cpp:build-test: Fix using --qt-root

### DIFF
--- a/qt-cpp/test/helper.mts
+++ b/qt-cpp/test/helper.mts
@@ -443,7 +443,7 @@ function pickKit(list: KitLike[]): string | undefined {
  *
  * @returns The selected kit name, or `undefined` if no kit was found.
  */
-export async function selectAndApplyKitLegacy(): Promise<string | undefined> {
+export async function selectAndApplyKit(): Promise<string | undefined> {
   await vscode.commands.executeCommand('cmake.scanForKits');
 
   const kits = readKitsFromDisk();

--- a/qt-cpp/test/suite/build.test.mts
+++ b/qt-cpp/test/suite/build.test.mts
@@ -18,7 +18,7 @@ import {
   setCMakeGeneratorForPlatform,
   prepareStandardCMakeArgs,
   readCMakeCacheVar,
-  selectAndApplyKitLegacy
+  selectAndApplyKit
 } from '../helper.mts';
 
 describe('build: minimal Qt project (index-build)', function () {
@@ -39,15 +39,7 @@ describe('build: minimal Qt project (index-build)', function () {
 
     await setCMakeGeneratorForPlatform(wsFolder);
 
-    // Non-interactive Kit (required esp. on Windows; harmless elsewhere)
-    // const kitName = await selectBestCMakeKitNonInteractive();
-    // await applyCMakeKitByName(wsFolder, kitName);
-    // if (kitName) {
-    //   console.log('[build.test] Selected Kit:', kitName);
-    // } else {
-    //   console.warn('[build.test] No kitName resolved; configure may prompt.');
-    // }
-    await selectAndApplyKitLegacy();
+    await selectAndApplyKit();
 
     // Qt: pin ONLY Qt6_DIR (no CMAKE_PREFIX_PATH)
     const qtRoot = vscode.workspace

--- a/qt-cpp/test/suite/build.test.mts
+++ b/qt-cpp/test/suite/build.test.mts
@@ -50,7 +50,13 @@ describe('build: minimal Qt project (index-build)', function () {
     await selectAndApplyKitLegacy();
 
     // Qt: pin ONLY Qt6_DIR (no CMAKE_PREFIX_PATH)
-    prepareCMakeQtEnvWithVersion({ verbose: true });
+    const qtRoot = vscode.workspace
+      .getConfiguration('qt-core')
+      .get<string>('qtInstallationRoot');
+    if (typeof qtRoot !== 'string' || qtRoot.trim() === '') {
+      throw new Error('qt-core.qtInstallationRoot is not configured.');
+    }
+    prepareCMakeQtEnvWithVersion({ topLevel: qtRoot, verbose: true });
 
     // Standard args
     prepareStandardCMakeArgs();


### PR DESCRIPTION

The content of --qt-root argument when present is set to qt-core.qtInstallationRoot. When searching for Qt installation in build.test.mts, via prepareCMakeQtEnvWithVersion, qt-core.qtInstallationRoot must be passed otherwise the Qt Installation is looked for in process.env.QT_TEST_QT_ROOT and --qt-root  is ignored.
