### PR TITLE
qt-lib, qt-cpp, qt-ui, qt-python: Introduce `QtWorkspaceFeatures`

### DIFF
--- a/qt-cpp/src/project.ts
+++ b/qt-cpp/src/project.ts
@@ -16,7 +16,7 @@ import {
   IsMacOS,
   IsWindows,
   QtWorkspaceConfigMessage,
-  QtWorkspaceType,
+  QtWorkspaceFeatures,
   telemetry
 } from 'qt-lib';
 import { Project, ProjectManager } from 'qt-lib';
@@ -430,10 +430,17 @@ export class CppProject implements Project {
     logger.info(
       `Setting selected Qt paths for ${folder.uri.fsPath} to ${selectedQtPaths}`
     );
-    coreAPI.setValue(folder, 'workspaceType', QtWorkspaceType.CMakeExt);
+
+    const featuresKey = 'workspaceFeatures';
+    let features = coreAPI.getValue<QtWorkspaceFeatures>(folder, featuresKey);
+    features ??= { projectTypes: {} };
+    features.projectTypes.cmake = true;
+
+    coreAPI.setValue(folder, featuresKey, features);
     logger.info(
-      `Setting workspace type for ${folder.uri.fsPath} to ${QtWorkspaceType.CMakeExt}`
+      `Setting workspace features for ${folder.uri.fsPath} to ${JSON.stringify(features)}`
     );
+
     coreAPI.setValue(folder, 'buildDir', this.buildDir);
     logger.info(
       `Setting build directory for ${folder.uri.fsPath} to ${this.buildDir}`
@@ -442,7 +449,7 @@ export class CppProject implements Project {
     const message = new QtWorkspaceConfigMessage(folder);
     message.config.add('selectedKitPath');
     message.config.add('selectedQtPaths');
-    message.config.add('workspaceType');
+    message.config.add(featuresKey);
     message.config.add('buildDir');
     coreAPI.notify(message);
   }

--- a/qt-lib/src/core-api.ts
+++ b/qt-lib/src/core-api.ts
@@ -30,7 +30,7 @@ export function compareQtAdditionalPath(
 export type ConfigType =
   | string
   | QtAdditionalPath[]
-  | QtWorkspaceType
+  | QtWorkspaceFeatures
   | undefined;
 
 export type QtWorkspaceConfig = Map<string, ConfigType>;
@@ -55,10 +55,11 @@ export class QtWorkspaceConfigMessage {
   }
 }
 
-export enum QtWorkspaceType {
-  CMakeExt = 'CMakeExt',
-  CMakeCMD = 'CMakeCMD',
-  PythonExt = 'PythonExt'
+export interface QtWorkspaceFeatures {
+  projectTypes: {
+    cmake?: boolean;
+    pyside?: boolean;
+  };
 }
 
 export type QtPathsData = Map<string, string>;

--- a/qt-python/src/constants.ts
+++ b/qt-python/src/constants.ts
@@ -23,7 +23,7 @@ export const VENV = {
 };
 
 export const EXECUTABLE_EXT = IsWindows ? '.exe' : '';
-export const CORE_API_KEY_WORKSPACE_TYPE = 'workspaceType';
+export const CORE_API_KEY_WORKSPACE_FEATURES = 'workspaceFeatures';
 
 export const TOML_PROJECT_FILE_NAME = 'pyproject.toml';
 export const TOML_KEY_PROJECT_NAME = 'project.name';

--- a/qt-python/src/project-manager.ts
+++ b/qt-python/src/project-manager.ts
@@ -3,7 +3,7 @@
 
 import * as vscode from 'vscode';
 
-import { ProjectManager, createLogger, QtWorkspaceType } from 'qt-lib';
+import { ProjectManager, createLogger, QtWorkspaceFeatures } from 'qt-lib';
 import { PySideProject } from './project';
 import { pyApi, coreApi } from './extension';
 import * as consts from '@/constants';
@@ -43,18 +43,13 @@ function updateCoreValues(p: PySideProject) {
     return;
   }
 
-  const fsPath = p.folder.uri.fsPath;
+  const key = consts.CORE_API_KEY_WORKSPACE_FEATURES;
+  let features = coreApi.getValue<QtWorkspaceFeatures>(p.folder, key);
+  features ??= { projectTypes: {} };
+  features.projectTypes.pyside = p.isValid();
 
-  if (p.isValid()) {
-    coreApi.setValue(
-      p.folder,
-      consts.CORE_API_KEY_WORKSPACE_TYPE,
-      QtWorkspaceType.PythonExt
-    );
-
-    logger.info(`Set workspace type to Python: "${fsPath}"`);
-    return;
-  }
-
-  logger.info(`Not a PySide6 project: "${fsPath}"`);
+  coreApi.setValue(p.folder, key, features);
+  logger.info(
+    `Setting core value: key = ${key}, value = ${JSON.stringify(features)}`
+  );
 }

--- a/qt-ui/src/editors/ui/ui-editor.ts
+++ b/qt-ui/src/editors/ui/ui-editor.ts
@@ -3,12 +3,7 @@
 
 import * as vscode from 'vscode';
 
-import {
-  askForKitSelection,
-  createLogger,
-  QtWorkspaceType,
-  telemetry
-} from 'qt-lib';
+import { askForKitSelection, createLogger, telemetry } from 'qt-lib';
 import { getNonce, getUri } from '@/editors/util';
 import { projectManager } from '@/extension';
 import { delay } from '@/util';
@@ -54,7 +49,7 @@ export class UIEditorProvider implements vscode.CustomTextEditorProvider {
           if (designerClient === undefined) {
             // User may not have selected the kit.
             // We can check and ask for kit selection.
-            if (project.workspaceType === QtWorkspaceType.CMakeExt) {
+            if (project.workspaceFeatures?.projectTypes.cmake) {
               askForKitSelection({
                 message:
                   'Cannot find Qt Widgets Designer in the Qt installation that the selected kit refers to.',

--- a/qt-ui/src/project-manager.ts
+++ b/qt-ui/src/project-manager.ts
@@ -5,9 +5,9 @@ import * as vscode from 'vscode';
 
 import {
   QtWorkspaceConfigMessage,
-  QtWorkspaceType,
   ProjectManager,
-  createLogger
+  createLogger,
+  QtWorkspaceFeatures
 } from 'qt-lib';
 import * as consts from '@/constants';
 import { coreAPI } from '@/extension';
@@ -70,9 +70,9 @@ export class UIProjectManager extends ProjectManager<UIProject> {
         continue;
       }
 
-      if (key === 'workspaceType') {
-        await project.setWorkspaceType(
-          coreAPI?.getValue<QtWorkspaceType>(folder, key)
+      if (key === 'workspaceFeatures') {
+        await project.setWorkspaceFeatures(
+          coreAPI?.getValue<QtWorkspaceFeatures>(folder, key)
         );
       }
     }

--- a/qt-ui/src/project.ts
+++ b/qt-ui/src/project.ts
@@ -7,8 +7,8 @@ import * as fs from 'fs';
 import {
   Project,
   createLogger,
-  QtWorkspaceType,
-  resolveConfiguration
+  resolveConfiguration,
+  QtWorkspaceFeatures
 } from 'qt-lib';
 import * as consts from '@/constants';
 import { coreAPI } from '@/extension';
@@ -19,7 +19,7 @@ import { locateDesignerFromKit, locateDesignerFromQtPaths } from '@/util';
 type UpdateReason =
   | 'init'
   | 'customExeChanged'
-  | 'workspaceTypeChanged'
+  | 'workspaceFeatureChanged'
   | 'selectedKitPathChanged'
   | 'selectedQtPathsChanged';
 
@@ -36,7 +36,7 @@ export async function createUIProject(
 // Project class represents a workspace folder in the extension.
 export class UIProject implements Project {
   private _customExePath: string | undefined;
-  private _workspaceType: QtWorkspaceType | undefined;
+  private _workspaceFeatures: QtWorkspaceFeatures | undefined;
   private _selectedKitPath: string | undefined;
   private _selectedQtPaths: string | undefined;
 
@@ -67,8 +67,8 @@ export class UIProject implements Project {
     return this._designerClient;
   }
 
-  get workspaceType() {
-    return this._workspaceType;
+  get workspaceFeatures() {
+    return this._workspaceFeatures;
   }
 
   public async init() {
@@ -78,7 +78,10 @@ export class UIProject implements Project {
     }
 
     this._customExePath = this._readCustomExePath();
-    this._workspaceType = read<QtWorkspaceType>(this._folder, 'workspaceType');
+    this._workspaceFeatures = read<QtWorkspaceFeatures>(
+      this._folder,
+      'workspaceFeatures'
+    );
     this._selectedKitPath = read<string>(this._folder, 'selectedKitPath');
     this._selectedQtPaths = read<string>(this._folder, 'selectedQtPaths');
 
@@ -94,10 +97,10 @@ export class UIProject implements Project {
     }
   }
 
-  public async setWorkspaceType(workspaceType: QtWorkspaceType | undefined) {
-    if (this._workspaceType !== workspaceType) {
-      this._workspaceType = workspaceType;
-      await this._updateClient('workspaceTypeChanged');
+  public async setWorkspaceFeatures(features: QtWorkspaceFeatures | undefined) {
+    if (this._workspaceFeatures !== features) {
+      this._workspaceFeatures = features;
+      await this._updateClient('workspaceFeatureChanged');
     }
   }
 
@@ -161,7 +164,7 @@ export class UIProject implements Project {
       void vscode.window.showWarningMessage(msg);
     }
 
-    if (this._workspaceType === QtWorkspaceType.CMakeExt) {
+    if (this._workspaceFeatures?.projectTypes.cmake) {
       if (this._selectedKitPath) {
         return locateDesignerFromKit(this._selectedKitPath);
       }


### PR DESCRIPTION
Previously the `QtWorkspaceType` enumeration was used to indicate which type of project a specific workspace folder contained. A folder could only represent one of the available types.

However, there was a need to handle the case where a folder could contain both a `PySide6` project file and a `CMakeLists.txt` file, which is logically possible.

This commit addresses that by introducing `QtWorkspaceFeatures`, which is an object that stores detailed information about a given workspace folder.

With this change, a workspace folder can be both a CMake project and a PySide6 project at the same time, instead of being forced to choose one type exclusively.

This makes multiple extensions such as qt-cpp and qt-python independent. Each extension can claim that a workspace folder matches the project type it supports.

Also, this enables the qt-ui extension to locate the Qt Widgets designer binary across all relevant project types, using it's own priotization scheme.

The previous `QtWorkspaceType` has been removed accordingly.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
