### PR TITLE
qt-ui, qt-python: Support opening Qt Widgets Designer from PySide6

### DIFF
--- a/qt-python/src/constants.ts
+++ b/qt-python/src/constants.ts
@@ -23,6 +23,8 @@ export const VENV = {
 };
 
 export const EXECUTABLE_EXT = IsWindows ? '.exe' : '';
+
+export const CORE_API_KEY_VENV_BIN_PATH = 'venvBinPath';
 export const CORE_API_KEY_WORKSPACE_FEATURES = 'workspaceFeatures';
 
 export const TOML_PROJECT_FILE_NAME = 'pyproject.toml';

--- a/qt-python/src/constants.ts
+++ b/qt-python/src/constants.ts
@@ -3,29 +3,21 @@
 
 import { IsWindows } from 'qt-lib';
 
-export const EXTENSION_ID = 'theqtcompany.qt-python';
+export const EXTENSION_ID = 'qt-python';
 export const MS_PYTHON_ID = 'ms-python.python';
 export const LOG_NAME = 'qt-python';
 
-export const TASK = {
-  TYPE: 'pyside', // contributes > taskDefinitions
-  SOURCE: 'PySide'
-};
+export const TASK_TYPE = 'pyside'; // contributes > taskDefinitions
+export const TASK_SOURCE = 'PySide';
 
-export const DEBUG = {
-  TYPE: 'pyside', // contributes > debuggers
-  DELEGATE_TYPE: 'debugpy',
-  DEFAULT_ENTRY_POINT: 'main.py'
-};
+export const DEBUG_TYPE = 'pyside'; // contributes > debuggers
+export const DEBUG_DELEGATE_TYPE = 'debugpy';
+export const DEBUG_DEFAULT_ENTRY_POINT = 'main.py';
 
-export const VENV = {
-  BIN_DIR: IsWindows ? 'Scripts' : 'bin'
-};
+export const VENV_BIN_DIR = IsWindows ? 'Scripts' : 'bin';
 
-export const EXECUTABLE_EXT = IsWindows ? '.exe' : '';
-
-export const CORE_API_KEY_VENV_BIN_PATH = 'venvBinPath';
-export const CORE_API_KEY_WORKSPACE_FEATURES = 'workspaceFeatures';
+export const CORE_KEY_VENV_BIN_PATH = 'venvBinPath';
+export const CORE_KEY_WORKSPACE_FEATURES = 'workspaceFeatures';
 
 export const TOML_PROJECT_FILE_NAME = 'pyproject.toml';
 export const TOML_KEY_PROJECT_NAME = 'project.name';

--- a/qt-python/src/debug.ts
+++ b/qt-python/src/debug.ts
@@ -16,10 +16,10 @@ export class PySideDebugConfigProvider
     folder: vscode.WorkspaceFolder | undefined,
     config: vscode.DebugConfiguration
   ) {
-    config.type = consts.DEBUG.DELEGATE_TYPE;
+    config.type = consts.DEBUG_DELEGATE_TYPE;
     config.program ??= path.join(
       folder?.uri.fsPath ?? './',
-      consts.DEBUG.DEFAULT_ENTRY_POINT
+      consts.DEBUG_DEFAULT_ENTRY_POINT
     );
     config.preLaunchTask ??= findTaskFullName(TaskId.Build);
 

--- a/qt-python/src/env.ts
+++ b/qt-python/src/env.ts
@@ -17,7 +17,7 @@ export class PySideEnv {
   get venvBinPath(): string {
     const root = this._pyEnv?.executable.sysPrefix ?? '';
     return root
-      ? utils.toForwardSlash(path.join(root, consts.VENV.BIN_DIR))
+      ? utils.toForwardSlash(path.join(root, consts.VENV_BIN_DIR))
       : '';
   }
 }

--- a/qt-python/src/extension.ts
+++ b/qt-python/src/extension.ts
@@ -80,6 +80,6 @@ const onPyApiEnvChanged = async (e: PyApiEnvChanged) => {
   const folder = e.resource;
   const project = folder && projectManager.getProject(folder);
   if (project) {
-    await project.refreshEnv(pyApi);
+    await projectManager.refreshEnv(project);
   }
 };

--- a/qt-python/src/extension.ts
+++ b/qt-python/src/extension.ts
@@ -69,17 +69,15 @@ async function initPythonSupport(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     projectManager,
     pyApi.environments.onDidChangeActiveEnvironmentPath(onPyApiEnvChanged),
-    vscode.tasks.registerTaskProvider(consts.TASK.TYPE, task),
-    vscode.debug.registerDebugConfigurationProvider(consts.DEBUG.TYPE, debug)
+    vscode.tasks.registerTaskProvider(consts.TASK_TYPE, task),
+    vscode.debug.registerDebugConfigurationProvider(consts.DEBUG_TYPE, debug)
   );
 }
 
 const onPyApiEnvChanged = async (e: PyApiEnvChanged) => {
-  logger.info(`Active environment changed: ${e.resource?.uri.fsPath}`);
-
   const folder = e.resource;
-  const project = folder && projectManager.getProject(folder);
-  if (project) {
-    await projectManager.refreshEnv(project);
+  if (folder) {
+    logger.info(`Active environment changed: ${folder.uri.fsPath}`);
+    await projectManager.refreshEnv(folder);
   }
 };

--- a/qt-python/src/project-manager.ts
+++ b/qt-python/src/project-manager.ts
@@ -3,11 +3,18 @@
 
 import * as vscode from 'vscode';
 
-import { ProjectManager, createLogger, QtWorkspaceFeatures } from 'qt-lib';
+import {
+  ConfigType,
+  QtWorkspaceFeatures,
+  QtWorkspaceConfigMessage,
+  ProjectManager,
+  createLogger
+} from 'qt-lib';
 import { PySideProject } from './project';
 import { pyApi, coreApi } from './extension';
 import * as consts from '@/constants';
 
+type Folder = vscode.WorkspaceFolder;
 type Context = vscode.ExtensionContext;
 
 const logger = createLogger('project-manager');
@@ -29,15 +36,30 @@ export class PySideProjectManager extends ProjectManager<PySideProject> {
   }
 
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  public async refreshEnv(p: PySideProject) {
+    await p.refreshEnv(pyApi);
+    updateVenvBinPath(p);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   private readonly _onProjectAdded = async (p: PySideProject) => {
     await p.refreshEnv(pyApi);
     p.refreshInfo();
-    updateCoreValues(p);
+    updateVenvBinPath(p);
+    updateWorkspaceFeatures(p);
   };
 }
 
 // helpers
-function updateCoreValues(p: PySideProject) {
+function updateVenvBinPath(p: PySideProject) {
+  setCoreValueAndNotify(
+    p.folder,
+    consts.CORE_API_KEY_VENV_BIN_PATH,
+    p.env?.venvBinPath
+  );
+}
+
+function updateWorkspaceFeatures(p: PySideProject) {
   if (!coreApi) {
     logger.error('CoreAPI is not initialized');
     return;
@@ -48,8 +70,22 @@ function updateCoreValues(p: PySideProject) {
   features ??= { projectTypes: {} };
   features.projectTypes.pyside = p.isValid();
 
-  coreApi.setValue(p.folder, key, features);
+  setCoreValueAndNotify(p.folder, key, features);
+}
+
+function setCoreValueAndNotify(folder: Folder, key: string, value: ConfigType) {
+  if (!coreApi) {
+    logger.error('CoreAPI is not initialized');
+    return;
+  }
+
+  const msg = new QtWorkspaceConfigMessage(folder);
+  msg.config.add(key);
+
   logger.info(
-    `Setting core value: key = ${key}, value = ${JSON.stringify(features)}`
+    `Updating core (${folder.name}): '${key}' = ${JSON.stringify(value)}`
   );
+
+  coreApi.setValue(folder, key, value);
+  coreApi.notify(msg);
 }

--- a/qt-python/src/project-manager.ts
+++ b/qt-python/src/project-manager.ts
@@ -1,7 +1,12 @@
 // Copyright (C) 2025 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
+import _ from 'lodash';
+import * as fs from 'fs';
+import * as path from 'path';
 import * as vscode from 'vscode';
+import { parse } from 'smol-toml';
+import { PythonExtension as PyApi } from '@vscode/python-extension';
 
 import {
   ConfigType,
@@ -10,7 +15,9 @@ import {
   ProjectManager,
   createLogger
 } from 'qt-lib';
+import { PySideEnv } from './env';
 import { PySideProject } from './project';
+import { PySideProjectInfo } from './types';
 import { pyApi, coreApi } from './extension';
 import * as consts from '@/constants';
 
@@ -30,62 +37,89 @@ export class PySideProjectManager extends ProjectManager<PySideProject> {
 
     for (const folder of folders) {
       const p = await PySideProject.create(folder, this.context);
-      await this._onProjectAdded(p);
       this.addProject(p);
+      await this._onProjectAdded(p);
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  public async refreshEnv(p: PySideProject) {
-    await p.refreshEnv(pyApi);
-    updateVenvBinPath(p);
+  public async refreshEnv(folder: Folder) {
+    const project = this.getProject(folder);
+    if (!project) {
+      return;
+    }
+
+    project.env = await resolveEnv(pyApi, folder);
+    setCoreAndNotify(
+      folder,
+      consts.CORE_KEY_VENV_BIN_PATH,
+      project.env?.venvBinPath
+    );
   }
 
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private _refreshProjectInfo(folder: Folder) {
+    const project = this.getProject(folder);
+    if (!project) {
+      return;
+    }
+
+    project.info = parseToml(
+      path.join(folder.uri.fsPath, consts.TOML_PROJECT_FILE_NAME)
+    );
+
+    const key = consts.CORE_KEY_WORKSPACE_FEATURES;
+    let value = coreApi?.getValue<QtWorkspaceFeatures>(folder, key);
+    value ??= { projectTypes: {} };
+    value.projectTypes.pyside = project.isValid();
+
+    setCoreAndNotify(folder, key, value);
+  }
+
   private readonly _onProjectAdded = async (p: PySideProject) => {
-    await p.refreshEnv(pyApi);
-    p.refreshInfo();
-    updateVenvBinPath(p);
-    updateWorkspaceFeatures(p);
+    await this.refreshEnv(p.folder);
+    this._refreshProjectInfo(p.folder);
   };
 }
 
 // helpers
-function updateVenvBinPath(p: PySideProject) {
-  setCoreValueAndNotify(
-    p.folder,
-    consts.CORE_API_KEY_VENV_BIN_PATH,
-    p.env?.venvBinPath
-  );
-}
-
-function updateWorkspaceFeatures(p: PySideProject) {
+function setCoreAndNotify(folder: Folder, key: string, value: ConfigType) {
   if (!coreApi) {
     logger.error('CoreAPI is not initialized');
     return;
   }
-
-  const key = consts.CORE_API_KEY_WORKSPACE_FEATURES;
-  let features = coreApi.getValue<QtWorkspaceFeatures>(p.folder, key);
-  features ??= { projectTypes: {} };
-  features.projectTypes.pyside = p.isValid();
-
-  setCoreValueAndNotify(p.folder, key, features);
-}
-
-function setCoreValueAndNotify(folder: Folder, key: string, value: ConfigType) {
-  if (!coreApi) {
-    logger.error('CoreAPI is not initialized');
-    return;
-  }
-
-  const msg = new QtWorkspaceConfigMessage(folder);
-  msg.config.add(key);
 
   logger.info(
     `Updating core (${folder.name}): '${key}' = ${JSON.stringify(value)}`
   );
 
+  const msg = new QtWorkspaceConfigMessage(folder);
+  msg.config.add(key);
+
   coreApi.setValue(folder, key, value);
   coreApi.notify(msg);
+}
+
+async function resolveEnv(pyapi: PyApi | undefined, folder: Folder) {
+  if (!pyapi) {
+    logger.error('Python API is invalid');
+    return undefined;
+  }
+
+  const envs = pyapi.environments;
+  const envPath = envs.getActiveEnvironmentPath(folder);
+  const resolved = await envs.resolveEnvironment(envPath);
+  return resolved ? new PySideEnv(resolved) : undefined;
+}
+
+function parseToml(absPath: string): PySideProjectInfo | undefined {
+  try {
+    const data = fs.readFileSync(absPath, 'utf-8');
+    const dataJson = parse(data);
+
+    return {
+      name: _.get(dataJson, consts.TOML_KEY_PROJECT_NAME, '') as string,
+      files: _.get(dataJson, consts.TOML_KEY_PROJECT_FILES, []) as string[]
+    };
+  } catch (e) {
+    return undefined;
+  }
 }

--- a/qt-python/src/project.ts
+++ b/qt-python/src/project.ts
@@ -1,18 +1,11 @@
 // Copyright (C) 2025 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
-import _ from 'lodash';
-import * as fs from 'fs';
-import * as path from 'path';
 import * as vscode from 'vscode';
-import { parse } from 'smol-toml';
-import { PythonExtension as PyApi } from '@vscode/python-extension';
 
 import { Project, createLogger } from 'qt-lib';
 import { PySideEnv } from './env';
 import { PySideProjectInfo } from './types';
-
-import * as consts from './constants';
 
 type Folder = vscode.WorkspaceFolder;
 type Context = vscode.ExtensionContext;
@@ -26,7 +19,6 @@ export class PySideProject implements Project {
     logger.info(`Create: "${_folder.uri.fsPath}"`);
   }
 
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   dispose() {
     logger.info(`Dispose: "${this._folder.uri.fsPath}"`);
   }
@@ -39,6 +31,10 @@ export class PySideProject implements Project {
     this._env = env;
   }
 
+  set info(info: PySideProjectInfo | undefined) {
+    this._info = info;
+  }
+
   get folder() {
     return this._folder;
   }
@@ -47,48 +43,8 @@ export class PySideProject implements Project {
     return this._info !== undefined;
   }
 
-  public async refreshEnv(pyapi: PyApi | undefined) {
-    this._env = await resolveEnv(pyapi, this._folder);
-  }
-
-  public refreshInfo() {
-    const toml = path.join(
-      this._folder.uri.fsPath,
-      consts.TOML_PROJECT_FILE_NAME
-    );
-
-    this._info = parseToml(toml);
-  }
-
   public static create = async (folder: Folder, context: Context) => {
     void context;
     return Promise.resolve(new PySideProject(folder));
   };
-}
-
-// helpers
-async function resolveEnv(pyapi: PyApi | undefined, folder: Folder) {
-  if (!pyapi) {
-    logger.error('Python API is invalid');
-    return undefined;
-  }
-
-  const envs = pyapi.environments;
-  const envPath = envs.getActiveEnvironmentPath(folder);
-  const resolved = await envs.resolveEnvironment(envPath);
-  return resolved ? new PySideEnv(resolved) : undefined;
-}
-
-function parseToml(absPath: string): PySideProjectInfo | undefined {
-  try {
-    const data = fs.readFileSync(absPath, 'utf-8');
-    const dataJson = parse(data);
-
-    return {
-      name: _.get(dataJson, consts.TOML_KEY_PROJECT_NAME, '') as string,
-      files: _.get(dataJson, consts.TOML_KEY_PROJECT_FILES, []) as string[]
-    };
-  } catch (e) {
-    return undefined;
-  }
 }

--- a/qt-python/src/project.ts
+++ b/qt-python/src/project.ts
@@ -11,7 +11,6 @@ import { PythonExtension as PyApi } from '@vscode/python-extension';
 import { Project, createLogger } from 'qt-lib';
 import { PySideEnv } from './env';
 import { PySideProjectInfo } from './types';
-import { coreApi } from './extension';
 
 import * as consts from './constants';
 
@@ -36,6 +35,10 @@ export class PySideProject implements Project {
     return this._env;
   }
 
+  set env(env: PySideEnv | undefined) {
+    this._env = env;
+  }
+
   get folder() {
     return this._folder;
   }
@@ -46,11 +49,6 @@ export class PySideProject implements Project {
 
   public async refreshEnv(pyapi: PyApi | undefined) {
     this._env = await resolveEnv(pyapi, this._folder);
-    const venvBinPath = this._env?.venvBinPath;
-
-    if (venvBinPath) {
-      coreApi?.setValue(this._folder, 'pythonVenvBinPath', venvBinPath);
-    }
   }
 
   public refreshInfo() {

--- a/qt-python/src/task.ts
+++ b/qt-python/src/task.ts
@@ -60,7 +60,7 @@ export class PySideTaskProvider implements vscode.TaskProvider {
 }
 
 export function findTaskFullName(id: TaskId): string {
-  return `${consts.TASK.SOURCE}: ${findTaskName(id)}`;
+  return `${consts.TASK_SOURCE}: ${findTaskName(id)}`;
 }
 
 // helpers
@@ -77,11 +77,11 @@ function createTask(project: PySideProject, taskId: TaskId) {
   const cwd = folder.uri.fsPath;
   const cmd = createCmdline(taskId, env);
   const def = {
-    type: consts.TASK.TYPE,
+    type: consts.TASK_TYPE,
     action // contributes > taskDefinitions
   };
 
-  const task = new vscode.Task(def, folder, taskName, consts.TASK.SOURCE);
+  const task = new vscode.Task(def, folder, taskName, consts.TASK_SOURCE);
   task.detail = `${consts.PYSIDE_PROJECT_TOOL} ${action}`;
   task.execution = new vscode.ShellExecution(cmd, { cwd });
   task.presentationOptions = { clear: true };

--- a/qt-python/src/texts.ts
+++ b/qt-python/src/texts.ts
@@ -1,7 +1,0 @@
-// Copyright (C) 2025 The Qt Company Ltd.
-// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
-
-export const task = {
-  execDone: (name: string) => `Task done: ${name}`,
-  execDoneWithCode: (code: string) => `Task ended with exit code: ${code}`
-};

--- a/qt-ui/src/project-manager.ts
+++ b/qt-ui/src/project-manager.ts
@@ -74,6 +74,12 @@ export class UIProjectManager extends ProjectManager<UIProject> {
         await project.setWorkspaceFeatures(
           coreAPI?.getValue<QtWorkspaceFeatures>(folder, key)
         );
+        continue;
+      }
+
+      if (key === 'venvBinPath') {
+        const value = coreAPI?.getValue<string>(folder, key);
+        await project.setVenvBinPath(value);
       }
     }
   };

--- a/qt-ui/src/project.ts
+++ b/qt-ui/src/project.ts
@@ -14,14 +14,19 @@ import * as consts from '@/constants';
 import { coreAPI } from '@/extension';
 import { DesignerClient } from '@/designer-client';
 import { DesignerServer } from '@/designer-server';
-import { locateDesignerFromKit, locateDesignerFromQtPaths } from '@/util';
+import {
+  locateDesignerFromKit,
+  locateDesignerFromQtPaths,
+  locateDesignerFromVenvBinPaths
+} from '@/util';
 
 type UpdateReason =
   | 'init'
   | 'customExeChanged'
   | 'workspaceFeatureChanged'
   | 'selectedKitPathChanged'
-  | 'selectedQtPathsChanged';
+  | 'selectedQtPathsChanged'
+  | 'venvBinPathChanged';
 
 const logger = createLogger('project');
 
@@ -39,6 +44,7 @@ export class UIProject implements Project {
   private _workspaceFeatures: QtWorkspaceFeatures | undefined;
   private _selectedKitPath: string | undefined;
   private _selectedQtPaths: string | undefined;
+  private _venvBinPath: string | undefined;
 
   private _designerClient: DesignerClient | undefined;
   private readonly _designerServer: DesignerServer;
@@ -84,6 +90,7 @@ export class UIProject implements Project {
     );
     this._selectedKitPath = read<string>(this._folder, 'selectedKitPath');
     this._selectedQtPaths = read<string>(this._folder, 'selectedQtPaths');
+    this._venvBinPath = read<string>(this._folder, 'venvBinPath');
 
     await this._updateClient('init');
   }
@@ -115,6 +122,13 @@ export class UIProject implements Project {
     if (this._selectedQtPaths !== exePath) {
       this._selectedQtPaths = exePath;
       await this._updateClient('selectedQtPathsChanged');
+    }
+  }
+
+  public async setVenvBinPath(venvBinPath: string | undefined) {
+    if (this._venvBinPath !== venvBinPath) {
+      this._venvBinPath = venvBinPath;
+      await this._updateClient('venvBinPathChanged');
     }
   }
 
@@ -162,6 +176,12 @@ export class UIProject implements Project {
 
       logger.error(msg);
       void vscode.window.showWarningMessage(msg);
+    }
+
+    if (this._workspaceFeatures?.projectTypes.pyside) {
+      if (this._venvBinPath) {
+        return locateDesignerFromVenvBinPaths(this._venvBinPath);
+      }
     }
 
     if (this._workspaceFeatures?.projectTypes.cmake) {

--- a/qt-ui/src/util.ts
+++ b/qt-ui/src/util.ts
@@ -54,6 +54,11 @@ export async function locateDesignerFromQtPaths(qtPaths: string) {
   return searchForExeInQtInfo(info, getDesignerExePathFromBin);
 }
 
+export async function locateDesignerFromVenvBinPaths(venvBinPath: string) {
+  const candidate = path.join(venvBinPath, 'pyside6-designer' + OSExeSuffix);
+  return (await exists(candidate)) ? candidate : undefined;
+}
+
 function getDesignerExePathFromBin(selectedQtBinPath: string) {
   return path.join(
     selectedQtBinPath,


### PR DESCRIPTION
This enables qt-ui to locate and launch the Qt Widgets Designer
executable provided within a PySide6 installation.

A new core API key `venvBinPath` is introduced to store the path to
the `bin` (or `Scripts` on Windows) directory of the active virtual
environment, and its value will be updated by `qt-python` whenever
the virtual environment changes.

Refactor qt-python refining responsiblities 
between PySideProject and PySideProjecManager.
Remove unused constants, varaibles and redundant lint directives.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
