### PR TITLE
qt-qml: Reset docsPath to undefined before setting it again in `updateQmllsParams()`

### DIFF
--- a/qt-qml/src/project.ts
+++ b/qt-qml/src/project.ts
@@ -123,6 +123,7 @@ export class QMLProject implements Project {
 
   updateQmllsParams() {
     this.qmlls.clearImportPaths();
+    this.qmlls.docsPath = undefined;
     if (this.kitPath) {
       this.qmlls.addImportPath(path.join(this.kitPath, 'qml'));
       const docsPath = this.getDocsPathFromKitDir(this.kitPath);


### PR DESCRIPTION
Fixes: [VSCODEEXT-257](https://bugreports.qt.io/browse/VSCODEEXT-257)
