### PR TITLE
qt-core: Change spawn() option when opening Qt Linguist

### DIFF
--- a/qt-core/src/translation.ts
+++ b/qt-core/src/translation.ts
@@ -156,7 +156,6 @@ async function locateLinguistFromVenvBinPaths(venvBinPath: string) {
 
 function openInLinguist(linguistPath: string, file: string) {
   const child = child_process.spawn(linguistPath, [file], {
-    stdio: 'inherit',
     shell: true
   });
 


### PR DESCRIPTION
Leave stdio at the default value to prevent an unintended terminal from opening on Windows. 
The previously used 'inherit' option would open a new terminal if there was no parent stdio to inherit from.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
