### PR TITLE
qt-python, qt-lib: Add link in PySide6 install message to open logs

### DIFF
--- a/qt-lib/src/logger.ts
+++ b/qt-lib/src/logger.ts
@@ -6,6 +6,7 @@ import * as winston from 'winston';
 import { LogOutputChannelTransport } from 'winston-transport-vscode';
 
 let logger: winston.Logger | undefined = undefined;
+let outputChannel: vscode.LogOutputChannel | undefined;
 
 export class Logger {
   constructor(private readonly tag: string) {
@@ -44,7 +45,7 @@ export class Logger {
 }
 
 export function initLogger(extensionName: string) {
-  const outputChannel = vscode.window.createOutputChannel(extensionName, {
+  outputChannel = vscode.window.createOutputChannel(extensionName, {
     log: true
   });
   logger = winston.createLogger({
@@ -56,4 +57,8 @@ export function initLogger(extensionName: string) {
 
 export function createLogger(tag: string) {
   return new Logger(tag);
+}
+
+export function getLogOutputChannel(): vscode.LogOutputChannel | undefined {
+  return outputChannel;
 }

--- a/qt-python/src/constants.ts
+++ b/qt-python/src/constants.ts
@@ -8,6 +8,7 @@ export const MS_PYTHON_ID = 'ms-python.python';
 export const LOG_NAME = 'qt-python';
 
 export const COMMAND_PREFIX = 'qt-python';
+export const COMMAND_SHOW_LOG = 'showLogOutputChannel';
 export const COMMAND_INSTALL_PYSIDE = 'installPySide6'; // contributes > commands
 export const COMMAND_PYTHON_CREATE_ENV = 'python.createEnvironment';
 export const COMMAND_PYTHON_SELECT_PYTHON = 'python.setInterpreter';

--- a/qt-python/src/extension.ts
+++ b/qt-python/src/extension.ts
@@ -12,6 +12,7 @@ import {
   getCoreApi,
   createLogger,
   initLogger,
+  getLogOutputChannel,
   telemetry
 } from 'qt-lib';
 import { PySideTaskProvider } from './task';
@@ -78,17 +79,23 @@ async function initPythonSupport(context: vscode.ExtensionContext) {
 }
 
 function initCommands(context: vscode.ExtensionContext) {
-  function register(c: string, callback: (...args: unknown[]) => unknown) {
+  type Callback = (...args: unknown[]) => unknown;
+
+  function register(c: string, callback: Callback, useTelemetry = true) {
     return vscode.commands.registerCommand(
       `${consts.COMMAND_PREFIX}.${c}`,
       async () => {
-        telemetry.sendAction(c);
+        if (useTelemetry) {
+          telemetry.sendAction(c);
+        }
+
         await callback();
       }
     );
   }
 
   context.subscriptions.push(
+    register(consts.COMMAND_SHOW_LOG, onShowLog, false),
     register(consts.COMMAND_INSTALL_PYSIDE, onInstallPySide6Command)
   );
 }
@@ -100,3 +107,7 @@ const onPyApiEnvChanged = async (e: PyApiEnvChanged) => {
     await projectManager.refreshEnv(folder);
   }
 };
+
+function onShowLog() {
+  getLogOutputChannel()?.show();
+}

--- a/qt-python/src/installer.ts
+++ b/qt-python/src/installer.ts
@@ -157,8 +157,12 @@ async function tryInstallPySide(
     info(folder, ' ', line);
   };
 
+  const linkText = texts.install.popup.linkShowLog;
+  const linkCommand = `${consts.COMMAND_PREFIX}.${consts.COMMAND_SHOW_LOG}`;
+  const linkShowLogs = `[${linkText}](command:${linkCommand})`;
+
   const options = {
-    title: texts.install.popup.installing,
+    title: texts.install.popup.installing + ` (${linkShowLogs})`,
     location: vscode.ProgressLocation.Notification,
     cancellable: false
   };
@@ -187,6 +191,10 @@ async function tryInstallPySide(
           pyside6Version,
           env.venvName ?? ''
         )
+      );
+    } else {
+      void vscode.window.showWarningMessage(
+        texts.install.popup.installFailed(folder.name) + ` (${linkShowLogs})`
       );
     }
   });

--- a/qt-python/src/texts.ts
+++ b/qt-python/src/texts.ts
@@ -10,11 +10,14 @@ export const install = {
     alreadyInstalled: (folder: string, pysideVersion: string, venv: string) =>
       `PySide ${pysideVersion} is already installed for '${folder}'. ` +
       `(venv: ${venv})`,
+    installFailed: (folder: string) =>
+      `Failed to install PySide for '${folder}'`,
     noVenv: (folder: string) =>
       `No virtual environment found for '${folder}'. ` +
       'Please create or select a virtual environment first.',
     buttonCreateEnv: 'Create Environment',
-    buttonSelectEnv: 'Select Interpreter'
+    buttonSelectEnv: 'Select Interpreter',
+    linkShowLog: 'Show logs'
   },
   placeHolder: {
     selectFolder: 'Select a Folder',


### PR DESCRIPTION
Since the stdout of `pip install <args>` is redirected to the log output channel, adding a link to open the output channel directly from the installation mesage improves usability.

The following changes are introduced:
- A getter for the log output channel in the logger facility
- An internal command `showLogOutputChannel`, triggered when the link is clicked.
- Show a warning message with a link to the log output channel when installation fails.
<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
