### PR TITLE
Doc: Fix product names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Qt Extensions for Visual Studio Code
+# Qt Extension for VS Code
 
 ## Overview
 
-This repository contains the source code for the Qt extensions for Visual Studio
+This repository contains the source code for the Qt Extension for Visual Studio
 Code.
 
 ## Development
@@ -12,10 +12,10 @@ For more information about developing Qt extensions, see [Development.md](Develo
 ## Documentation
 
 For more information about using Qt extensions, go to
-[Qt Extensions for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
+[Qt Extension for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
 
 For pre-release versions, go to
-[Qt Extensions for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
+[Qt Extension for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
 
 ## Issues
 

--- a/extension_packs/cpp/README.md
+++ b/extension_packs/cpp/README.md
@@ -30,10 +30,10 @@ extensions are installed automatically.
 ## Documentation
 
 For more information about using Qt extensions, go to
-[Qt Extensions for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
+[Qt Extension for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
 
 For pre-release versions, go to
-[Qt Extensions for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
+[Qt Extension for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
 
 ## Issues
 

--- a/extension_packs/qt/README.md
+++ b/extension_packs/qt/README.md
@@ -20,10 +20,10 @@ extensions are installed automatically.
 ## Documentation
 
 For more information about using Qt extensions, go to
-[Qt Extensions for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
+[Qt Extension for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
 
 For pre-release versions, go to
-[Qt Extensions for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
+[Qt Extension for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
 
 ## Issues
 

--- a/extension_packs/wasm/README.md
+++ b/extension_packs/wasm/README.md
@@ -30,10 +30,10 @@ extensions are installed automatically.
 ## Documentation
 
 For more information about using Qt extensions, go to
-[Qt Extensions for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
+[Qt Extension for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
 
 For pre-release versions, go to
-[Qt Extensions for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
+[Qt Extension for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
 
 ## Issues
 

--- a/qt-core/.reuse/dep5
+++ b/qt-core/.reuse/dep5
@@ -1,5 +1,5 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: Qt Extension for Visual Studio Code
+Upstream-Name: Qt Extension for VS Code
 Upstream-Contact: The Qt Company Ltd <https://www.qt.io/>
 Source: https://github.com/qt-labs/vscodeext
 

--- a/qt-core/README.md
+++ b/qt-core/README.md
@@ -1,4 +1,4 @@
-# Qt Core Extension for Visual Studio Code
+# Qt Core Extension for VS Code
 
 This extension provides basic functionality for other Qt extensions.
 
@@ -17,10 +17,10 @@ or one of its dependencies.
 ## Documentation
 
 For more information about using Qt extensions, go to
-[Qt Extensions for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
+[Qt Extension for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
 
 For pre-release versions, go to
-[Qt Extensions for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
+[Qt Extension for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
 
 ## Issues
 

--- a/qt-cpp/README.md
+++ b/qt-cpp/README.md
@@ -1,4 +1,4 @@
-# Qt C++ Extension for Visual Studio Code
+# Qt C++ Extension for VS Code
 
 This extension helps you develop Qt C++ projects with Visual Studio
 Code and CMake.
@@ -25,10 +25,10 @@ required. They will be installed automatically.
 ## Documentation
 
 For more information about using Qt extensions, go to
-[Qt Extensions for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
+[Qt Extension for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
 
 For pre-release versions, go to
-[Qt Extensions for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
+[Qt Extension for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
 
 ## Issues
 

--- a/qt-python/README.md
+++ b/qt-python/README.md
@@ -1,4 +1,4 @@
-# Qt Python Extension for Visual Studio Code
+# Qt Python Extension for VS Code
 
 This extension helps you develop Qt for Python projects with Visual Studio
 Code and Python
@@ -12,10 +12,10 @@ Code and Python
 ## Documentation
 
 For more information about using Qt extensions, go to
-[Qt Extensions for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
+[Qt Extension for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
 
 For pre-release versions, go to
-[Qt Extensions for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
+[Qt Extension for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
 
 ## Issues
 

--- a/qt-qml/.reuse/dep5
+++ b/qt-qml/.reuse/dep5
@@ -1,5 +1,5 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: Qt Extension for Visual Studio Code
+Upstream-Name: Qt Extension for VS Code
 Upstream-Contact: The Qt Company Ltd <https://www.qt.io/>
 Source: https://github.com/qt-labs/vscodeext
 

--- a/qt-qml/README.md
+++ b/qt-qml/README.md
@@ -1,4 +1,4 @@
-# Qt Qml Extension for Visual Studio Code
+# Qt Qml Extension for VS Code
 
 This extension provides you with QML syntax highlighting and code completion when
 you develop Qt Quick applications with Visual Studio Code.
@@ -19,10 +19,10 @@ you develop Qt Quick applications with Visual Studio Code.
 ## Documentation
 
 For more information about using Qt extensions, go to
-[Qt Extensions for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
+[Qt Extension for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
 
 For pre-release versions, go to
-[Qt Extensions for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
+[Qt Extension for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
 
 ## Issues
 

--- a/qt-ui/README.md
+++ b/qt-ui/README.md
@@ -1,4 +1,4 @@
-# Qt UI Extension for Visual Studio Code
+# Qt UI Extension for VS Code
 
 This extension provides support for designing widget-based UIs with
 [Qt Widgets Designer](https://doc.qt.io/qt-6/qtdesigner-manual.html)
@@ -12,10 +12,10 @@ using `.ui` files.
 ## Documentation
 
 For more information about using Qt extensions, go to
-[Qt Extensions for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
+[Qt Extension for VS Code Documentation](https://doc.qt.io/vscodeext/index.html).
 
 For pre-release versions, go to
-[Qt Extensions for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
+[Qt Extension for VS Code Pre-release Documentation](https://doc-snapshots.qt.io/vscodeext-dev/).
 
 ## Issues
 


### PR DESCRIPTION
- Change plural 'Extensions' to singluar 'Extension'.
- Replace 'Visual Studio Code' with 'VS Code' when it's part of our product name.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
