### PR TITLE
qt-qml, qt-python: Update debug configuration for python

### DIFF
--- a/qt-python/package.json
+++ b/qt-python/package.json
@@ -99,10 +99,10 @@
         ],
         "configurationSnippets": [
           {
-            "label": "Qt: PySide: Launch",
-            "description": "Launch and debug a PySide application",
+            "label": "%qt-python.debug.launch.label%",
+            "description": "%qt-python.debug.lunch.description%",
             "body": {
-              "name": "PySide: Launch",
+              "name": "%qt-python.debug.launch.label%",
               "type": "debugpy",
               "request": "launch",
               "program": "^\"\\${workspaceFolder}/main.py\"",

--- a/qt-python/package.nls.json
+++ b/qt-python/package.nls.json
@@ -1,3 +1,5 @@
 {
-  "qt-python.command.installPySide6.title": "Install PySide6"
+  "qt-python.command.installPySide6.title": "Install PySide6",
+  "qt-python.debug.launch.label": "Qt: PySide: Launch",
+  "qt-python.debug.launch.description": "Launch a PySide application"
 }

--- a/qt-qml/package.json
+++ b/qt-qml/package.json
@@ -370,6 +370,20 @@
                 ]
               }
             }
+          },
+          {
+            "label": "%qt-qml.debug.pyside.label%",
+            "description": "%qt-qml.debug.pyside.description%",
+            "body": {
+              "name": "%qt-qml.debug.pyside.label%",
+              "type": "debugpy",
+              "request": "launch",
+              "program": "^\"\\${workspaceFolder}/main.py\"",
+              "preLaunchTask": "PySide: build",
+              "args": [
+                "^\"-qmljsdebugger=port:\\${command:qt-qml.debugPort},block,services:DebugMessages,QmlDebugger,V8Debugger\""
+              ]
+            }
           }
         ]
       }

--- a/qt-qml/package.nls.json
+++ b/qt-qml/package.nls.json
@@ -9,5 +9,7 @@
   "qt-qml.debug.cppdbg.label": "Qt: Debug with cppdbg and QML debugger",
   "qt-qml.debug.cppdbg.description": "Launch a QML application with C++ debugger and attach with QML debugger",
   "qt-qml.debug.cppvsdbg.label": "Qt: Debug with cppdbg and QML debugger (Windows)",
-  "qt-qml.debug.cppvsdbg.description": "Launch a QML application with Visual Studio Debugger and attach with QML debugger"
+  "qt-qml.debug.cppvsdbg.description": "Launch a QML application with Visual Studio Debugger and attach with QML debugger",
+  "qt-qml.debug.pyside.label": "Qt: PySide: Launch with QML debugger",
+  "qt-qml.debug.pyside.description": "Launch a PySide QML application and attach with QML debugger"
 }


### PR DESCRIPTION
- qt-qml: Add a debug configuration snippet for PySide applications
   that provides QML debugger arguments to support integrated debugging.

- qt-python: Some texts from `package.json` are moved into `package.nls.json`
   to align with the conventions used by other extensions.

Task-number: [VSCODEEXT-241](https://bugreports.qt.io/browse/VSCODEEXT-241)