### PR TITLE
qt-cpp: qt-qml: qt-ui: Introduce CMakePresets support

### DIFF
--- a/qt-core/src/translation.ts
+++ b/qt-core/src/translation.ts
@@ -9,7 +9,7 @@ import {
   CoreKey,
   createLogger,
   exists,
-  findQtPathsInKitDir,
+  findQtPathsInInstallationPath,
   IsMacOS,
   IsWindows,
   OSExeSuffix,
@@ -51,7 +51,7 @@ export async function openInLinguistCommand() {
   );
   const selectedKitPath = coreAPI?.getValue<string>(
     project.folder,
-    CoreKey.SELECTED_KIT_PATH
+    CoreKey.INSTALLATION_PATH
   );
   const selectedQtPaths = coreAPI?.getValue<string>(
     project.folder,
@@ -131,7 +131,7 @@ async function locateLinguist(selectedKitPath: string) {
   if (await exists(linguistExePath)) {
     return linguistExePath;
   }
-  const qtPaths = findQtPathsInKitDir(selectedKitPath);
+  const qtPaths = findQtPathsInInstallationPath(selectedKitPath);
   if (qtPaths) {
     const linguistPath = await locateLinguistFromQtPaths(qtPaths);
     if (linguistPath) {

--- a/qt-core/src/util.ts
+++ b/qt-core/src/util.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 import * as vscode from 'vscode';
-import { spawnSync } from 'child_process';
 
 import { QtAdditionalPath, inVCPKGRoot, resolveConfiguration } from 'qt-lib';
 import { EXTENSION_ID } from '@/constants';
@@ -26,15 +25,4 @@ export function convertAdditionalQtPaths(
     ret.path = resolveConfiguration(ret.path);
     return ret;
   });
-}
-
-export function getQueryOutput(exePath: string) {
-  const ret = spawnSync(exePath, ['-query'], {
-    encoding: 'utf8',
-    timeout: 1000
-  });
-  if (ret.error ?? ret.status !== 0) {
-    return undefined;
-  }
-  return ret;
 }

--- a/qt-core/src/vcpkg.ts
+++ b/qt-core/src/vcpkg.ts
@@ -1,23 +1,16 @@
 // Copyright (C) 2024 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
-import * as path from 'path';
 import * as vscode from 'vscode';
 import * as commandExists from 'command-exists';
 
 import {
   createLogger,
-  IsLinux,
-  IsMacOS,
-  IsWindows,
-  OSExeSuffix,
   QtAdditionalPath,
   getVCPKGRoot,
-  IsArm64,
-  Isx64,
+  searchForQtPathsInVCPKG,
   telemetry
 } from 'qt-lib';
-import { getQueryOutput } from '@/util';
 import { getCurrentGlobalAdditionalQtPaths } from '@/installation-root';
 import { EXTENSION_ID } from '@/constants';
 import { addQtPathToSettings } from '@/qtpaths';
@@ -93,48 +86,4 @@ async function setDoNotAskForVCPKG(value: boolean) {
   await vscode.workspace
     .getConfiguration(EXTENSION_ID)
     .update('doNotAskForVCPKG', value, vscode.ConfigurationTarget.Global);
-}
-
-function searchForQtPathsInVCPKG(root: string): string | undefined {
-  if (!root) {
-    return;
-  }
-  const exeNames = [`qtpaths${OSExeSuffix}`, `qmake${OSExeSuffix}`];
-  if (IsWindows) {
-    exeNames.push('qmake.bat');
-  }
-
-  const osPath = () => {
-    const arch = Isx64 ? 'x64' : 'x86';
-    if (IsLinux) {
-      return `${arch}-linux`;
-    } else if (IsMacOS) {
-      if (IsArm64) {
-        return 'arm64-osx';
-      } else {
-        return `x64-osx`;
-      }
-    } else if (IsWindows) {
-      return `${arch}-windows`;
-    } else {
-      throw new Error('Not supported');
-    }
-  };
-  for (const exeName of exeNames) {
-    const exePath = path.join(
-      root,
-      'installed',
-      osPath(),
-      'tools',
-      'Qt6',
-      'bin',
-      exeName
-    );
-    const ret = getQueryOutput(exePath);
-    if (ret) {
-      logger.info(`Found Qt paths in vcpkg: ${exePath}`);
-      return exePath;
-    }
-  }
-  return undefined;
 }

--- a/qt-cpp/ThirdPartyNotices.txt
+++ b/qt-cpp/ThirdPartyNotices.txt
@@ -2743,7 +2743,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------------------------
 
-vscode-cmake-tools 1.2.0 - MIT
+vscode-cmake-tools 1.5.0 - MIT
 https://github.com/microsoft/vscode-cmake-tools-api#readme
 
 vscode-cmake-tools-api

--- a/qt-cpp/package-lock.json
+++ b/qt-cpp/package-lock.json
@@ -16,7 +16,7 @@
         "qt-lib": "file:../qt-lib",
         "sinon": "^20.0.0",
         "typescript": "^5.6.3",
-        "vscode-cmake-tools": "^1.2.0"
+        "vscode-cmake-tools": "^1.5.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.0",
@@ -8378,7 +8378,9 @@
       }
     },
     "node_modules/vscode-cmake-tools": {
-      "version": "1.2.0",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vscode-cmake-tools/-/vscode-cmake-tools-1.5.0.tgz",
+      "integrity": "sha512-74reQEhe/Gpf7dYPE8tQTtmbCahBKR7B8gfbBQDF02la91DtbdyCf7Zcx18FUzpOz3CTGZo6ILk21kEX+te2MQ==",
       "license": "MIT",
       "engines": {
         "vscode": "^1.63.0"

--- a/qt-cpp/package.json
+++ b/qt-cpp/package.json
@@ -78,11 +78,6 @@
           "type": "boolean",
           "default": false,
           "description": "Do not show a warning when the source directory cannot be determined from the selected kit."
-        },
-        "qt-cpp.doNotShowCMakePresetWarning": {
-          "type": "boolean",
-          "default": false,
-          "description": "Do not show a warning when CMake presets are found in the workspace."
         }
       }
     },
@@ -328,6 +323,6 @@
     "qt-lib": "file:../qt-lib",
     "sinon": "^20.0.0",
     "typescript": "^5.6.3",
-    "vscode-cmake-tools": "^1.2.0"
+    "vscode-cmake-tools": "^1.5.0"
   }
 }

--- a/qt-cpp/src/commands/launch-variables.ts
+++ b/qt-cpp/src/commands/launch-variables.ts
@@ -4,11 +4,18 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 
-import { inVCPKGRoot, createLogger, telemetry } from 'qt-lib';
+import {
+  inVCPKGRoot,
+  createLogger,
+  telemetry,
+  findQtPathsInInstallationPath
+} from 'qt-lib';
 import { getFilenameWithoutExtension } from '@util/util';
 import { EXTENSION_ID } from '@/constants';
 import { getQtInsRoot, getSelectedKit } from '@cmd/register-qt-path';
 import { coreAPI } from '@/extension';
+import { Kit } from '@/kit-manager';
+import { CppProjectType, getActiveProject } from '@/project';
 
 const logger = createLogger('launch-variables');
 
@@ -44,61 +51,110 @@ export function registerbuildDirectoryName() {
     }
   );
 }
-
-export function qtDirCommand() {
-  return vscode.commands.registerCommand(`${EXTENSION_ID}.qtDir`, async () => {
-    telemetry.sendAction('qtDir');
-    const kit = await getSelectedKit();
-    if (!kit) {
-      return undefined;
+function getQtPathsFromKit(kit: Kit) {
+  let pathsExe = kit.environmentVariables?.VSCODE_QT_QTPATHS_EXE;
+  // Fallback to findQtPathsInInstallationPath if VSCODE_QT_QTPATHS_EXE is not set
+  if (pathsExe) {
+    return pathsExe;
+  }
+  const insRoot = getQtInsRoot(kit);
+  if (!insRoot) {
+    logger.warn(
+      'Cannot find VSCODE_QT_INSTALLATION or VSCODE_QT_QTPATHS_EXE in the kit'
+    );
+    return undefined;
+  }
+  pathsExe = findQtPathsInInstallationPath(insRoot);
+  if (pathsExe) {
+    return pathsExe;
+  }
+  logger.warn('Cannot find Qt Paths executable in the kit');
+  return undefined;
+}
+function getQtDirFromQtPaths(pathsExe: string, toolchainFile?: string) {
+  const isValidKey = (key: string) => {
+    const keysShouldStartWith = ['QT_INSTALL', 'QT_HOST'];
+    for (const k of keysShouldStartWith) {
+      if (key.startsWith(k)) {
+        return true;
+      }
     }
-    const insRoot = getQtInsRoot(kit);
-    if (insRoot) {
-      return path.join(insRoot, 'bin');
-    }
-    const pathsExe = kit.environmentVariables?.VSCODE_QT_QTPATHS_EXE;
-    if (pathsExe) {
-      const isValidKey = (key: string) => {
-        const keysShouldStartWith = ['QT_INSTALL', 'QT_HOST'];
-        for (const k of keysShouldStartWith) {
-          if (key.startsWith(k)) {
-            return true;
-          }
-        }
-        return false;
-      };
-      const info = coreAPI?.getQtInfoFromPath(pathsExe);
-      const paths: string[] = [];
-      if (info) {
-        const keys = info.data;
-        const isInVCPKG = kit.toolchainFile && inVCPKGRoot(kit.toolchainFile);
-        for (const [key, value] of keys) {
-          if (!isValidKey(key)) {
-            continue;
-          }
-          if (value) {
-            paths.push(value);
-            // vcpkg spacial case
-            if (isInVCPKG) {
-              if (value.endsWith('bin')) {
-                const installPrefix = info.get('QT_INSTALL_PREFIX');
-                if (installPrefix) {
-                  const installPrefixDebug = path.join(installPrefix, 'debug');
-                  const newValue = value.replace(
-                    installPrefix,
-                    installPrefixDebug
-                  );
-                  paths.push(newValue);
-                }
-              }
+    return false;
+  };
+  const info = coreAPI?.getQtInfoFromPath(pathsExe);
+  const paths: string[] = [];
+  if (info) {
+    const keys = info.data;
+    const isInVCPKG = toolchainFile && toolchainFile.endsWith('vcpkg.cmake');
+    for (const [key, value] of keys) {
+      if (!isValidKey(key)) {
+        continue;
+      }
+      if (value) {
+        paths.push(value);
+        // vcpkg spacial case
+        if (isInVCPKG) {
+          if (value.endsWith('bin')) {
+            const installPrefix = info.get('QT_INSTALL_PREFIX');
+            if (installPrefix) {
+              const installPrefixDebug = path.join(installPrefix, 'debug');
+              const newValue = value.replace(installPrefix, installPrefixDebug);
+              paths.push(newValue);
             }
           }
         }
       }
-      const ret = paths.join(path.delimiter);
-      return ret;
     }
-    logger.error('Cannot find the selected Qt installation path');
+  }
+  const ret = paths.join(path.delimiter);
+  return ret;
+}
+export function qtDirCommand() {
+  return vscode.commands.registerCommand(`${EXTENSION_ID}.qtDir`, async () => {
+    telemetry.sendAction('qtDir');
+    const project = await getActiveProject();
+    if (!project) {
+      logger.error('Cannot find a project for the active folder');
+      return undefined;
+    }
+    const type = project.type;
+    if (type === undefined) {
+      logger.error('Cannot determine the project type');
+      return undefined;
+    }
+    const convertToBinPath = (p: string) => {
+      return path.join(p, 'bin');
+    };
+    if (type === CppProjectType.Presets) {
+      const installationPath = await project.getInstallationPathFromPreset();
+      if (installationPath) {
+        return convertToBinPath(installationPath);
+      }
+      const toolchainFile = await project.getToolchainFile();
+      const qtpathsExe = await project.getQtPaths();
+      if (qtpathsExe) {
+        const qtDir = getQtDirFromQtPaths(qtpathsExe, toolchainFile);
+        if (qtDir) {
+          return qtDir;
+        }
+      }
+    } else {
+      // CppProjectType.Kit
+      const kit = await getSelectedKit();
+      if (!kit) {
+        return undefined;
+      }
+      const qtpathsExe = getQtPathsFromKit(kit);
+      if (!qtpathsExe) {
+        return undefined;
+      }
+      const qtDir = getQtDirFromQtPaths(qtpathsExe, kit.toolchainFile);
+      if (qtDir) {
+        return qtDir;
+      }
+    }
+
+    logger.error('Cannot find the binary directory of the Qt installation');
     return undefined;
   });
 }
@@ -109,6 +165,18 @@ export function registerKitDirectoryCommand() {
     `${EXTENSION_ID}.kitDirectory`,
     async () => {
       telemetry.sendAction('kitDirectory');
+      const project = await getActiveProject();
+      if (!project) {
+        return undefined;
+      }
+      const type = project.type;
+      if (type === undefined) {
+        logger.error('Cannot determine the project type');
+        return undefined;
+      }
+      if (type === CppProjectType.Presets) {
+        return undefined;
+      }
       const kit = await getSelectedKit();
       if (!kit) {
         return undefined;
@@ -124,39 +192,67 @@ export function registerKitDirectoryCommand() {
   );
 }
 
+async function findQtPluginPath(qtpaths: string) {
+  const info = coreAPI?.getQtInfoFromPath(qtpaths);
+  if (info) {
+    const buildType = await vscode.commands.executeCommand('cmake.buildType');
+    let pluginPath = info.get('QT_INSTALL_PLUGINS');
+    if (pluginPath) {
+      pluginPath = path.join(pluginPath, 'platforms');
+      if (buildType !== 'Debug') {
+        return pluginPath;
+      }
+      // If code reaches here, it means that the build type is Debug and
+      // we need to return the debug version of the plugin path
+      const installPrefix = info.get('QT_INSTALL_PREFIX');
+      if (installPrefix) {
+        const installPrefixDebug = path.join(installPrefix, 'debug');
+        if (pluginPath) {
+          const pluginPathDebug = pluginPath.replace(
+            path.normalize(installPrefix),
+            installPrefixDebug
+          );
+          return pluginPathDebug;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
 export function qpaPlatformPluginPathCommand() {
   return vscode.commands.registerCommand(
     `${EXTENSION_ID}.QT_QPA_PLATFORM_PLUGIN_PATH`,
     async () => {
       telemetry.sendAction('QT_QPA_PLATFORM_PLUGIN_PATH');
-      const kit = await getSelectedKit();
-      if (kit?.environmentVariables?.VSCODE_QT_QTPATHS_EXE) {
-        if (kit.toolchainFile && inVCPKGRoot(kit.toolchainFile)) {
-          const info = coreAPI?.getQtInfoFromPath(
-            kit.environmentVariables.VSCODE_QT_QTPATHS_EXE
-          );
-          if (info) {
-            const buildType =
-              await vscode.commands.executeCommand('cmake.buildType');
-            let pluginPath = info.get('QT_INSTALL_PLUGINS');
+      const project = await getActiveProject();
+      if (!project) {
+        logger.error('Cannot find a project for the active folder');
+        return undefined;
+      }
+      const type = project.type;
+      if (type === undefined) {
+        logger.error('Cannot determine the project type');
+        return undefined;
+      }
+      if (type === CppProjectType.Presets) {
+        const qtpathsExe = await project.getQtPaths();
+        if (qtpathsExe) {
+          const pluginPath = await findQtPluginPath(qtpathsExe);
+          if (pluginPath) {
+            return pluginPath;
+          }
+        }
+      } else {
+        // CppProjectType.Kit
+        const kit = await getSelectedKit();
+        if (kit?.environmentVariables?.VSCODE_QT_QTPATHS_EXE) {
+          if (kit.toolchainFile && inVCPKGRoot(kit.toolchainFile)) {
+            const pluginPath = await findQtPluginPath(
+              kit.environmentVariables.VSCODE_QT_QTPATHS_EXE
+            );
             if (pluginPath) {
-              pluginPath = path.join(pluginPath, 'platforms');
-              if (buildType !== 'Debug') {
-                return pluginPath;
-              }
-              // If code reaches here, it means that the build type is Debug and
-              // we need to return the debug version of the plugin path
-              const installPrefix = info.get('QT_INSTALL_PREFIX');
-              if (installPrefix) {
-                const installPrefixDebug = path.join(installPrefix, 'debug');
-                if (pluginPath) {
-                  const pluginPathDebug = pluginPath.replace(
-                    path.normalize(installPrefix),
-                    installPrefixDebug
-                  );
-                  return pluginPathDebug;
-                }
-              }
+              return pluginPath;
             }
           }
         }
@@ -166,40 +262,78 @@ export function qpaPlatformPluginPathCommand() {
   );
 }
 
+function isVCPKGToolchainFile(toolchainFile: string) {
+  return toolchainFile.endsWith('vcpkg.cmake');
+}
+
+async function getQmlImportPathFromQtPaths(qtpaths: string) {
+  const info = coreAPI?.getQtInfoFromPath(qtpaths);
+  if (!info) {
+    return undefined;
+  }
+  const buildType = await vscode.commands.executeCommand('cmake.buildType');
+  let importPath = info.get('QT_INSTALL_QML');
+  if (importPath) {
+    importPath = path.normalize(importPath);
+    if (buildType !== 'Debug') {
+      return importPath;
+    }
+    // If code reaches here, it means that the build type is Debug and
+    // we need to return the debug version of the import path
+    const installPrefix = info.get('QT_INSTALL_PREFIX');
+    if (installPrefix) {
+      const installPrefixDebug = path.join(installPrefix, 'debug');
+      if (importPath) {
+        const importPathDebug = importPath.replace(
+          path.normalize(installPrefix),
+          installPrefixDebug
+        );
+        return importPathDebug;
+      }
+    }
+  }
+  return undefined;
+}
 export function qmlImportPathCommand() {
   return vscode.commands.registerCommand(
     `${EXTENSION_ID}.QML_IMPORT_PATH`,
     async () => {
       telemetry.sendAction('QML_IMPORT_PATH');
-      const kit = await getSelectedKit();
-      if (kit?.environmentVariables?.VSCODE_QT_QTPATHS_EXE) {
-        if (kit.toolchainFile && inVCPKGRoot(kit.toolchainFile)) {
-          const info = coreAPI?.getQtInfoFromPath(
-            kit.environmentVariables.VSCODE_QT_QTPATHS_EXE
-          );
-          if (info) {
-            const buildType =
-              await vscode.commands.executeCommand('cmake.buildType');
-            let importPath = info.get('QT_INSTALL_QML');
-            if (importPath) {
-              importPath = path.normalize(importPath);
-              if (buildType !== 'Debug') {
-                return importPath;
-              }
-              // If code reaches here, it means that the build type is Debug and
-              // we need to return the debug version of the import path
-              const installPrefix = info.get('QT_INSTALL_PREFIX');
-              if (installPrefix) {
-                const installPrefixDebug = path.join(installPrefix, 'debug');
-                if (importPath) {
-                  const importPathDebug = importPath.replace(
-                    path.normalize(installPrefix),
-                    installPrefixDebug
-                  );
-                  return importPathDebug;
-                }
-              }
-            }
+      const project = await getActiveProject();
+      if (!project) {
+        logger.error('Cannot find a project for the active folder');
+        return undefined;
+      }
+      const type = project.type;
+      if (type === undefined) {
+        logger.error('Cannot determine the project type');
+        return undefined;
+      }
+      if (type === CppProjectType.Presets) {
+        const qtpathsExe = await project.getQtPaths();
+        const toolchainFile = await project.getToolchainFile();
+        if (
+          qtpathsExe &&
+          toolchainFile &&
+          isVCPKGToolchainFile(toolchainFile)
+        ) {
+          const importPath = await getQmlImportPathFromQtPaths(qtpathsExe);
+          if (importPath) {
+            return importPath;
+          }
+        }
+      } else {
+        // CppProjectType.Kit
+        const qtpathsExe = await project.getQtPaths();
+        const kit = await getSelectedKit();
+        if (
+          qtpathsExe &&
+          kit?.toolchainFile &&
+          isVCPKGToolchainFile(kit.toolchainFile)
+        ) {
+          const importPath = await getQmlImportPathFromQtPaths(qtpathsExe);
+          if (importPath) {
+            return importPath;
           }
         }
       }

--- a/qt-cpp/src/commands/natvis.ts
+++ b/qt-cpp/src/commands/natvis.ts
@@ -9,6 +9,8 @@ import { getSelectedKit, IsQtKit } from '@cmd/register-qt-path';
 import { createLogger, telemetry } from 'qt-lib';
 import { EXTENSION_ID } from '@/constants';
 import { QtVersionFromKit } from '@/util/util';
+import { CppProjectType, getActiveProject } from '@/project';
+import { coreAPI } from '@/extension';
 
 const logger = createLogger('natvis');
 
@@ -47,18 +49,40 @@ export function registerNatvisCommand() {
     `${EXTENSION_ID}.natvis`,
     async () => {
       telemetry.sendAction('natvis');
-      const kit = await getSelectedKit();
-      if (!kit || !IsQtKit(kit)) {
-        const error = `${kit?.name} is not a Qt kit`;
-        throw new Error(error);
+      const project = await getActiveProject();
+      if (!project) {
+        logger.error('Cannot find an active project');
+        return '';
       }
-      const version = QtVersionFromKit(kit);
-      if (version) {
-        const majorVersion = version.split('.')[0];
+      if (project.type === CppProjectType.Presets) {
+        const qtpaths = await project.getQtPaths({
+          includeInstallationPathSearch: true
+        });
+        if (!qtpaths) {
+          const error = 'Cannot find Qt Paths in the project presets';
+          throw new Error(error);
+        }
+        const qtInfo = coreAPI?.getQtInfoFromPath(qtpaths);
+        const majorVersion = qtInfo?.get('QT_VERSION')?.split('.')[0];
         if (!majorVersion) {
           throw new Error('Cannot determine the major version');
         }
         return getNatvis(majorVersion);
+      } else {
+        // CppProjectType.Kit
+        const kit = await getSelectedKit();
+        if (!kit || !IsQtKit(kit)) {
+          const error = `${kit?.name} is not a Qt kit`;
+          throw new Error(error);
+        }
+        const version = QtVersionFromKit(kit);
+        if (version) {
+          const majorVersion = version.split('.')[0];
+          if (!majorVersion) {
+            throw new Error('Cannot determine the major version');
+          }
+          return getNatvis(majorVersion);
+        }
       }
       return undefined;
     }

--- a/qt-cpp/src/commands/register-qt-path.ts
+++ b/qt-cpp/src/commands/register-qt-path.ts
@@ -33,7 +33,7 @@ export function getQtPathsExe(kit: Kit) {
   return kit.environmentVariables?.VSCODE_QT_QTPATHS_EXE;
 }
 
-async function getActiveFolder() {
+export async function getActiveFolder() {
   const activeFolder = await vscode.commands.executeCommand<string>(
     'cmake.activeFolderPath'
   );

--- a/qt-cpp/src/commands/source-directory.ts
+++ b/qt-cpp/src/commands/source-directory.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import { createLogger, telemetry } from 'qt-lib';
 import { getQtInsRoot, getSelectedKit } from '@cmd/register-qt-path';
 import { EXTENSION_ID } from '@/constants';
+import { CppProjectType, getActiveProject } from '@/project';
 
 const logger = createLogger('source-directory');
 
@@ -15,42 +16,51 @@ export function registerSourceDirectoryCommand() {
     `${EXTENSION_ID}.sourceDirectory`,
     async () => {
       telemetry.sendAction('sourceDirectory');
-      const kit = await getSelectedKit();
-      if (!kit) {
+      const project = await getActiveProject();
+      if (!project) {
         return undefined;
       }
-      const insRoot = getQtInsRoot(kit);
-      if (!insRoot) {
-        const config = vscode.workspace.getConfiguration(EXTENSION_ID);
-        const doNotWarn = config.get<boolean>(
-          'doNotWarnMissingSourceDir',
-          false
-        );
-        const message = `Cannot find VSCODE_QT_INSTALLATION in the selected kit: ${kit.name}. Source directory cannot be determined.`;
-        logger.error(message);
-        if (!doNotWarn) {
-          const doNotAskBtn = 'Do not show again';
-          void vscode.window
-            .showWarningMessage(message, doNotAskBtn)
-            .then((result) => {
-              if (result === doNotAskBtn) {
-                void config.update(
-                  'doNotWarnMissingSourceDir',
-                  true,
-                  vscode.ConfigurationTarget.Global
-                );
-              }
-            });
+      if (project.type === CppProjectType.Presets) {
+        return undefined;
+      } else {
+        // CppProjectType.Kit
+        const kit = await getSelectedKit();
+        if (!kit) {
+          return undefined;
         }
-        return undefined;
+        const insRoot = getQtInsRoot(kit);
+        if (!insRoot) {
+          const config = vscode.workspace.getConfiguration(EXTENSION_ID);
+          const doNotWarn = config.get<boolean>(
+            'doNotWarnMissingSourceDir',
+            false
+          );
+          const message = `Cannot find VSCODE_QT_INSTALLATION in the selected kit: ${kit.name}. Source directory cannot be determined.`;
+          logger.error(message);
+          if (!doNotWarn) {
+            const doNotAskBtn = 'Do not show again';
+            void vscode.window
+              .showWarningMessage(message, doNotAskBtn)
+              .then((result) => {
+                if (result === doNotAskBtn) {
+                  void config.update(
+                    'doNotWarnMissingSourceDir',
+                    true,
+                    vscode.ConfigurationTarget.Global
+                  );
+                }
+              });
+          }
+          return undefined;
+        }
+        // Remove the last part of the path to get the source directory
+        // For example, if insRoot is '/path/to/Qt/6.5.0/gcc_64', we want to get '/path/to/Qt/6.5.0'
+        const versionDir = path.dirname(insRoot);
+        // Add the 'Src' directory to the path
+        const sourceDir = path.join(versionDir, 'Src');
+        logger.info(`Source directory for kit ${kit.name} is: ${sourceDir}`);
+        return sourceDir;
       }
-      // Remove the last part of the path to get the source directory
-      // For example, if insRoot is '/path/to/Qt/6.5.0/gcc_64', we want to get '/path/to/Qt/6.5.0'
-      const versionDir = path.dirname(insRoot);
-      // Add the 'Src' directory to the path
-      const sourceDir = path.join(versionDir, 'Src');
-      logger.info(`Source directory for kit ${kit.name} is: ${sourceDir}`);
-      return sourceDir;
     }
   );
 }

--- a/qt-cpp/src/constants.ts
+++ b/qt-cpp/src/constants.ts
@@ -2,4 +2,3 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 export const EXTENSION_ID = 'qt-cpp';
-export const CONFIG_CMAKE_PRESET_WARNING = 'doNotShowCMakePresetWarning';

--- a/qt-cpp/src/project.ts
+++ b/qt-cpp/src/project.ts
@@ -9,27 +9,29 @@ import * as crypto from 'crypto';
 import { isEmpty, isEqual } from 'lodash';
 
 import { WorkspaceStateManager } from '@/state';
-import { coreAPI, kitManager } from '@/extension';
+import { coreAPI, kitManager, projectManager } from '@/extension';
 import {
   CoreKey,
   createLogger,
+  findQtPathsInInstallationPath,
   IsLinux,
   IsMacOS,
   IsWindows,
   QtWorkspaceConfigMessage,
   QtWorkspaceFeatures,
+  searchForQtPathsInVCPKG,
   telemetry
 } from 'qt-lib';
 import { Project, ProjectManager } from 'qt-lib';
 import {
+  getActiveFolder,
   getQtInsRoot,
   getQtPathsExe,
   getSelectedKit
 } from '@cmd/register-qt-path';
 import { analyzeKit } from '@/kit-manager';
 import * as cmakeFileApi from '@/cmake-file-api';
-import { getMajorQtVersion } from '@/util/util';
-import { CONFIG_CMAKE_PRESET_WARNING, EXTENSION_ID } from '@/constants';
+import { getMajorQtVersion, isValidAndString } from '@/util/util';
 
 const logger = createLogger('project');
 
@@ -49,13 +51,34 @@ export async function createCppProject(
     cmakeProject = await api.getProject(folder.uri);
   }
   const buildDir = await cmakeProject?.getBuildDirectory();
+  if (!cmakeProject) {
+    logger.error('CMake project is not found for folder: ' + folder.uri.fsPath);
+    throw new Error(
+      'CMake project is not found for folder: ' + folder.uri.fsPath
+    );
+  }
+
   return Promise.resolve(
     new CppProject(folder, context, cmakeProject, buildDir)
   );
 }
 
+export async function getActiveProject() {
+  const activeFolder = await getActiveFolder();
+  if (!activeFolder) {
+    return undefined;
+  }
+  return projectManager.getProject(activeFolder);
+}
+
+export enum CppProjectType {
+  Kit = 'Kit',
+  Presets = 'CMakePresets'
+}
+
 // Project class represents a workspace folder in the extension.
 export class CppProject implements Project {
+  private readonly _type: CppProjectType | undefined;
   private readonly _disposables: vscode.Disposable[] = [];
   private readonly _stateManager: WorkspaceStateManager;
   private readonly _cmakeProject: cmakeApi.Project | undefined;
@@ -63,128 +86,228 @@ export class CppProject implements Project {
   constructor(
     private readonly _folder: vscode.WorkspaceFolder,
     readonly _context: vscode.ExtensionContext,
-    cmakeProject: cmakeApi.Project | undefined,
+    cmakeProject: cmakeApi.Project,
     buildDir: string | undefined
   ) {
     this._cmakeProject = cmakeProject;
     this._stateManager = new WorkspaceStateManager(_context, _folder);
     this._buildDir = buildDir;
 
-    if (this._cmakeProject) {
-      const onSelectedConfigurationChangedHandler =
-        this._cmakeProject.onSelectedConfigurationChanged(
-          async (configurationType: cmakeApi.ConfigurationType) => {
-            switch (configurationType) {
-              case cmakeApi.ConfigurationType.Kit:
-                await this.onKitConfigurationChanged();
-                break;
-              case cmakeApi.ConfigurationType.ConfigurePreset:
-              case cmakeApi.ConfigurationType.BuildPreset:
-                CppProject.warnUserForPresetUsage();
-                break;
-            }
-          }
-        );
-      const onCodeModelChangedHandler = this._cmakeProject.onCodeModelChanged(
-        async () => {
-          if (!this._cmakeProject) {
-            throw new Error('CMake project is not defined');
-          }
-          const prevbuildDir = this._buildDir;
-          const currentBuildDir = await this._cmakeProject.getBuildDirectory();
-          if (prevbuildDir !== currentBuildDir) {
-            logger.info(
-              'Build directory changed:',
-              currentBuildDir ?? 'undefined'
-            );
-            this._buildDir = currentBuildDir;
-            const message = new QtWorkspaceConfigMessage(this.folder);
-            coreAPI?.setValue(this.folder, CoreKey.BUILD_DIR, currentBuildDir);
-            message.config.add(CoreKey.BUILD_DIR);
-            logger.info(
-              `Notifying coreAPI with message: ${message.toString()}`
-            );
-            coreAPI?.notify(message);
-          }
-          // Obtain used Qt modules if telemetry is enabled
-          if (vscode.env.isTelemetryEnabled) {
-            await this.obtainUsedQtModules();
-          }
+    if (this._cmakeProject.useCMakePresets) {
+      logger.info('Using CMake presets');
+      this._type = CppProjectType.Presets;
+    } else {
+      logger.info('Using Kit configuration');
+      this._type = CppProjectType.Kit;
+    }
+    logger.info(
+      `Project type for ${this._folder.uri.fsPath} is ${this._type.toString()}`
+    );
+    const onSelectedConfigurationChangedHandler =
+      this._cmakeProject.onSelectedConfigurationChanged(
+        async (configurationType: cmakeApi.ConfigurationType) => {
+          await this.onSelectedConfigurationChanged(configurationType);
         }
       );
-      this.checkCMakePresetInWorkspace();
-      this._disposables.push(onCodeModelChangedHandler);
-      this._disposables.push(onSelectedConfigurationChangedHandler);
+    const onCodeModelChangedHandler = this._cmakeProject.onCodeModelChanged(
+      async () => {
+        await this.onCodeModelChanged();
+      }
+    );
+
+    this._disposables.push(onCodeModelChangedHandler);
+    this._disposables.push(onSelectedConfigurationChangedHandler);
+  }
+  private async onCodeModelChanged() {
+    if (!this._cmakeProject) {
+      throw new Error('CMake project is not defined');
+    }
+    const prevbuildDir = this._buildDir;
+    const currentBuildDir = await this._cmakeProject.getBuildDirectory();
+    if (prevbuildDir !== currentBuildDir) {
+      logger.info('Build directory changed:', currentBuildDir ?? 'undefined');
+      this._buildDir = currentBuildDir;
+      const message = new QtWorkspaceConfigMessage(this.folder);
+      coreAPI?.setValue(this.folder, 'buildDir', currentBuildDir);
+      message.config.add('buildDir');
+      logger.info(`Notifying coreAPI with message: ${message.toString()}`);
+      coreAPI?.notify(message);
+    }
+    // Obtain used Qt modules if telemetry is enabled
+    if (vscode.env.isTelemetryEnabled) {
+      await this.obtainUsedQtModules();
     }
   }
+  private async onSelectedConfigurationChanged(
+    configurationType: cmakeApi.ConfigurationType
+  ) {
+    logger.info(
+      `Selected configuration changed: ${configurationType.toString()} for project: ${this._folder.uri.fsPath}`
+    );
+    logger.info(
+      `useCMakePresets: ${this._cmakeProject?.useCMakePresets} for project: ${this._folder.uri.fsPath}`
+    );
+    switch (configurationType) {
+      case cmakeApi.ConfigurationType.Kit:
+        await this.onKitConfigurationChanged();
+        break;
+      case cmakeApi.ConfigurationType.ConfigurePreset:
+        await this.onConfigurePresetsChanged();
+        break;
+      case cmakeApi.ConfigurationType.BuildPreset:
+        // Do nothing for build preset change
+        break;
+    }
+  }
+  get type() {
+    return this._type;
+  }
+  private async onConfigurePresetsChanged() {
+    if (!this._cmakeProject?.configurePreset) {
+      throw new Error('Configure preset is not defined');
+    }
+    const message = new QtWorkspaceConfigMessage(this.folder);
+    const configEntries: [string, string | undefined][] = [
+      [CoreKey.INSTALLATION_PATH, await this.getInstallationPathFromPreset()],
+      [CoreKey.SELECTED_QT_PATHS, await this.getQtPathsExeFromPreset()],
+      [CoreKey.BUILD_DIR, await this._cmakeProject.getBuildDirectory()]
+    ];
+    for (const [key, value] of configEntries) {
+      coreAPI?.setValue(this.folder, key, value);
+      message.config.add(key);
+      logger.info(
+        `Setting ${key} for ${this.folder.uri.fsPath} to ${typeof value === 'object' ? JSON.stringify(value) : value}`
+      );
+    }
+    coreAPI?.notify(message);
+  }
+  async getToolchainFile() {
+    if (this._type === CppProjectType.Kit) {
+      const kit = await getSelectedKit(this._folder);
+      if (kit) {
+        return kit.toolchainFile;
+      }
+    } else if (this._type === CppProjectType.Presets) {
+      const presets = this._cmakeProject?.configurePreset;
+      if (!presets) {
+        return undefined;
+      }
+      const toolchainFile =
+        presets.toolchainFile ??
+        presets.cacheVariables?.CMAKE_TOOLCHAIN_FILE ??
+        presets.environment?.CMAKE_TOOLCHAIN_FILE;
+      if (toolchainFile && typeof toolchainFile === 'string') {
+        return toolchainFile;
+      }
+    }
+    return undefined;
+  }
+
+  async getInstallationPathFromPreset() {
+    const preset = this._cmakeProject?.configurePreset;
+    if (!preset) {
+      return undefined;
+    }
+    const qtInstallationPath = CppProject.getVendorValue(
+      this._cmakeProject.configurePreset,
+      'VSCODE_QT_INSTALLATION'
+    ) as string | undefined;
+    if (qtInstallationPath) {
+      if (isValidAndString(qtInstallationPath)) {
+        return qtInstallationPath;
+      }
+    }
+    const keys = [
+      'CMAKE_PREFIX_PATH',
+      'QT_ADDITIONAL_PACKAGES_PREFIX_PATH',
+      'QT_PACKAGES_PREFIX_PATH',
+      'Qt6_ROOT',
+      'Qt_ROOT',
+      'QTDIR'
+    ];
+
+    for (const key of keys) {
+      const value = preset.cacheVariables?.[key];
+      if (value && typeof value === 'string') {
+        return value;
+      }
+    }
+    if (preset.environment) {
+      for (const key of keys) {
+        const value = preset.environment[key];
+        if (value && typeof value === 'string') {
+          return value;
+        }
+      }
+    }
+
+    for (const version of ['Qt6', 'Qt5']) {
+      const dirKey = `${version}_DIR`;
+      // Example D:/Qt/6.7.2/msvc2019_64/lib/cmake/Qt6
+      // /home/orkun/Qt/6.9.0/gcc_64/lib/cmake/Qt6
+      const isValidQtDir = (dir: string) => {
+        if (dir && typeof dir === 'string') {
+          if (dir.endsWith(pathToRemove)) {
+            return dir.slice(0, dir.length - pathToRemove.length - 1);
+          }
+        }
+        return undefined;
+      };
+
+      const pathToRemove = path.join('lib', 'cmake', version);
+      const dirValue = preset.cacheVariables?.[dirKey];
+      if (dirValue && typeof dirValue === 'string') {
+        const validDir = isValidQtDir(dirValue);
+        if (validDir) {
+          return validDir;
+        }
+      }
+      if (preset.environment) {
+        const envDirValue = preset.environment[dirKey];
+        if (envDirValue && typeof envDirValue === 'string') {
+          if (envDirValue.endsWith(pathToRemove)) {
+            return envDirValue.slice(
+              0,
+              envDirValue.length - pathToRemove.length - 1
+            );
+          }
+        }
+      }
+    }
+    // Try to find Qt installation from toolchain file
+    const officialToolchainFileName = 'qt.toolchain.cmake';
+    const toolchainFile = await this.getToolchainFile();
+    if (toolchainFile) {
+      const toolchainFileName = path.basename(toolchainFile);
+      if (toolchainFileName === officialToolchainFileName) {
+        const pathToRemove = path.join('lib', 'cmake', 'Qt6');
+        const toolchainDir = path.dirname(toolchainFile);
+        const installationPath = toolchainDir.slice(
+          0,
+          toolchainDir.length - pathToRemove.length - 1
+        );
+        return installationPath;
+      }
+    }
+
+    return undefined;
+  }
+
   private async onKitConfigurationChanged() {
     const kit = await getSelectedKit(this.folder);
     if (vscode.env.isTelemetryEnabled && kit) {
       analyzeKit(kit);
     }
-    const selectedKitPath = kit ? getQtInsRoot(kit) : undefined;
+    const installationPath = await this.getInstallationPathFromKit();
     const message = new QtWorkspaceConfigMessage(this.folder);
-    coreAPI?.setValue(this.folder, CoreKey.SELECTED_KIT_PATH, selectedKitPath);
-    message.config.add(CoreKey.SELECTED_KIT_PATH);
+    coreAPI?.setValue(this.folder, CoreKey.INSTALLATION_PATH, installationPath);
+    message.config.add(CoreKey.INSTALLATION_PATH);
 
-    const selectedQtPaths = kit ? getQtPathsExe(kit) : undefined;
+    const selectedQtPaths = await this.getQtPaths();
     coreAPI?.setValue(this.folder, CoreKey.SELECTED_QT_PATHS, selectedQtPaths);
     message.config.add(CoreKey.SELECTED_QT_PATHS);
     logger.info(`Notifying coreAPI with message: ${message.toString()}`);
     coreAPI?.notify(message);
-  }
-  private static getDoNotShowCMakePresetWarning() {
-    const configKey = `${EXTENSION_ID}.${CONFIG_CMAKE_PRESET_WARNING}`;
-    const config = vscode.workspace.getConfiguration();
-    return config.get<boolean>(configKey);
-  }
-  private static setDoNotShowCMakePresetWarning(value: boolean) {
-    const configKey = `${EXTENSION_ID}.${CONFIG_CMAKE_PRESET_WARNING}`;
-    const config = vscode.workspace.getConfiguration();
-    void config.update(configKey, value, vscode.ConfigurationTarget.Global);
-  }
-  private static warnUserForPresetUsage() {
-    if (CppProject.getDoNotShowCMakePresetWarning()) {
-      return;
-    }
-
-    const doNotShowAgainButtonMessage = 'Do not show again';
-    void vscode.window
-      .showWarningMessage(
-        'Qt C++ extension does not support CMake Presets yet. Use Kits instead.',
-        doNotShowAgainButtonMessage
-      )
-      .then((result) => {
-        if (result === doNotShowAgainButtonMessage) {
-          CppProject.setDoNotShowCMakePresetWarning(true);
-        }
-      });
-  }
-  private checkCMakePresetInWorkspace() {
-    if (!this._cmakeProject) {
-      throw new Error('CMake project is not defined');
-    }
-    if (CppProject.getDoNotShowCMakePresetWarning()) {
-      return;
-    }
-    // If the project has a CMake Preset, warn the user
-    const presetFiles = ['CMakePresets.json', 'CMakeUserPresets.json'];
-    const presetFileExists = presetFiles.some((file) => {
-      const presetFilePath = path.join(this.folder.uri.fsPath, file);
-      return fs.existsSync(presetFilePath);
-    });
-    // If cmake.useCMakePresets is not never, warn the user
-    const useCMakePresets =
-      vscode.workspace
-        .getConfiguration('cmake')
-        .get<string>('useCMakePresets') !== 'never';
-    if (presetFileExists && useCMakePresets) {
-      // Show warning message after 2 seconds because when the project is opened,
-      // Multiple messages can be shown at once and our message can be lost.
-      setTimeout(() => {
-        CppProject.warnUserForPresetUsage();
-      }, 2000);
-    }
   }
 
   private async obtainUsedQtModules() {
@@ -415,43 +538,200 @@ export class CppProject implements Project {
       return [];
     }
   }
+  async getInstallationPathFromKit() {
+    const folder = this.folder;
+    const kit = await getSelectedKit(folder, true);
+    if (!kit) {
+      return undefined;
+    }
+    const installationPath = getQtInsRoot(kit);
+    if (installationPath) {
+      return installationPath;
+    }
+    // const qtPathsExe = getQtPathsExe(kit);
+    // if (qtPathsExe) {
+    //   const qtInfo = coreAPI?.getQtInfoFromPath(qtPathsExe);
+    //   if (qtInfo) {
+    //     return qtInfo.get('QT_INSTALL_PREFIX');
+    //   }
+    // }
+    return undefined;
+  }
+  async getInstallationPath() {
+    if (this._type === CppProjectType.Kit) {
+      const selectedKitPath = await this.getInstallationPathFromKit();
+      if (selectedKitPath) {
+        return selectedKitPath;
+      }
+    } else if (this._type === CppProjectType.Presets) {
+      return this.getInstallationPathFromPreset();
+    }
+    return undefined;
+  }
+  async getQtPathsExeFromKit() {
+    const folder = this.folder;
+    const kit = await getSelectedKit(folder, true);
+    if (!kit) {
+      return undefined;
+    }
+    const qtPathsExe = getQtPathsExe(kit);
+    if (qtPathsExe) {
+      return qtPathsExe;
+    }
+    return undefined;
+  }
+  private static getVendorValue(preset: cmakeApi.ConfigurePreset, key: string) {
+    const qtCppVendor = preset.vendor?.['qt-cpp'] as
+      | cmakeApi.VendorType
+      | undefined;
+    if (qtCppVendor) {
+      const value = qtCppVendor[key] as unknown;
+      return value;
+    }
+    return undefined;
+  }
+  async getQtPathsExeFromPreset({
+    includeInstallationPathSearch = false
+  } = {}) {
+    const presets = this._cmakeProject?.configurePreset;
+    if (!presets) {
+      return undefined;
+    }
+    // Example:
+    //"configurePresets": [
+    //   {
+    //    "vendor": {
+    //       "qt-cpp": {
+    //           "VSCODE_QT_INSTALLATION": "/home/orkun/qt_work/qt5/build/qtbase",
+    //            or
+    //           "VSCODE_QT_QTPATHS_EXE": "/home/orkun/Qt/6.7.3/gcc_64/bin/qtpaths"
+    //       },
+    //    }
+    // ]
+    const qtpathsVendor = CppProject.getVendorValue(
+      this._cmakeProject.configurePreset,
+      'VSCODE_QT_QTPATHS_EXE'
+    ) as string | undefined;
+    if (qtpathsVendor) {
+      if (isValidAndString(qtpathsVendor)) {
+        return qtpathsVendor;
+      }
+    }
+    // Try to find Qt paths from cacheVariables and environment variables
+    if (includeInstallationPathSearch) {
+      const installationPath = await this.getInstallationPathFromPreset();
+      if (installationPath) {
+        const qtpaths = findQtPathsInInstallationPath(installationPath);
+        if (qtpaths) {
+          return qtpaths;
+        }
+      }
+    }
+    // Check VCPKG_ROOT in environment variables and cache variables
+    // const vcpkgRoot =
+    //   presets.environment?.VCPKG_ROOT ?? presets.cacheVariables?.VCPKG_ROOT;
+    // if (isValidAndString(vcpkgRoot)) {
+    //   const qtPaths = searchForQtPathsInVCPKG(vcpkgRoot);
+    //   if (qtPaths) {
+    //     return qtPaths;
+    //   }
+    // }
+    const vcpkgToolchain = await this.getToolchainFile();
+    if (
+      isValidAndString(vcpkgToolchain) &&
+      vcpkgToolchain.endsWith('vcpkg.cmake')
+    ) {
+      // Examples:
+      // /home/<username>/vcpkg/scripts/buildsystems/vcpkg.cmake
+      // D:/vcpkg/scripts/buildsystems/vcpkg.cmake
+      // Extract vcpkg root from toolchain file path
+      const pathToRemove = path.join('scripts', 'buildsystems', 'vcpkg.cmake');
+      const vcpkgRootFromToolchain = vcpkgToolchain.slice(
+        0,
+        vcpkgToolchain.length - pathToRemove.length - 1
+      );
+      const qtPaths = searchForQtPathsInVCPKG(vcpkgRootFromToolchain);
+      if (qtPaths) {
+        return qtPaths;
+      }
+    }
+    return undefined;
+  }
+  async getQtPaths({ includeInstallationPathSearch = false } = {}) {
+    if (this._type === CppProjectType.Kit) {
+      const qtPathsExe = await this.getQtPathsExeFromKit();
+      if (qtPathsExe) {
+        return qtPathsExe;
+      }
+    } else if (this._type === CppProjectType.Presets) {
+      const qtPathsExe = await this.getQtPathsExeFromPreset({
+        includeInstallationPathSearch
+      });
+      if (qtPathsExe) {
+        return qtPathsExe;
+      }
+    }
+    return undefined;
+  }
   async initConfigValues() {
     if (!coreAPI) {
       throw new Error('CoreAPI is not initialized');
     }
-    const folder = this.folder;
-    const kit = await getSelectedKit(folder, true);
-    const selectedKitPath = kit ? getQtInsRoot(kit) : undefined;
-    logger.info(
-      `Setting selected kit path for ${folder.uri.fsPath} to ${selectedKitPath}`
-    );
-    coreAPI.setValue(folder, CoreKey.SELECTED_KIT_PATH, selectedKitPath);
-    const selectedQtPaths = kit ? getQtPathsExe(kit) : undefined;
-    coreAPI.setValue(folder, CoreKey.SELECTED_QT_PATHS, selectedQtPaths);
-    logger.info(
-      `Setting selected Qt paths for ${folder.uri.fsPath} to ${selectedQtPaths}`
-    );
+    // const installationPath = await this.getInstallationPath();
+    // logger.info(
+    //   `Setting installation path for ${folder.uri.fsPath} to ${installationPath}`
+    // );
 
-    const featuresKey = CoreKey.WORKSPACE_FEATURES;
-    let features = coreAPI.getValue<QtWorkspaceFeatures>(folder, featuresKey);
+    // // const kit = await getSelectedKit(folder, true);
+    // coreAPI.setValue(folder, CoreKey.INSTALLATION_PATH, installationPath);
+    // // const selectedQtPaths = kit ? getQtPathsExe(kit) : undefined;
+    // const selectedQtPaths = await this.getQtPaths();
+    // coreAPI.setValue(folder, CoreKey.SELECTED_QT_PATHS, selectedQtPaths);
+    // logger.info(
+    //   `Setting selected Qt paths for ${folder.uri.fsPath} to ${selectedQtPaths}`
+    // );
+
+    // coreAPI.setValue(folder, featuresKey, features);
+    // logger.info(
+    //   `Setting workspace features for ${folder.uri.fsPath} to ${JSON.stringify(features)}`
+    // );
+
+    // coreAPI.setValue(folder, CoreKey.BUILD_DIR, this.buildDir);
+    // logger.info(
+    //   `Setting build directory for ${folder.uri.fsPath} to ${this.buildDir}`
+    // );
+    // logger.info('Config values initialized for:', folder.uri.fsPath);
+    // const message = new QtWorkspaceConfigMessage(folder);
+    // message.config.add(CoreKey.INSTALLATION_PATH);
+    // message.config.add(CoreKey.SELECTED_QT_PATHS);
+    // message.config.add(featuresKey);
+    // message.config.add(CoreKey.BUILD_DIR);
+    if (!this._cmakeProject) {
+      throw new Error('CMake project is not defined');
+    }
+    // coreAPI.notify(message);
+    const folder = this.folder;
+    let features = coreAPI.getValue<QtWorkspaceFeatures>(
+      folder,
+      CoreKey.WORKSPACE_FEATURES
+    );
     features ??= { projectTypes: {} };
     features.projectTypes.cmake = true;
-
-    coreAPI.setValue(folder, featuresKey, features);
-    logger.info(
-      `Setting workspace features for ${folder.uri.fsPath} to ${JSON.stringify(features)}`
-    );
-
-    coreAPI.setValue(folder, CoreKey.BUILD_DIR, this.buildDir);
-    logger.info(
-      `Setting build directory for ${folder.uri.fsPath} to ${this.buildDir}`
-    );
-    logger.info('Config values initialized for:', folder.uri.fsPath);
-    const message = new QtWorkspaceConfigMessage(folder);
-    message.config.add(CoreKey.SELECTED_KIT_PATH);
-    message.config.add(CoreKey.SELECTED_QT_PATHS);
-    message.config.add(featuresKey);
-    message.config.add(CoreKey.BUILD_DIR);
+    const message = new QtWorkspaceConfigMessage(this.folder);
+    const configEntries: [string, string | undefined | QtWorkspaceFeatures][] =
+      [
+        [CoreKey.INSTALLATION_PATH, await this.getInstallationPath()],
+        [CoreKey.SELECTED_QT_PATHS, await this.getQtPaths()],
+        [CoreKey.BUILD_DIR, await this._cmakeProject.getBuildDirectory()],
+        [CoreKey.WORKSPACE_FEATURES, features]
+      ];
+    for (const [key, value] of configEntries) {
+      coreAPI.setValue(this.folder, key, value);
+      message.config.add(key);
+      logger.info(
+        `Setting ${key} for ${this.folder.uri.fsPath} to ${typeof value === 'object' ? JSON.stringify(value) : value}`
+      );
+    }
     coreAPI.notify(message);
   }
   public getStateManager() {

--- a/qt-cpp/src/util/util.ts
+++ b/qt-cpp/src/util/util.ts
@@ -25,6 +25,10 @@ export function getFilenameWithoutExtension(filename: string): string {
   return splitPath;
 }
 
+export const isValidAndString = (value: unknown) => {
+  return value !== undefined && typeof value === 'string';
+};
+
 export function QtVersionFromKit(kit: Kit) {
   const qtInsRoot = getQtInsRoot(kit);
   if (qtInsRoot) {

--- a/qt-lib/src/constants.ts
+++ b/qt-lib/src/constants.ts
@@ -10,7 +10,7 @@ export const CoreKey = {
   QT_INSTALLATION_ROOT: 'qtInstallationRoot',
   VENV_BIN_PATH: 'venvBinPath',
   WORKSPACE_FEATURES: 'workspaceFeatures',
-  SELECTED_KIT_PATH: 'selectedKitPath',
+  INSTALLATION_PATH: 'installationPath',
   SELECTED_QT_PATHS: 'selectedQtPaths',
   BUILD_DIR: 'buildDir',
   GLOBAL_WORKSPACE: 'global'

--- a/qt-lib/src/index.ts
+++ b/qt-lib/src/index.ts
@@ -7,5 +7,6 @@ export * from './state';
 export * from './telemetry';
 export * from './color-provider';
 export * from './configuration-resolver';
+export * from './vcpkg';
 export * from './test-helper';
 export * from './test-constants';

--- a/qt-lib/src/util.ts
+++ b/qt-lib/src/util.ts
@@ -244,7 +244,7 @@ export async function waitForQtCpp() {
   }
 }
 
-export function findQtPathsInKitDir(dir: string): string | undefined {
+export function findQtPathsInInstallationPath(dir: string): string | undefined {
   const qtpathsVersions = ['qtpaths', 'qtpaths6'];
   const suffixes = [OSExeSuffix];
   if (IsWindows) {

--- a/qt-lib/src/vcpkg.ts
+++ b/qt-lib/src/vcpkg.ts
@@ -1,0 +1,68 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as path from 'path';
+
+import {
+  IsLinux,
+  IsMacOS,
+  IsWindows,
+  OSExeSuffix,
+  IsArm64,
+  Isx64
+} from './util';
+import { spawnSync } from 'child_process';
+
+export function getQueryOutput(exePath: string) {
+  const ret = spawnSync(exePath, ['-query'], {
+    encoding: 'utf8',
+    timeout: 1000
+  });
+  if (ret.error ?? ret.status !== 0) {
+    return undefined;
+  }
+  return ret;
+}
+
+export function searchForQtPathsInVCPKG(root: string): string | undefined {
+  if (!root) {
+    return;
+  }
+  const exeNames = [`qtpaths${OSExeSuffix}`, `qmake${OSExeSuffix}`];
+  if (IsWindows) {
+    exeNames.push('qmake.bat');
+  }
+
+  const osPath = () => {
+    const arch = Isx64 ? 'x64' : 'x86';
+    if (IsLinux) {
+      return `${arch}-linux`;
+    } else if (IsMacOS) {
+      if (IsArm64) {
+        return 'arm64-osx';
+      } else {
+        return `x64-osx`;
+      }
+    } else if (IsWindows) {
+      return `${arch}-windows`;
+    } else {
+      throw new Error('Not supported');
+    }
+  };
+  for (const exeName of exeNames) {
+    const exePath = path.join(
+      root,
+      'installed',
+      osPath(),
+      'tools',
+      'Qt6',
+      'bin',
+      exeName
+    );
+    const ret = getQueryOutput(exePath);
+    if (ret) {
+      return exePath;
+    }
+  }
+  return undefined;
+}

--- a/qt-qml/src/constants.ts
+++ b/qt-qml/src/constants.ts
@@ -1,4 +1,5 @@
 // Copyright (C) 2024 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
+export * from 'qt-lib/src/constants';
 export const EXTENSION_ID = 'qt-qml';

--- a/qt-qml/src/extension.ts
+++ b/qt-qml/src/extension.ts
@@ -18,7 +18,7 @@ import { registerDownloadQmllsCommand } from '@cmd/download-qmlls';
 import { registerDebugPort } from '@cmd/debug';
 import { registerCheckQmllsUpdateCommand } from '@cmd/check-qmlls-update';
 import { getDoNotAskForDownloadingQmlls, Qmlls, QmllsStatus } from '@/qmlls';
-import { EXTENSION_ID } from '@/constants';
+import * as consts from '@/constants';
 import { QMLProjectManager, createQMLProject } from '@/project';
 import { registerResetCommand } from '@cmd/reset';
 import { registerQmlDebugAdapterFactory } from '@debug/debug-adapter';
@@ -35,7 +35,7 @@ let taskProvider: vscode.Disposable | undefined;
 const logger = createLogger('extension');
 
 export async function activate(context: vscode.ExtensionContext) {
-  initLogger(EXTENSION_ID);
+  initLogger(consts.EXTENSION_ID);
   telemetry.activate(context);
   projectManager = new QMLProjectManager(context);
   coreAPI = await getCoreApi();
@@ -91,7 +91,7 @@ async function startQmlls() {
 }
 
 export function deactivate() {
-  logger.info(`Deactivating ${EXTENSION_ID}`);
+  logger.info(`Deactivating ${consts.EXTENSION_ID}`);
   telemetry.dispose();
   projectManager.dispose();
   if (taskProvider) {
@@ -113,10 +113,10 @@ function processMessage(message: QtWorkspaceConfigMessage) {
     }
     let updateQmlls = false;
     for (const key of message.config.keys()) {
-      if (key === CoreKey.SELECTED_KIT_PATH) {
+      if (key === CoreKey.INSTALLATION_PATH) {
         const selectedKitPath = coreAPI?.getValue<string>(
           message.workspaceFolder,
-          CoreKey.SELECTED_KIT_PATH
+          CoreKey.INSTALLATION_PATH
         );
         if (selectedKitPath !== project.kitPath) {
           updateQmlls = true;

--- a/qt-qml/src/project.ts
+++ b/qt-qml/src/project.ts
@@ -9,7 +9,7 @@ import {
   Project,
   ProjectManager,
   createLogger,
-  findQtPathsInKitDir
+  findQtPathsInInstallationPath
 } from 'qt-lib';
 import { Qmlls } from '@/qmlls';
 import { coreAPI } from '@/extension';
@@ -106,7 +106,7 @@ export class QMLProject implements Project {
   getConfigValues() {
     this.kitPath = coreAPI?.getValue<string>(
       this.folder,
-      CoreKey.SELECTED_KIT_PATH
+      CoreKey.INSTALLATION_PATH
     );
     this.qtpathsExe = coreAPI?.getValue<string>(
       this.folder,
@@ -115,7 +115,7 @@ export class QMLProject implements Project {
     this.buildDir = coreAPI?.getValue<string>(this.folder, CoreKey.BUILD_DIR);
   }
   getDocsPathFromKitDir(kitDir: string) {
-    const qtpaths = findQtPathsInKitDir(kitDir);
+    const qtpaths = findQtPathsInInstallationPath(kitDir);
     if (!qtpaths) {
       logger.error(`Cannot find qtpaths in: ${this.kitPath}`);
       return undefined;
@@ -134,10 +134,8 @@ export class QMLProject implements Project {
     if (this.kitPath) {
       this.qmlls.addImportPath(path.join(this.kitPath, 'qml'));
       const docsPath = this.getDocsPathFromKitDir(this.kitPath);
-      if (docsPath) {
-        logger.info('Setting docs path:', docsPath);
-        this.qmlls.docsPath = docsPath;
-      }
+      logger.info('Setting docs path:', docsPath ?? 'undefined');
+      this.qmlls.docsPath = docsPath;
     } else if (this.qtpathsExe) {
       const info = coreAPI?.getQtInfoFromPath(this.qtpathsExe);
       if (!info) {

--- a/qt-ui/src/constants.ts
+++ b/qt-ui/src/constants.ts
@@ -1,6 +1,7 @@
 // Copyright (C) 2024 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
+export * from 'qt-lib/src/constants';
 export const EXTENSION_ID = 'qt-ui';
 export const CONF_CUSTOM_WIDGETS_DESIGNER_EXE_PATH =
   'customWidgetsDesignerExePath';

--- a/qt-ui/src/project-manager.ts
+++ b/qt-ui/src/project-manager.ts
@@ -59,7 +59,7 @@ export class UIProjectManager extends ProjectManager<UIProject> {
     }
 
     for (const key of msg.config.keys()) {
-      if (key === CoreKey.SELECTED_KIT_PATH) {
+      if (key === CoreKey.INSTALLATION_PATH) {
         const value = coreAPI?.getValue<string>(folder, key);
         await project.setSelectedKitPath(value);
         continue;

--- a/qt-ui/src/project.ts
+++ b/qt-ui/src/project.ts
@@ -91,7 +91,7 @@ export class UIProject implements Project {
     );
     this._selectedKitPath = read<string>(
       this._folder,
-      CoreKey.SELECTED_KIT_PATH
+      CoreKey.INSTALLATION_PATH
     );
     this._selectedQtPaths = read<string>(
       this._folder,

--- a/qt-ui/src/util.ts
+++ b/qt-ui/src/util.ts
@@ -9,7 +9,7 @@ import {
   OSExeSuffix,
   exists,
   searchForExeInQtInfo,
-  findQtPathsInKitDir
+  findQtPathsInInstallationPath
 } from 'qt-lib';
 import { coreAPI } from '@/extension';
 
@@ -27,7 +27,7 @@ export async function locateDesignerFromKit(
   }
 
   if (qtPathsFallback) {
-    const qtPaths = findQtPathsInKitDir(selectedKitPath);
+    const qtPaths = findQtPathsInInstallationPath(selectedKitPath);
     const exeFromQtPaths =
       qtPaths && (await locateDesignerFromQtPaths(qtPaths));
     if (exeFromQtPaths) {


### PR DESCRIPTION
Add full support for CMakePresets, allowing users to configure Qt projects
using either CMake Kits or CMakePresets. The extension automatically detects
the project configuration type and adapts accordingly.

Project Type Detection:
- Add CppProjectType enum to distinguish between Kit and Presets modes
- Detect configuration type on project activation
- Support mixed workspaces with different configuration types per folder

CMakePresets Qt Path Resolution:
- Extract Qt installation from CMake cache variables (CMAKE_PREFIX_PATH,
  Qt6_ROOT, Qt_ROOT, etc.)
- Parse Qt*_DIR variables (Qt6_DIR, Qt5_DIR) to derive installation path
- Detect Qt from vcpkg toolchain files (qt.toolchain.cmake)
- Support custom vendor parameters (VSCODE_QT_INSTALLATION, VSCODE_QT_QTPATHS_EXE)
  in CMakePresets vendor.qt-cpp field

Configuration Management:
- Refactor handlers for ConfigurePreset and BuildPreset changes
- Remove unsupported CMakePresets warning (now fully supported)
- Implement getToolchainFile() for both Kit and Preset modes
- Update initConfigValues() to work with both configuration types

Shared Infrastructure:
- Move vcpkg search logic to qt-lib for cross-extension reuse
- Rename SELECTED_KIT_PATH → INSTALLATION_PATH for clarity
- Rename findQtPathsInKitDir() → findQtPathsInInstallationPath()
- Update dependent extensions (qt-qml, qt-ui) to use new constant

Task-number: [VSCODEEXT-64](https://bugreports.qt.io/browse/VSCODEEXT-64)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
