### PR TITLE
qt-lib, qt-python, qt-qml, qt-ui, qt-core: Add PySide QMLLS support

### DIFF
--- a/qt-core/src/translation.ts
+++ b/qt-core/src/translation.ts
@@ -15,7 +15,8 @@ import {
   OSExeSuffix,
   searchForExeInQtInfo,
   telemetry,
-  QtWorkspaceFeatures
+  QtWorkspaceFeatures,
+  PySideEnvData
 } from 'qt-lib';
 import { coreAPI, projectManager } from '@/extension';
 import { EXTENSION_ID } from '@/constants';
@@ -45,9 +46,9 @@ export async function openInLinguistCommand() {
     project.folder,
     CoreKey.WORKSPACE_FEATURES
   );
-  const venvBinPath = coreAPI?.getValue<string>(
+  const pysideEnv = coreAPI?.getValue<PySideEnvData>(
     project.folder,
-    CoreKey.VENV_BIN_PATH
+    CoreKey.PYSIDE_ENV_DATA
   );
   const selectedKitPath = coreAPI?.getValue<string>(
     project.folder,
@@ -60,8 +61,10 @@ export async function openInLinguistCommand() {
   let linguistPath: string | undefined;
 
   if (workspaceFeatures?.projectTypes.pyside) {
-    if (venvBinPath) {
-      linguistPath = await locateLinguistFromVenvBinPaths(venvBinPath);
+    if (pysideEnv?.venvBinPath) {
+      linguistPath = await locateLinguistFromVenvBinPaths(
+        pysideEnv.venvBinPath
+      );
     }
   }
 

--- a/qt-lib/src/constants.ts
+++ b/qt-lib/src/constants.ts
@@ -8,7 +8,7 @@ export const CORE_EXTENSION_ID = 'qt-core';
 export const CoreKey = {
   ADDITIONAL_QT_PATHS: 'additionalQtPaths',
   QT_INSTALLATION_ROOT: 'qtInstallationRoot',
-  VENV_BIN_PATH: 'venvBinPath',
+  PYSIDE_ENV_DATA: 'pysideEnvData',
   WORKSPACE_FEATURES: 'workspaceFeatures',
   SELECTED_KIT_PATH: 'selectedKitPath',
   SELECTED_QT_PATHS: 'selectedQtPaths',

--- a/qt-lib/src/core-api.ts
+++ b/qt-lib/src/core-api.ts
@@ -10,6 +10,11 @@ export interface QtAdditionalPath {
   isVCPKG?: boolean;
 }
 
+export interface PySideEnvData {
+  venvBinPath?: string;
+  qmlImportPath?: string;
+}
+
 // Implement sorter for QtAdditionalPath
 export function compareQtAdditionalPath(
   a: QtAdditionalPath,
@@ -31,6 +36,7 @@ export type ConfigType =
   | string
   | QtAdditionalPath[]
   | QtWorkspaceFeatures
+  | PySideEnvData
   | undefined;
 
 export type QtWorkspaceConfig = Map<string, ConfigType>;

--- a/qt-python/src/builder.ts
+++ b/qt-python/src/builder.ts
@@ -1,55 +1,58 @@
 // Copyright (C) 2025 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
+import * as fs from 'fs';
 import * as path from 'path';
 import * as childProcess from 'child_process';
 
 import { IsWindows } from 'qt-lib';
-import { PySideEnv } from './env';
 
-export interface PySideCommandBuildOptions {
-  useVenv?: boolean;
-  cwd?: string;
+export interface PySideCommandBuildOutput {
+  shellPath: string;
+  shellArgs: string[];
+  venvActivationCommand: string;
+  commandLine: string;
 }
 
 export class PySideCommandBuilder {
-  private readonly _shellPath: string;
-  private readonly _shellArgs: string[];
-  private readonly _venvActivationCommand: string;
+  private _venvBinPath: string | undefined;
+  private _useVenv: boolean | undefined;
+  private _cwd: string | undefined;
 
-  constructor(
-    private readonly _env: PySideEnv,
-    private readonly _options?: PySideCommandBuildOptions
-  ) {
-    this._shellPath = resolveShellPath();
-    this._shellArgs = [IsWindows ? '/c' : '-c'];
-    this._venvActivationCommand = resolveVenvActivationCommand(this._env);
+  public venvBinPath(p: string | undefined) {
+    this._venvBinPath = p;
+    return this;
   }
 
-  get shellPath(): string {
-    return this._shellPath;
+  public useVenv(use: boolean | undefined) {
+    this._useVenv = use;
+    return this;
   }
 
-  get shellArgs(): string[] {
-    return this._shellArgs;
-  }
-
-  get venvActivationCommand(): string {
-    return this._venvActivationCommand;
+  public cwd(cwd: string | undefined) {
+    this._cwd = cwd;
+    return this;
   }
 
   public build(command: string) {
     const all: string[] = [command];
 
-    if (this._options?.cwd) {
-      all.unshift(`cd ${enclosePath(this._options.cwd)}`);
+    if (this._cwd) {
+      all.unshift(`cd ${enclosePath(this._cwd)}`);
     }
 
-    if (this._options?.useVenv && this._venvActivationCommand) {
-      all.unshift(this._venvActivationCommand);
+    const activation =
+      this._venvBinPath && resolveVenvActivationCommand(this._venvBinPath);
+    if (this._useVenv && activation) {
+      all.unshift(activation);
     }
 
-    return all.join(' && ');
+    return {
+      shellPath: resolveShellPath(),
+      shellArgs: [IsWindows ? '/c' : '-c'],
+      venvActivationCommand: activation,
+      commandLine: all.join(' && ')
+    };
   }
 }
 
@@ -64,14 +67,13 @@ function resolveShellPath(): string {
   return result.status === 0 && found ? found : '/bin/bash';
 }
 
-function resolveVenvActivationCommand(env: PySideEnv): string {
-  const bin = env.venvBinPath;
-  if (!bin) {
+function resolveVenvActivationCommand(venvBinPath: string): string {
+  if (!venvBinPath || !fs.existsSync(venvBinPath)) {
     return '';
   }
 
   const script = enclosePath(
-    path.join(bin, IsWindows ? 'activate.bat' : 'activate')
+    path.join(venvBinPath, IsWindows ? 'activate.bat' : 'activate')
   );
 
   return IsWindows ? script : `source ${script}`;

--- a/qt-python/src/constants.ts
+++ b/qt-python/src/constants.ts
@@ -12,6 +12,7 @@ export const COMMAND_SHOW_LOG = 'showLogOutputChannel';
 export const COMMAND_INSTALL_PYSIDE = 'installPySide6'; // contributes > commands
 export const COMMAND_PYTHON_CREATE_ENV = 'python.createEnvironment';
 export const COMMAND_PYTHON_SELECT_PYTHON = 'python.setInterpreter';
+export const COMMAND_RESTART_QMLLS = 'qt-qml.restartQmlls';
 
 export const TASK_TYPE = 'pyside'; // contributes > taskDefinitions
 export const TASK_SOURCE = 'PySide';

--- a/qt-python/src/env.ts
+++ b/qt-python/src/env.ts
@@ -4,6 +4,9 @@
 import * as path from 'path';
 import { Environment } from '@vscode/python-extension';
 
+import { isError } from 'qt-lib';
+import { PySidePackageInfo } from './types';
+import { PySideCommandRunner } from './runner';
 import * as utils from './utils';
 import * as consts from './constants';
 
@@ -31,5 +34,43 @@ export class PySideEnv {
 
   get interpreterPath(): string | undefined {
     return this._pyEnv?.executable.uri?.fsPath;
+  }
+
+  public async readPySide6PackageInfo(outputHandler?: (line: string) => void) {
+    const parsedOutput: Record<string, string> = {};
+
+    try {
+      // expected output from 'pip show <package>'
+      //
+      // Version: 6.10.0
+      // Summary: Python bindings for the Qt cross-platform application and UI framework
+      // Home-page:
+      // Author:
+      // Author-email: Qt for Python Team <pyside@qt-project.org>
+      // License: LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+      // Location: /Users/bencho/ws_temp/myenv/lib/python3.9/site-packages
+      // Requires: PySide6_Essentials, PySide6_Addons, shiboken6
+      // Required-by:
+
+      const runner = new PySideCommandRunner(this);
+      runner.onStdout(outputHandler);
+      runner.onStderr(outputHandler);
+
+      const lines = await runner.run(`pip show PySide6`, { useVenv: true });
+      lines.forEach((line) => {
+        const [key, value] = line.split(': ');
+        if (key && value) {
+          parsedOutput[key.trim()] = value.trim();
+        }
+      });
+    } catch (e) {
+      outputHandler?.(isError(e) ? e.message : String(e));
+      return undefined;
+    }
+
+    return {
+      version: parsedOutput.Version ?? '',
+      location: parsedOutput.Location ?? ''
+    } as PySidePackageInfo;
   }
 }

--- a/qt-python/src/installer.ts
+++ b/qt-python/src/installer.ts
@@ -14,6 +14,7 @@ import {
 } from 'qt-lib';
 import { PySideEnv } from './env';
 import { PySideProject } from './project';
+import { PySidePackageInfo } from './types';
 import { PySideCommandRunner } from './runner';
 import { coreApi, projectManager } from './extension';
 import { normalizeDriveLetter } from './utils';
@@ -91,12 +92,17 @@ async function checkInstallation(project: PySideProject): Promise<CheckResult> {
     return { status: 'noVenv', folder };
   }
 
-  const pysideVersion = await fetchPySide6Version(env);
-  if (!pysideVersion) {
+  const pyside = await fetchPySide6Version(env);
+  if (!pyside) {
     return { status: 'noPySide', folder, env };
   }
 
-  return { status: 'alreadyInstalled', folder, env, pysideVersion };
+  return {
+    status: 'alreadyInstalled',
+    folder,
+    env,
+    pysideVersion: pyside.version
+  };
 }
 
 async function showMessageOrInstall(result: CheckResult) {
@@ -186,12 +192,14 @@ async function tryInstallPySide(
       return;
     }
 
-    const pyside6Version = await fetchPySide6Version(env);
-    if (pyside6Version) {
+    await projectManager.refreshEnv(folder);
+
+    const pyside = await fetchPySide6Version(env);
+    if (pyside) {
       void vscode.window.showInformationMessage(
         texts.install.popup.installed(
           folder.name,
-          pyside6Version,
+          pyside.version,
           env.venvName ?? ''
         )
       );
@@ -283,33 +291,44 @@ const info = (folder: vscode.WorkspaceFolder, ...message: string[]) => {
   logger.info(`(${folder.name}) `, ...message);
 };
 
-async function fetchPySide6Version(env: PySideEnv) {
+export async function fetchPySide6Version(env: PySideEnv) {
   const logIndented = (line: string) => {
     logger.info(' ', line);
   };
 
+  const parsedOutput: Record<string, string> = {};
+
   try {
     // expected output from 'pip show <package>'
     //
-    // Name: PySide6_Essentials
-    // Version: 6.7.0+commercial
-    // Summary: Python bindings for the Qt cross-platform ...
+    // Version: 6.10.0
+    // Summary: Python bindings for the Qt cross-platform application and UI framework
+    // Home-page:
+    // Author:
+    // Author-email: Qt for Python Team <pyside@qt-project.org>
+    // License: LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+    // Location: /Users/bencho/ws_temp/myenv/lib/python3.9/site-packages
+    // Requires: PySide6_Essentials, PySide6_Addons, shiboken6
+    // Required-by:
 
     const runner = new PySideCommandRunner(env);
     runner.onStdout(logIndented);
     runner.onStderr(logIndented);
 
-    const output = await runner.run(`pip show PySide6`, { useVenv: true });
-
-    for (const line of output) {
-      const [key, value] = line.split(':');
-      if (key?.toLowerCase() === 'version' && value) {
-        return value.trim();
+    const lines = await runner.run(`pip show PySide6`, { useVenv: true });
+    lines.forEach((line) => {
+      const [key, value] = line.split(': ');
+      if (key && value) {
+        parsedOutput[key.trim()] = value.trim();
       }
-    }
+    });
   } catch (e) {
     logger.error(isError(e) ? e.message : String(e));
+    return undefined;
   }
 
-  return undefined;
+  return {
+    version: parsedOutput.Version ?? '',
+    location: parsedOutput.Location ?? ''
+  } as PySidePackageInfo;
 }

--- a/qt-python/src/installer.ts
+++ b/qt-python/src/installer.ts
@@ -6,7 +6,6 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import {
-  isError,
   CoreKey,
   createLogger,
   QtInsRootConfigName,
@@ -14,7 +13,6 @@ import {
 } from 'qt-lib';
 import { PySideEnv } from './env';
 import { PySideProject } from './project';
-import { PySidePackageInfo } from './types';
 import { PySideCommandRunner } from './runner';
 import { coreApi, projectManager } from './extension';
 import { normalizeDriveLetter } from './utils';
@@ -92,7 +90,10 @@ async function checkInstallation(project: PySideProject): Promise<CheckResult> {
     return { status: 'noVenv', folder };
   }
 
-  const pyside = await fetchPySide6Version(env);
+  const logIndented = (line: string) => {
+    logger.info(' ', line);
+  };
+  const pyside = await env.readPySide6PackageInfo(logIndented);
   if (!pyside) {
     return { status: 'noPySide', folder, env };
   }
@@ -194,7 +195,7 @@ async function tryInstallPySide(
 
     await projectManager.refreshEnv(folder);
 
-    const pyside = await fetchPySide6Version(env);
+    const pyside = await env.readPySide6PackageInfo(logIndented);
     if (pyside) {
       void vscode.window.showInformationMessage(
         texts.install.popup.installed(
@@ -290,45 +291,3 @@ async function getLocalPackageInfo(insRoot: string, env: PySideEnv) {
 const info = (folder: vscode.WorkspaceFolder, ...message: string[]) => {
   logger.info(`(${folder.name}) `, ...message);
 };
-
-export async function fetchPySide6Version(env: PySideEnv) {
-  const logIndented = (line: string) => {
-    logger.info(' ', line);
-  };
-
-  const parsedOutput: Record<string, string> = {};
-
-  try {
-    // expected output from 'pip show <package>'
-    //
-    // Version: 6.10.0
-    // Summary: Python bindings for the Qt cross-platform application and UI framework
-    // Home-page:
-    // Author:
-    // Author-email: Qt for Python Team <pyside@qt-project.org>
-    // License: LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
-    // Location: /Users/bencho/ws_temp/myenv/lib/python3.9/site-packages
-    // Requires: PySide6_Essentials, PySide6_Addons, shiboken6
-    // Required-by:
-
-    const runner = new PySideCommandRunner(env);
-    runner.onStdout(logIndented);
-    runner.onStderr(logIndented);
-
-    const lines = await runner.run(`pip show PySide6`, { useVenv: true });
-    lines.forEach((line) => {
-      const [key, value] = line.split(': ');
-      if (key && value) {
-        parsedOutput[key.trim()] = value.trim();
-      }
-    });
-  } catch (e) {
-    logger.error(isError(e) ? e.message : String(e));
-    return undefined;
-  }
-
-  return {
-    version: parsedOutput.Version ?? '',
-    location: parsedOutput.Location ?? ''
-  } as PySidePackageInfo;
-}

--- a/qt-python/src/project-manager.ts
+++ b/qt-python/src/project-manager.ts
@@ -21,6 +21,7 @@ import { PySideProject } from './project';
 import { PySideProjectInfo } from './types';
 import { pyApi, coreApi } from './extension';
 import * as consts from '@/constants';
+import { fetchPySide6Version } from './installer';
 
 type Folder = vscode.WorkspaceFolder;
 type Context = vscode.ExtensionContext;
@@ -49,8 +50,20 @@ export class PySideProjectManager extends ProjectManager<PySideProject> {
       return;
     }
 
-    project.env = await resolveEnv(pyApi, folder);
-    setCoreAndNotify(folder, CoreKey.VENV_BIN_PATH, project.env?.venvBinPath);
+    const env = await resolveEnv(pyApi, folder);
+    const pyside = env && (await fetchPySide6Version(env));
+    const qmlImportPath = pyside?.location
+      ? path.normalize(path.join(pyside.location, 'PySide6/qml'))
+      : '';
+
+    project.env = env;
+
+    setCoreAndNotify(folder, CoreKey.PYSIDE_ENV_DATA, {
+      venvBinPath: env?.venvBinPath ?? '',
+      qmlImportPath
+    });
+
+    void vscode.commands.executeCommand(consts.COMMAND_RESTART_QMLLS);
   }
 
   private _refreshProjectInfo(folder: Folder) {

--- a/qt-python/src/project-manager.ts
+++ b/qt-python/src/project-manager.ts
@@ -21,7 +21,6 @@ import { PySideProject } from './project';
 import { PySideProjectInfo } from './types';
 import { pyApi, coreApi } from './extension';
 import * as consts from '@/constants';
-import { fetchPySide6Version } from './installer';
 
 type Folder = vscode.WorkspaceFolder;
 type Context = vscode.ExtensionContext;
@@ -50,8 +49,12 @@ export class PySideProjectManager extends ProjectManager<PySideProject> {
       return;
     }
 
+    const logIndented = (line: string) => {
+      logger.info(' ', line);
+    };
+
     const env = await resolveEnv(pyApi, folder);
-    const pyside = env && (await fetchPySide6Version(env));
+    const pyside = env && (await env.readPySide6PackageInfo(logIndented));
     const qmlImportPath = pyside?.location
       ? path.normalize(path.join(pyside.location, 'PySide6/qml'))
       : '';

--- a/qt-python/src/runner.ts
+++ b/qt-python/src/runner.ts
@@ -5,9 +5,14 @@ import * as childProcess from 'child_process';
 
 import { createLogger } from 'qt-lib';
 import { PySideEnv } from './env';
-import { PySideCommandBuilder, PySideCommandBuildOptions } from './builder';
+import { PySideCommandBuilder } from './builder';
 
 const logger = createLogger('runner');
+
+export interface PySideCommandRunOptions {
+  useVenv?: boolean;
+  cwd?: string;
+}
 
 export class PySideCommandRunner {
   private _onStdout: ((line: string) => void) | undefined;
@@ -23,20 +28,23 @@ export class PySideCommandRunner {
     this._onStderr = f;
   }
 
-  public async run(command: string, options?: PySideCommandBuildOptions) {
-    const builder = new PySideCommandBuilder(this._env, options);
-    const commandLine = builder.build(command);
+  public async run(command: string, options?: PySideCommandRunOptions) {
+    const cmd = new PySideCommandBuilder()
+      .venvBinPath(this._env.venvBinPath)
+      .useVenv(options?.useVenv)
+      .cwd(options?.cwd)
+      .build(command);
 
     logger.info('Running command');
-    logger.info(`- shell: ${builder.shellPath}`);
-    logger.info(`- command: ${commandLine}`);
+    logger.info(`- shell: ${cmd.shellPath}`);
+    logger.info(`- command: ${cmd.commandLine}`);
     logger.info(
       '- venv activation: ' +
         `${options?.useVenv ?? false}, ` +
-        builder.venvActivationCommand
+        cmd.venvActivationCommand
     );
 
-    const proc = childProcess.spawn(commandLine, { shell: builder.shellPath });
+    const proc = childProcess.spawn(cmd.commandLine, { shell: cmd.shellPath });
     const outPromise = streamToLines(proc.stdout, this._onStdout);
     const errPromise = streamToLines(proc.stderr, this._onStderr);
 

--- a/qt-python/src/task.ts
+++ b/qt-python/src/task.ts
@@ -74,12 +74,15 @@ function createTask(project: PySideProject, taskId: TaskId) {
     return undefined;
   }
 
-  const builder = new PySideCommandBuilder(env, { useVenv: true });
-  const commandLine = builder.build(createProjectToolCommand(taskId));
+  const cmd = new PySideCommandBuilder()
+    .useVenv(true)
+    .venvBinPath(env.venvBinPath)
+    .build(createProjectToolCommand(taskId));
+
   const shellOptions = {
     cwd: folder.uri.fsPath,
-    executable: builder.shellPath,
-    shellArgs: builder.shellArgs
+    executable: cmd.shellPath,
+    shellArgs: cmd.shellArgs
   };
 
   const def = {
@@ -89,7 +92,7 @@ function createTask(project: PySideProject, taskId: TaskId) {
 
   const task = new vscode.Task(def, folder, taskName, consts.TASK_SOURCE);
   task.detail = `${consts.PYSIDE_PROJECT_TOOL} ${action}`;
-  task.execution = new vscode.ShellExecution(commandLine, shellOptions);
+  task.execution = new vscode.ShellExecution(cmd.commandLine, shellOptions);
   task.presentationOptions = { clear: true };
 
   const group = findTaskGroup(taskId);

--- a/qt-python/src/types.ts
+++ b/qt-python/src/types.ts
@@ -14,3 +14,8 @@ export interface PySideProjectInfo {
   name: string;
   files: string[];
 }
+
+export interface PySidePackageInfo {
+  version: string;
+  location: string;
+}

--- a/qt-qml/src/qmlls.ts
+++ b/qt-qml/src/qmlls.ts
@@ -20,7 +20,9 @@ import {
   compareVersions,
   CoreKey,
   telemetry,
-  resolveConfiguration
+  resolveConfiguration,
+  PySideEnvData,
+  QtWorkspaceFeatures
 } from 'qt-lib';
 import { coreAPI, projectManager } from '@/extension';
 import { EXTENSION_ID } from '@/constants';
@@ -289,6 +291,25 @@ export class Qmlls {
         'additionalImportPaths',
         []
       );
+
+      if (coreAPI) {
+        const workspaceFeatures = coreAPI.getValue<QtWorkspaceFeatures>(
+          this._folder,
+          CoreKey.WORKSPACE_FEATURES
+        );
+
+        const pysideEnv = coreAPI.getValue<PySideEnvData>(
+          this._folder,
+          CoreKey.PYSIDE_ENV_DATA
+        );
+
+        if (
+          workspaceFeatures?.projectTypes.pyside &&
+          pysideEnv?.qmlImportPath
+        ) {
+          additionalImportPaths.push(pysideEnv.qmlImportPath);
+        }
+      }
 
       let docsPath = configs.get<string>('customDocsPath', '');
       if (docsPath) {

--- a/qt-ui/src/project-manager.ts
+++ b/qt-ui/src/project-manager.ts
@@ -8,7 +8,8 @@ import {
   ProjectManager,
   createLogger,
   QtWorkspaceFeatures,
-  CoreKey
+  CoreKey,
+  PySideEnvData
 } from 'qt-lib';
 import * as consts from '@/constants';
 import { coreAPI } from '@/extension';
@@ -78,9 +79,9 @@ export class UIProjectManager extends ProjectManager<UIProject> {
         continue;
       }
 
-      if (key === CoreKey.VENV_BIN_PATH) {
-        const value = coreAPI?.getValue<string>(folder, key);
-        await project.setVenvBinPath(value);
+      if (key === CoreKey.PYSIDE_ENV_DATA) {
+        const value = coreAPI?.getValue<PySideEnvData>(folder, key);
+        await project.setPySideEnv(value);
       }
     }
   };

--- a/qt-ui/src/project.ts
+++ b/qt-ui/src/project.ts
@@ -9,7 +9,8 @@ import {
   createLogger,
   resolveConfiguration,
   QtWorkspaceFeatures,
-  CoreKey
+  CoreKey,
+  PySideEnvData
 } from 'qt-lib';
 import * as consts from '@/constants';
 import { coreAPI } from '@/extension';
@@ -27,7 +28,7 @@ type UpdateReason =
   | 'workspaceFeatureChanged'
   | 'selectedKitPathChanged'
   | 'selectedQtPathsChanged'
-  | 'venvBinPathChanged';
+  | 'pythonEnvDataChanged';
 
 const logger = createLogger('project');
 
@@ -45,7 +46,7 @@ export class UIProject implements Project {
   private _workspaceFeatures: QtWorkspaceFeatures | undefined;
   private _selectedKitPath: string | undefined;
   private _selectedQtPaths: string | undefined;
-  private _venvBinPath: string | undefined;
+  private _pythonEnvData: PySideEnvData | undefined;
 
   private _designerClient: DesignerClient | undefined;
   private readonly _designerServer: DesignerServer;
@@ -97,7 +98,10 @@ export class UIProject implements Project {
       this._folder,
       CoreKey.SELECTED_QT_PATHS
     );
-    this._venvBinPath = read<string>(this._folder, CoreKey.VENV_BIN_PATH);
+    this._pythonEnvData = read<PySideEnvData>(
+      this._folder,
+      CoreKey.PYSIDE_ENV_DATA
+    );
 
     await this._updateClient('init');
   }
@@ -132,10 +136,10 @@ export class UIProject implements Project {
     }
   }
 
-  public async setVenvBinPath(venvBinPath: string | undefined) {
-    if (this._venvBinPath !== venvBinPath) {
-      this._venvBinPath = venvBinPath;
-      await this._updateClient('venvBinPathChanged');
+  public async setPySideEnv(data: PySideEnvData | undefined) {
+    if (this._pythonEnvData !== data) {
+      this._pythonEnvData = data;
+      await this._updateClient('pythonEnvDataChanged');
     }
   }
 
@@ -186,8 +190,8 @@ export class UIProject implements Project {
     }
 
     if (this._workspaceFeatures?.projectTypes.pyside) {
-      if (this._venvBinPath) {
-        return locateDesignerFromVenvBinPaths(this._venvBinPath);
+      if (this._pythonEnvData?.venvBinPath) {
+        return locateDesignerFromVenvBinPaths(this._pythonEnvData.venvBinPath);
       }
     }
 


### PR DESCRIPTION
Replace `CoreKey.VENV_BIN_PATH` to `CoreKey.PYSIDE_ENV_DATA` 
to hold more information rather than the simple path to the venv.

Whenever the Python environment changes for a given folder, 
The qt-python extension updates the `PySideEnvData` and notify the core.
Our QML extension then uses the updated PysideEnvData when building the additionalImportPaths argument.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
