### PR TITLE
qt-cli: Preserve blank lines in Python templates and clean up others

### DIFF
--- a/qt-cli/src/assets/templates/cpp/class/templates.yml
+++ b/qt-cli/src/assets/templates/cpp/class/templates.yml
@@ -4,7 +4,7 @@ meta:
   type: file
   title: C++ class
   description: >-
-    Creates a C++ header and source file 
+    Creates a C++ header and source file
     for a new class that you can add to a C++ project.
 
 files:

--- a/qt-cli/src/assets/templates/projects/cpp/qtquick/CMakeLists.txt
+++ b/qt-cli/src/assets/templates/projects/cpp/qtquick/CMakeLists.txt
@@ -1,5 +1,5 @@
-{{- $target := printf "app%s" .name }}
-{{- $mininumQtVersionFloat := (.minimumQtVersion | Qt.ParseFloat) }}
+{{- $target := printf "app%s" .name -}}
+{{- $mininumQtVersionFloat := (.minimumQtVersion | Qt.ParseFloat) -}}
 cmake_minimum_required(VERSION 3.16)
 
 project({{ .name }} VERSION 0.1 LANGUAGES CXX)

--- a/qt-cli/src/assets/templates/projects/cpp/qtquick/main.cpp
+++ b/qt-cli/src/assets/templates/projects/cpp/qtquick/main.cpp
@@ -1,4 +1,4 @@
-{{- $mininumQtVersionFloat := (.minimumQtVersion | Qt.ParseFloat) }}
+{{- $mininumQtVersionFloat := (.minimumQtVersion | Qt.ParseFloat) -}}
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 

--- a/qt-cli/src/assets/templates/projects/python/qtquick/main.py
+++ b/qt-cli/src/assets/templates/projects/python/qtquick/main.py
@@ -8,9 +8,11 @@ from PySide6.QtQml import QQmlApplicationEngine
 
 if __name__ == "__main__":
     app = QGuiApplication(sys.argv)
+
     engine = QQmlApplicationEngine()
     qml_file = Path(__file__).resolve().parent / "main.qml"
     engine.load(qml_file)
     if not engine.rootObjects():
         sys.exit(-1)
+
     sys.exit(app.exec())

--- a/qt-cli/src/assets/templates/projects/python/qtquick/templates.yml
+++ b/qt-cli/src/assets/templates/projects/python/qtquick/templates.yml
@@ -15,3 +15,7 @@ files:
   - in: '@/common/git.ignore'
     out: .gitignore
     bypass: true
+
+options:
+  polish:
+    compressEmptyLines: false

--- a/qt-cli/src/assets/templates/projects/python/qwidget/main.py
+++ b/qt-cli/src/assets/templates/projects/python/qwidget/main.py
@@ -1,14 +1,15 @@
 # This Python file uses the following encoding: utf-8
 import sys
+
 from PySide6.QtWidgets import QApplication, {{ .baseClass }}
 
 {{- if .useForm }}
+
 # Important:
 # You need to run the following command to generate the ui_form.py file
 #     pyside6-uic form.ui -o ui_form.py
 from ui_form import Ui_{{ .className }}
 {{- end }}
-
 
 class {{ .className }}({{ .baseClass }}):
     def __init__(self, parent=None):
@@ -22,6 +23,8 @@ class {{ .className }}({{ .baseClass }}):
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
+
     widget = {{ .className }}()
     widget.show()
+
     sys.exit(app.exec())

--- a/qt-cli/src/assets/templates/projects/python/qwidget/templates.yml
+++ b/qt-cli/src/assets/templates/projects/python/qwidget/templates.yml
@@ -35,3 +35,6 @@ fields:
       {{ else }}widget
       {{ end }}
 
+options:
+  polish:
+    compressEmptyLines: false


### PR DESCRIPTION
Turn off the `polish.compressEmptyLines` option in Python templates 
to comply with PEP8 (https://peps.python.org/pep-0008/#blank-lines)

Some others templates are updated to remove trailing spaces.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
