### PR TITLE
qt-python: Monitor changes of the virtual environment

### DIFF
--- a/qt-python/src/env.ts
+++ b/qt-python/src/env.ts
@@ -2,19 +2,68 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 import * as path from 'path';
+import * as vscode from 'vscode';
 import { Environment } from '@vscode/python-extension';
 
-import { isError } from 'qt-lib';
+import { isError, OSExeSuffix } from 'qt-lib';
 import { PySidePackageInfo } from './types';
 import { PySideCommandRunner } from './runner';
+import { pyApi } from './extension';
 import * as utils from './utils';
 import * as consts from './constants';
 
 export class PySideEnv {
-  private readonly _pyEnv: Environment | undefined;
+  private _disposables: vscode.Disposable[] = [];
 
-  constructor(pyenv?: Environment) {
-    this._pyEnv = pyenv;
+  constructor(
+    private readonly _folder: vscode.WorkspaceFolder,
+    private _pyEnv?: Environment
+  ) {
+    const folder = this._folder;
+    const isVenv = this._pyEnv?.environment?.type === 'VirtualEnvironment';
+
+    if (isVenv) {
+      const sysPrefix = this._pyEnv?.executable.sysPrefix;
+      if (sysPrefix) {
+        const pattern = new vscode.RelativePattern(
+          vscode.Uri.file(sysPrefix),
+          '/'
+        );
+        const watcher = vscode.workspace.createFileSystemWatcher(pattern);
+        watcher.onDidDelete(() => {
+          watcher.dispose();
+          this._pyEnv = undefined;
+          if (pyApi) {
+            void pyApi.environments.updateActiveEnvironmentPath('', folder);
+          }
+        });
+        this._disposables.push(watcher);
+      }
+      return;
+    }
+
+    const pythonPathRel = path.join(
+      '.venv',
+      consts.VENV_BIN_DIR,
+      'python' + OSExeSuffix
+    );
+    const pattern = new vscode.RelativePattern(folder.uri, pythonPathRel);
+    const watcher = vscode.workspace.createFileSystemWatcher(pattern);
+    watcher.onDidCreate(() => {
+      watcher.dispose();
+      if (pyApi) {
+        const pythonPath = path.join(folder.uri.fsPath, pythonPathRel);
+        void pyApi.environments.updateActiveEnvironmentPath(pythonPath, folder);
+      }
+    });
+    this._disposables.push(watcher);
+  }
+
+  public dispose() {
+    this._disposables.forEach((w) => {
+      w.dispose();
+    });
+    this._disposables = [];
   }
 
   public isVenv(): boolean {

--- a/qt-python/src/project-manager.ts
+++ b/qt-python/src/project-manager.ts
@@ -120,7 +120,7 @@ async function resolveEnv(pyapi: PyApi | undefined, folder: Folder) {
   const envs = pyapi.environments;
   const envPath = envs.getActiveEnvironmentPath(folder);
   const resolved = await envs.resolveEnvironment(envPath);
-  return resolved ? new PySideEnv(resolved) : undefined;
+  return resolved ? new PySideEnv(folder, resolved) : undefined;
 }
 
 function parseToml(absPath: string): PySideProjectInfo | undefined {

--- a/qt-python/src/project.ts
+++ b/qt-python/src/project.ts
@@ -22,6 +22,7 @@ export class PySideProject implements Project {
 
   dispose() {
     logger.info(`Dispose: "${this._folder.uri.fsPath}"`);
+    this._env?.dispose();
   }
 
   get env() {


### PR DESCRIPTION
Add a file system watcher to detect:
- Removal of the virtual environment itself
- Creating of a virtual environment under `.venv/`

This ensures consistency of the virtual environment configuration across various scenarios.

For example, when the assigned virtual environment is removed, the python extension doesn't fire the expected event. It only updates according to its own internal logic.

In such cases, we need to set the active environment path to an invalid value so that our extension's internal state remains consistent.

When no valid virtual environment is assigned,
we monitor the creation of a virtual environment under .venv/ and automatically select it when a python interpreter is created there. This again ensures the internal consistency when a virtual environment is created using either the python extension's command or terminal.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
