### PR TITLE
qt-python: Fix picking up global environment when running command

### DIFF
--- a/qt-python/src/builder.ts
+++ b/qt-python/src/builder.ts
@@ -1,7 +1,6 @@
 // Copyright (C) 2025 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
-import * as fs from 'fs';
 import * as path from 'path';
 import * as childProcess from 'child_process';
 
@@ -10,7 +9,6 @@ import { IsWindows } from 'qt-lib';
 export interface PySideCommandBuildOutput {
   shellPath: string;
   shellArgs: string[];
-  venvActivationCommand: string;
   commandLine: string;
 }
 
@@ -41,16 +39,13 @@ export class PySideCommandBuilder {
       all.unshift(`cd ${enclosePath(this._cwd)}`);
     }
 
-    const activation =
-      this._venvBinPath && resolveVenvActivationCommand(this._venvBinPath);
-    if (this._useVenv && activation) {
-      all.unshift(activation);
+    if (this._useVenv) {
+      all.unshift(makeVenvActivationCommand(this._venvBinPath ?? '<no-venv>'));
     }
 
     return {
       shellPath: resolveShellPath(),
       shellArgs: [IsWindows ? '/c' : '-c'],
-      venvActivationCommand: activation,
       commandLine: all.join(' && ')
     };
   }
@@ -67,11 +62,7 @@ function resolveShellPath(): string {
   return result.status === 0 && found ? found : '/bin/bash';
 }
 
-function resolveVenvActivationCommand(venvBinPath: string): string {
-  if (!venvBinPath || !fs.existsSync(venvBinPath)) {
-    return '';
-  }
-
+function makeVenvActivationCommand(venvBinPath: string): string {
   const script = enclosePath(
     path.join(venvBinPath, IsWindows ? 'activate.bat' : 'activate')
   );

--- a/qt-python/src/runner.ts
+++ b/qt-python/src/runner.ts
@@ -37,12 +37,8 @@ export class PySideCommandRunner {
 
     logger.info('Running command');
     logger.info(`- shell: ${cmd.shellPath}`);
+    logger.info(`- venv activation: ${options?.useVenv ?? false}`);
     logger.info(`- command: ${cmd.commandLine}`);
-    logger.info(
-      '- venv activation: ' +
-        `${options?.useVenv ?? false}, ` +
-        cmd.venvActivationCommand
-    );
 
     const proc = childProcess.spawn(cmd.commandLine, { shell: cmd.shellPath });
     const outPromise = streamToLines(proc.stdout, this._onStdout);


### PR DESCRIPTION
The previous implementation produced an empty string for a virtual environment activation command, which was not considered as an error by the shell.

In such cases, the following command would succeed, but it would run in the global environment, causing unintended behavior.

For example, when retrieving PySide6 installation information by running a `pip` command with no virtual environment installed, it would fetch the information from the global environment which is incorrect.

This patch fixes the issue.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
