### PR TITLE
Remove duplication in test infrastructure && clean up packaging artifacts

### DIFF
--- a/extension_packs/cpp/package.json
+++ b/extension_packs/cpp/package.json
@@ -43,6 +43,6 @@
   ],
   "scripts": {
     "vscode:prepublish": "git rev-parse HEAD > commit",
-    "package": "vsce package"
+    "package": "vsce package && rm commit"
   }
 }

--- a/extension_packs/python/package.json
+++ b/extension_packs/python/package.json
@@ -40,6 +40,6 @@
   ],
   "scripts": {
     "vscode:prepublish": "git rev-parse HEAD > commit",
-    "package": "vsce package"
+    "package": "vsce package && rm commit"
   }
 }

--- a/extension_packs/qt/package.json
+++ b/extension_packs/qt/package.json
@@ -40,6 +40,6 @@
   ],
   "scripts": {
     "vscode:prepublish": "git rev-parse HEAD > commit",
-    "package": "vsce package"
+    "package": "vsce package && rm commit"
   }
 }

--- a/extension_packs/wasm/package.json
+++ b/extension_packs/wasm/package.json
@@ -47,6 +47,6 @@
   ],
   "scripts": {
     "vscode:prepublish": "git rev-parse HEAD > commit",
-    "package": "vsce package"
+    "package": "vsce package && rm commit"
   }
 }

--- a/qt-core/package.json
+++ b/qt-core/package.json
@@ -262,7 +262,7 @@
     "prettierWrite": "npm run prettierBase -- --write \"**/*.{js,ts,mts,json,mjs,cjs,mts}\" --log-level silent",
     "prettierCheck": "npm run prettierBase -- --check \"**/*.{js,ts,mts,json,mjs,cjs,mts}\"",
     "prettierBase": "prettier --config \"../common/.prettierrc\" --ignore-path \"../common/.prettierignore\" --cache --cache-strategy metadata",
-    "package": "vsce package --out out",
+    "package": "vsce package --out out && rm commit",
     "ci:all": "npm run ci:webview && npm ci",
     "install:all": "npm run install:webview && npm install",
     "ci:webview": "cd webview-ui && npm ci",

--- a/qt-cpp/package.json
+++ b/qt-cpp/package.json
@@ -286,7 +286,7 @@
     "prettierWrite": "npm run prettierBase -- --write \"**/*.{js,ts,mts,json,mjs,cjs}\" --log-level silent",
     "prettierCheck": "npm run prettierBase -- --check \"**/*.{js,ts,mts,json,mjs,cjs}\"",
     "prettierBase": "prettier --config \"../common/.prettierrc\" --ignore-path \"../common/.prettierignore\" --cache --cache-strategy metadata",
-    "package": "vsce package --out out"
+    "package": "vsce package --out out && rm commit"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.0",

--- a/qt-cpp/test/runTest.build.mts
+++ b/qt-cpp/test/runTest.build.mts
@@ -2,48 +2,16 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 import * as path from 'path';
-import * as fs from 'fs';
 import * as os from 'os';
 import * as fsp from 'fs/promises';
 
-const QT_INS_ROOT_CONFIG_NAME = 'qtInstallationRoot';
+import { downloadAndUnzipVSCode, runTests } from '@vscode/test-electron';
 
 import {
-  downloadAndUnzipVSCode,
-  resolveCliArgsFromVSCodeExecutablePath,
-  runTests
-} from '@vscode/test-electron';
-
-import {
-  getLocalQtCore,
-  getQuietVSCodeArgs
-} from '../../qt-lib/src/test-constants.js';
-
-import {
-  parseVSCodeDirs,
-  installExtensionWithRetry,
-  debugListExtensions,
-  assertExtensionsInstalled,
-  getDebugLevel
-} from '../../qt-lib/src/test-vscode-install.js';
-
-// --- CLI arg parsing (no deps) ---------------------------------------------
-function getCliArg(name: string): string | undefined {
-  const flag = `--${name}`;
-  const argv = process.argv.slice(2);
-
-  for (let i = 0; i < argv.length; i++) {
-    const a: string = argv[i]!;
-    if (a === flag) {
-      const next = argv[i + 1];
-      return next ? next.trim() : undefined;
-    }
-    if (a.startsWith(flag + '=')) {
-      return a.slice(flag.length + 1).trim();
-    }
-  }
-  return undefined;
-}
+  setupTestInfrastructure,
+  setupVSCodeSettings,
+  installRequiredExtensions
+} from './runTestHelper.mjs';
 
 async function main() {
   try {
@@ -54,79 +22,16 @@ async function main() {
     // The path to the extension test script
     // Passed to --extensionTestsPath
     const extensionTestsPath = path.resolve(__dirname, './suite/index-build');
-    // Path to the local qt-core extension to be used during testing
-    const localQtCoreVsix = path.normalize(
-      path.resolve(__dirname, getLocalQtCore())
-    );
-    // Check that qt-core .vsix exists
-    if (!fs.existsSync(localQtCoreVsix)) {
-      console.error(`Required extension not found: ${localQtCoreVsix}`);
-      process.exit(1); // Fail early
-    }
+
     const vscodeExecutablePath = await downloadAndUnzipVSCode();
-    const [cli, ...args] =
-      resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
 
-    //--------------------
-    // Read from env (set this when launching tests)
-    // Prefer CLI over env
-    const cliQtRoot = getCliArg('qt-root');
-    const envQtRoot = process.env.QT_TEST_QT_ROOT?.trim();
-    const qtRoot = (cliQtRoot ?? envQtRoot)?.trim();
+    const { qtRoot, localQtCoreVsix, cli, args, userDataDir } =
+      await setupTestInfrastructure(vscodeExecutablePath);
 
-    if (!qtRoot) {
-      console.error(
-        [
-          'Qt root is required. Provide either:',
-          '  1) CLI:   --qt-root /absolute/path/to/Qt',
-          '  2) ENV:   QT_TEST_QT_ROOT=/absolute/path/to/Qt',
-          '',
-          'Examples:',
-          '  npm run test -- --qt-root=/Users/me/Qt',
-          '  QT_TEST_QT_ROOT=/Users/me/Qt npm run test'
-        ].join('\n')
-      );
-      process.exit(1);
-    }
-
-    // Reuse the dirs that @vscode/test-electron already configured
-    const { userDataDir, extensionsDir } = parseVSCodeDirs(args);
-    if (getDebugLevel() >= 1) {
-      console.log('[runTest][qt-cpp] CLI:', cli, 'args:', args.join(' '));
-      console.log('[runTest][qt-cpp] userDataDir:', userDataDir);
-      console.log('[runTest][qt-cpp] extensionsDir:', extensionsDir);
-    }
-
-    // Seed VS Code settings in that SAME user-data-dir
-    if (!userDataDir) {
-      console.error(
-        '[runTest] Could not determine userDataDir from VS Code args.'
-      );
-      process.exit(1);
-    }
-    const userDir = path.join(userDataDir, 'User');
-    fs.mkdirSync(userDir, { recursive: true });
-
-    const settingsPath = path.join(userDir, 'settings.json');
-    const settings = {
-      // VS Code setting key that qt-core reads:
-      [`qt-core.${QT_INS_ROOT_CONFIG_NAME}`]: qtRoot,
-      // Silence CMake Tools logs (trace/debug/info/warn → only errors)
-      'cmake.loggingLevel': 'error',
+    setupVSCodeSettings(userDataDir, qtRoot, {
       'cmake.configureOnOpen': false
-    };
-    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
-    console.log('[runTest] Wrote settings to:', settingsPath);
-
-    const quietArgs = [...args, ...getQuietVSCodeArgs()];
-    const required = ['ms-vscode.cmake-tools', localQtCoreVsix];
-    const requiredIds = ['ms-vscode.cmake-tools', 'theqtcompany.qt-core'];
-    // Install required extensions into the SAME profile/dir combo
-    for (const ext of required) {
-      installExtensionWithRetry(cli as string, quietArgs, ext);
-    }
-    debugListExtensions(cli as string, args);
-    assertExtensionsInstalled(cli as string, args, requiredIds);
+    });
+    installRequiredExtensions(cli, args, localQtCoreVsix);
 
     // The workspace folder we want to open
     const projectDir = path.resolve(__dirname, '../../test/projectFolder');

--- a/qt-cpp/test/runTest.mts
+++ b/qt-cpp/test/runTest.mts
@@ -2,46 +2,14 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 import * as path from 'path';
-import * as fs from 'fs';
 
-const QT_INS_ROOT_CONFIG_NAME = 'qtInstallationRoot';
-
-import {
-  downloadAndUnzipVSCode,
-  resolveCliArgsFromVSCodeExecutablePath,
-  runTests
-} from '@vscode/test-electron';
+import { downloadAndUnzipVSCode, runTests } from '@vscode/test-electron';
 
 import {
-  getLocalQtCore,
-  getQuietVSCodeArgs
-} from '../../qt-lib/src/test-constants.js';
-
-import {
-  parseVSCodeDirs,
-  installExtensionWithRetry,
-  debugListExtensions,
-  assertExtensionsInstalled,
-  getDebugLevel
-} from '../../qt-lib/src/test-vscode-install.js';
-
-// --- CLI arg parsing (no deps) ---------------------------------------------
-function getCliArg(name: string): string | undefined {
-  const flag = `--${name}`;
-  const argv = process.argv.slice(2);
-
-  for (let i = 0; i < argv.length; i++) {
-    const a: string = argv[i]!;
-    if (a === flag) {
-      const next = argv[i + 1];
-      return next ? next.trim() : undefined;
-    }
-    if (a.startsWith(flag + '=')) {
-      return a.slice(flag.length + 1).trim();
-    }
-  }
-  return undefined;
-}
+  setupTestInfrastructure,
+  setupVSCodeSettings,
+  installRequiredExtensions
+} from './runTestHelper.mjs';
 
 async function main() {
   try {
@@ -52,78 +20,14 @@ async function main() {
     // The path to the extension test script
     // Passed to --extensionTestsPath
     const extensionTestsPath = path.resolve(__dirname, './suite/index');
-    // Path to the local qt-core extension to be used during testing
-    const localQtCoreVsix = path.normalize(
-      path.resolve(__dirname, getLocalQtCore())
-    );
-    // Check that qt-core .vsix exists
-    if (!fs.existsSync(localQtCoreVsix)) {
-      console.error(`Required extension not found: ${localQtCoreVsix}`);
-      process.exit(1); // Fail early
-    }
+
     const vscodeExecutablePath = await downloadAndUnzipVSCode();
-    const [cli, ...args] =
-      resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
 
-    //--------------------
-    // Read from env (set this when launching tests)
-    // Prefer CLI over env
-    const cliQtRoot = getCliArg('qt-root');
-    const envQtRoot = process.env.QT_TEST_QT_ROOT?.trim();
-    const qtRoot = (cliQtRoot ?? envQtRoot)?.trim();
+    const { qtRoot, localQtCoreVsix, cli, args, userDataDir } =
+      await setupTestInfrastructure(vscodeExecutablePath);
 
-    if (!qtRoot) {
-      console.error(
-        [
-          'Qt root is required. Provide either:',
-          '  1) CLI:   --qt-root /absolute/path/to/Qt',
-          '  2) ENV:   QT_TEST_QT_ROOT=/absolute/path/to/Qt',
-          '',
-          'Examples:',
-          '  npm run test -- --qt-root=/Users/me/Qt',
-          '  QT_TEST_QT_ROOT=/Users/me/Qt npm run test'
-        ].join('\n')
-      );
-      process.exit(1);
-    }
-
-    // Reuse the dirs that @vscode/test-electron already configured
-    const { userDataDir, extensionsDir } = parseVSCodeDirs(args);
-    if (getDebugLevel() >= 1) {
-      console.log('[runTest][qt-cpp] CLI:', cli, 'args:', args.join(' '));
-      console.log('[runTest][qt-cpp] userDataDir:', userDataDir);
-      console.log('[runTest][qt-cpp] extensionsDir:', extensionsDir);
-    }
-
-    // Seed VS Code settings in that SAME user-data-dir
-    if (!userDataDir) {
-      console.error(
-        '[runTest] Could not determine userDataDir from VS Code args.'
-      );
-      process.exit(1);
-    }
-    const userDir = path.join(userDataDir, 'User');
-    fs.mkdirSync(userDir, { recursive: true });
-
-    const settingsPath = path.join(userDir, 'settings.json');
-    const settings = {
-      // VS Code setting key that qt-core reads:
-      [`qt-core.${QT_INS_ROOT_CONFIG_NAME}`]: qtRoot,
-      // Silence CMake Tools logs (trace/debug/info/warn → only errors)
-      'cmake.loggingLevel': 'error'
-    };
-    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
-    console.log('[runTest] Wrote settings to:', settingsPath);
-
-    const quietArgs = [...args, ...getQuietVSCodeArgs()];
-    const required = ['ms-vscode.cmake-tools', localQtCoreVsix];
-    const requiredIds = ['ms-vscode.cmake-tools', 'theqtcompany.qt-core'];
-    // Install required extensions into the SAME profile/dir combo
-    for (const ext of required) {
-      installExtensionWithRetry(cli as string, quietArgs, ext);
-    }
-    debugListExtensions(cli as string, args);
-    assertExtensionsInstalled(cli as string, args, requiredIds);
+    setupVSCodeSettings(userDataDir, qtRoot);
+    installRequiredExtensions(cli, args, localQtCoreVsix);
 
     // Run the integration tests (no need to pass launchArgs; we reused the same dirs)
     await runTests({

--- a/qt-cpp/test/runTestHelper.mts
+++ b/qt-cpp/test/runTestHelper.mts
@@ -1,0 +1,174 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { resolveCliArgsFromVSCodeExecutablePath } from '@vscode/test-electron';
+import {
+  getLocalQtCore,
+  getQuietVSCodeArgs
+} from '../../qt-lib/src/test-constants.js';
+import {
+  parseVSCodeDirs,
+  installExtensionWithRetry,
+  debugListExtensions,
+  assertExtensionsInstalled,
+  getDebugLevel
+} from '../../qt-lib/src/test-vscode-install.js';
+
+const QT_INS_ROOT_CONFIG_NAME = 'qtInstallationRoot';
+
+/**
+ * Parse a CLI argument by name (e.g., --qt-root or --qt-root=/path)
+ */
+export function getCliArg(name: string): string | undefined {
+  const flag = `--${name}`;
+  const argv = process.argv.slice(2);
+
+  for (let i = 0; i < argv.length; i++) {
+    const a: string = argv[i]!;
+    if (a === flag) {
+      const next = argv[i + 1];
+      return next ? next.trim() : undefined;
+    }
+    if (a.startsWith(flag + '=')) {
+      return a.slice(flag.length + 1).trim();
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Get and validate the Qt root path from CLI or environment
+ */
+export function getQtRoot(): string {
+  const cliQtRoot = getCliArg('qt-root');
+  const envQtRoot = process.env.QT_TEST_QT_ROOT?.trim();
+  const qtRoot = (cliQtRoot ?? envQtRoot)?.trim();
+
+  if (!qtRoot) {
+    console.error(
+      [
+        'Qt root is required. Provide either:',
+        '  1) CLI:   --qt-root /absolute/path/to/Qt',
+        '  2) ENV:   QT_TEST_QT_ROOT=/absolute/path/to/Qt',
+        '',
+        'Examples:',
+        '  npm run test -- --qt-root=/Users/me/Qt',
+        '  QT_TEST_QT_ROOT=/Users/me/Qt npm run test'
+      ].join('\n')
+    );
+    process.exit(1);
+  }
+
+  return qtRoot;
+}
+
+/**
+ * Verify that the required qt-core .vsix file exists
+ */
+export function verifyQtCoreVsix(): string {
+  const localQtCoreVsix = path.normalize(
+    path.resolve(__dirname, getLocalQtCore())
+  );
+
+  if (!fs.existsSync(localQtCoreVsix)) {
+    console.error(`Required extension not found: ${localQtCoreVsix}`);
+    process.exit(1);
+  }
+
+  return localQtCoreVsix;
+}
+
+/**
+ * Setup VS Code settings for testing
+ */
+export function setupVSCodeSettings(
+  userDataDir: string,
+  qtRoot: string,
+  additionalSettings: Record<string, unknown> = {}
+): void {
+  const userDir = path.join(userDataDir, 'User');
+  fs.mkdirSync(userDir, { recursive: true });
+
+  const settingsPath = path.join(userDir, 'settings.json');
+  const settings = {
+    [`qt-core.${QT_INS_ROOT_CONFIG_NAME}`]: qtRoot,
+    'cmake.loggingLevel': 'error',
+    ...additionalSettings
+  };
+
+  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
+  console.log('[runTest] Wrote settings to:', settingsPath);
+}
+
+/**
+ * Install required extensions for testing
+ */
+export function installRequiredExtensions(
+  cli: string,
+  args: string[],
+  localQtCoreVsix: string
+): void {
+  const quietArgs = [...args, ...getQuietVSCodeArgs()];
+  const required = ['ms-vscode.cmake-tools', localQtCoreVsix];
+  const requiredIds = ['ms-vscode.cmake-tools', 'theqtcompany.qt-core'];
+
+  for (const ext of required) {
+    installExtensionWithRetry(cli, quietArgs, ext);
+  }
+
+  debugListExtensions(cli, args);
+  assertExtensionsInstalled(cli, args, requiredIds);
+}
+
+/**
+ * Setup common test infrastructure
+ */
+export async function setupTestInfrastructure(
+  vscodeExecutablePath: string
+): Promise<{
+  qtRoot: string;
+  localQtCoreVsix: string;
+  cli: string;
+  args: string[];
+  userDataDir: string;
+  extensionsDir: string;
+}> {
+  const qtRoot = getQtRoot();
+  const localQtCoreVsix = verifyQtCoreVsix();
+
+  const [cli, ...args] =
+    resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
+
+  const { userDataDir, extensionsDir } = parseVSCodeDirs(args);
+
+  if (getDebugLevel() >= 1) {
+    console.log('[runTest][qt-cpp] CLI:', cli, 'args:', args.join(' '));
+    console.log('[runTest][qt-cpp] userDataDir:', userDataDir);
+    console.log('[runTest][qt-cpp] extensionsDir:', extensionsDir);
+  }
+
+  if (!userDataDir) {
+    console.error(
+      '[runTest] Could not determine userDataDir from VS Code args.'
+    );
+    process.exit(1);
+  }
+
+  if (!extensionsDir) {
+    console.error(
+      '[runTest] Could not determine extensionsDir from VS Code args.'
+    );
+    process.exit(1);
+  }
+
+  return {
+    qtRoot,
+    localQtCoreVsix,
+    cli: cli!,
+    args,
+    userDataDir,
+    extensionsDir
+  };
+}

--- a/qt-python/package.json
+++ b/qt-python/package.json
@@ -126,7 +126,7 @@
     "prettierWrite": "npm run prettierBase -- --write \"**/*.{js,ts,json,mjs,cjs}\" --log-level silent",
     "prettierCheck": "npm run prettierBase -- --check \"**/*.{js,ts,json,mjs,cjs}\"",
     "prettierBase": "prettier --config \"../common/.prettierrc\" --ignore-path \"../common/.prettierignore\" --cache --cache-strategy metadata",
-    "package": "vsce package --out out"
+    "package": "vsce package --out out && rm commit"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.0",

--- a/qt-qml/package.json
+++ b/qt-qml/package.json
@@ -414,7 +414,7 @@
     "prettierWrite": "npm run prettierBase -- --write \"**/*.{js,ts,mts,json,mjs,cjs}\" --log-level silent",
     "prettierCheck": "npm run prettierBase -- --check \"**/*.{js,ts,mts,json,mjs,cjs}\"",
     "prettierBase": "prettier --config \"../common/.prettierrc\" --ignore-path \"../common/.prettierignore\" --cache --cache-strategy metadata",
-    "package": "vsce package --out out"
+    "package": "vsce package --out out && rm commit"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.0",

--- a/qt-ui/package.json
+++ b/qt-ui/package.json
@@ -118,7 +118,7 @@
     "prettierWrite": "npm run prettierBase -- --write \"**/*.{js,ts,mts,json,mjs,cjs}\" --log-level silent",
     "prettierCheck": "npm run prettierBase -- --check \"**/*.{js,ts,mts,json,mjs,cjs}\"",
     "prettierBase": "prettier --config \"../common/.prettierrc\" --ignore-path \"../common/.prettierignore\" --cache --cache-strategy metadata",
-    "package": "vsce package --out out"
+    "package": "vsce package --out out && rm commit"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.0",

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -4,7 +4,6 @@
 import * as path from 'path';
 import { execSync } from 'child_process';
 import { program } from 'commander';
-import * as fs from 'fs';
 
 function main() {
   program.option('--extension <string>', 'Extension to generate package');
@@ -18,8 +17,6 @@ function main() {
     cwd: targetExtensionRoot,
     stdio: 'inherit'
   });
-  // Remove the generated `commit` file
-  fs.unlinkSync(path.join(targetExtensionRoot, 'commit'));
 }
 
 main();

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -100,8 +100,6 @@ function main() {
     cwd: targetExtensionRoot,
     stdio: 'inherit'
   });
-  // Remove the generated `commit` file
-  fs.unlinkSync(path.join(targetExtension, 'commit'));
 
   common.pushTag(extensionRoot, targetExtension, version, remote);
 

--- a/scripts/publish_ext_pack.ts
+++ b/scripts/publish_ext_pack.ts
@@ -4,7 +4,6 @@
 import * as path from 'path';
 import { execSync } from 'child_process';
 import { program } from 'commander';
-import * as fs from 'fs';
 
 import * as common from './common';
 
@@ -38,8 +37,6 @@ function main() {
     cwd: targetExtensionPackRoot,
     stdio: 'inherit'
   });
-  // Remove the generated `commit` file
-  fs.unlinkSync(path.join(targetExtensionPackRoot, 'commit'));
 
   common.pushTag(targetExtensionPackRoot, targetExtensionPack, version, remote);
 


### PR DESCRIPTION
## Summary

Remove duplicated test runner code && automate cleanup of packaging artifacts.

## Changes

- Extract shared test runner helpers into \`runTestHelper.mts\` to avoid bundling \`vscode\` in Node.js context
- Add \`&& rm commit\` to all package scripts to automatically clean up generated commit files
- Remove manual cleanup code from packaging scripts