### PR TITLE
Improve CMake Presets support && skip kit operations for preset projects

### DIFF
--- a/qt-core/src/recommended-settings.ts
+++ b/qt-core/src/recommended-settings.ts
@@ -24,11 +24,6 @@ export function registerSetRecommendedSettingsCommand() {
       extensionId: 'cmake',
       setting: 'buildDirectory',
       value: `\${workspaceFolder}${path.sep}builds${path.sep}\${buildKit}${path.sep}\${buildType}`
-    },
-    {
-      extensionId: 'cmake',
-      setting: 'useCMakePresets',
-      value: 'never'
     }
   ];
 

--- a/qt-core/test/suite/commands.test.mts
+++ b/qt-core/test/suite/commands.test.mts
@@ -301,7 +301,7 @@ describe('command: setRecommendedSettings', () => {
 
     await runRecommandSettingsCommand();
 
-    expect(updateSpy.callCount).to.equal(3);
+    expect(updateSpy.callCount).to.equal(2);
     const configurationTarget = isMultiWorkspace()
       ? vscode.ConfigurationTarget.Workspace
       : undefined;
@@ -320,9 +320,6 @@ describe('command: setRecommendedSettings', () => {
         `\${workspaceFolder}${path.sep}builds${path.sep}\${buildKit}${path.sep}\${buildType}`,
         configurationTarget
       )
-    ).to.be.true;
-    expect(
-      updateSpy.calledWith('useCMakePresets', 'never', configurationTarget)
     ).to.be.true;
   });
 });

--- a/qt-cpp/package.json
+++ b/qt-cpp/package.json
@@ -78,6 +78,11 @@
           "type": "boolean",
           "default": false,
           "description": "Do not show a warning when the source directory cannot be determined from the selected kit."
+        },
+        "qt-cpp.doNotWarnOutdatedCMakeTools": {
+          "type": "boolean",
+          "default": false,
+          "description": "Do not show a warning when the installed CMake Tools extension is too old for CMake Presets support."
         }
       }
     },

--- a/qt-cpp/src/extension.ts
+++ b/qt-cpp/src/extension.ts
@@ -11,7 +11,8 @@ import {
   QtWorkspaceConfigMessage,
   CoreKey,
   QtAdditionalPath,
-  telemetry
+  telemetry,
+  compareVersions
 } from 'qt-lib';
 import { registerMinGWgdbCommand } from '@cmd/mingw-gdb';
 import { registerResetCommand } from '@cmd/reset-qt-ext';
@@ -87,6 +88,8 @@ export async function activate(context: vscode.ExtensionContext) {
   });
   void tryToUseCMakeFromQtTools();
 
+  checkCMakeToolsVersion();
+
   if (isAnyOfProjectsUsingKits()) {
     await kitManager.checkForAllQtInstallations();
   }
@@ -151,4 +154,54 @@ function isAnyOfProjectsUsingKits(): boolean {
   return Array.from(projectManager.getProjects()).some(
     (project) => project.type === CppProjectType.Kit
   );
+}
+
+function checkCMakeToolsVersion(): void {
+  const cmakeExt = vscode.extensions.getExtension('ms-vscode.cmake-tools');
+  if (!cmakeExt) {
+    logger.warn('CMake Tools extension not found');
+    return;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const version = cmakeExt.packageJSON.version as string;
+  const requiredVersion = '1.22.16';
+
+  // compareVersions returns: -1 if version1 < version2, 0 if equal, 1 if version1 > version2
+  const isOutdated = compareVersions(version, requiredVersion) < 0;
+
+  if (!isOutdated) {
+    return;
+  }
+
+  const config = vscode.workspace.getConfiguration(EXTENSION_ID);
+  const disableWarning = config.get<boolean>(
+    'doNotWarnOutdatedCMakeTools',
+    false
+  );
+  if (disableWarning) {
+    return;
+  }
+
+  const message = `CMake Tools ${version} is outdated. Version ${requiredVersion} or later is required for CMake Presets support.`;
+  const updateBtn = 'Update';
+  const doNotShowBtn = 'Do not show again';
+  logger.error(message);
+
+  void vscode.window
+    .showErrorMessage(message, updateBtn, doNotShowBtn)
+    .then((selection) => {
+      if (selection === updateBtn) {
+        void vscode.commands.executeCommand(
+          'extension.open',
+          'ms-vscode.cmake-tools'
+        );
+      } else if (selection === doNotShowBtn) {
+        void config.update(
+          'doNotWarnOutdatedCMakeTools',
+          true,
+          vscode.ConfigurationTarget.Global
+        );
+      }
+    });
 }

--- a/qt-cpp/src/extension.ts
+++ b/qt-cpp/src/extension.ts
@@ -26,7 +26,12 @@ import {
   qpaPlatformPluginPathCommand,
   qmlImportPathCommand
 } from '@cmd/launch-variables';
-import { createCppProject, CppProjectManager, CppProject } from '@/project';
+import {
+  createCppProject,
+  CppProjectManager,
+  CppProject,
+  CppProjectType
+} from '@/project';
 import { KitManager, tryToUseCMakeFromQtTools } from '@/kit-manager';
 import { wasmStartTaskProvider, WASMStartTaskProvider } from '@task/wasm-start';
 import { EXTENSION_ID } from '@/constants';
@@ -81,7 +86,10 @@ export async function activate(context: vscode.ExtensionContext) {
     return processMessage(message);
   });
   void tryToUseCMakeFromQtTools();
-  await kitManager.checkForAllQtInstallations();
+
+  if (isAnyOfProjectsUsingKits()) {
+    await kitManager.checkForAllQtInstallations();
+  }
 
   await initConfigValues();
   logger.info('Config values initialized');
@@ -137,4 +145,10 @@ async function processMessage(message: QtWorkspaceConfigMessage) {
       continue;
     }
   }
+}
+
+function isAnyOfProjectsUsingKits(): boolean {
+  return Array.from(projectManager.getProjects()).some(
+    (project) => project.type === CppProjectType.Kit
+  );
 }

--- a/qt-cpp/src/kit-manager.ts
+++ b/qt-cpp/src/kit-manager.ts
@@ -25,7 +25,7 @@ import {
   fileWriter
 } from 'qt-lib';
 import * as qtPath from '@util/get-qt-paths';
-import { CppProject } from '@/project';
+import { CppProject, CppProjectType } from '@/project';
 import { coreAPI } from '@/extension';
 import { GlobalStateManager } from '@/state';
 import { IsQtKit } from '@cmd/register-qt-path';
@@ -235,7 +235,9 @@ export class KitManager {
 
   private async checkForWorkspaceFolderQtInstallations() {
     for (const project of this.projects) {
-      await this.checkForQtInstallations(project);
+      if (project.type === CppProjectType.Kit) {
+        await this.checkForQtInstallations(project);
+      }
     }
   }
 

--- a/qt-cpp/src/project.ts
+++ b/qt-cpp/src/project.ts
@@ -93,7 +93,9 @@ export class CppProject implements Project {
     this._stateManager = new WorkspaceStateManager(_context, _folder);
     this._buildDir = buildDir;
 
-    if (this._cmakeProject.useCMakePresets) {
+    const usePresets = this._cmakeProject.useCMakePresets;
+
+    if (usePresets) {
       logger.info('Using CMake presets');
       this._type = CppProjectType.Presets;
     } else {

--- a/qt-cpp/src/project.ts
+++ b/qt-cpp/src/project.ts
@@ -677,39 +677,10 @@ export class CppProject implements Project {
     if (!coreAPI) {
       throw new Error('CoreAPI is not initialized');
     }
-    // const installationPath = await this.getInstallationPath();
-    // logger.info(
-    //   `Setting installation path for ${folder.uri.fsPath} to ${installationPath}`
-    // );
 
-    // // const kit = await getSelectedKit(folder, true);
-    // coreAPI.setValue(folder, CoreKey.INSTALLATION_PATH, installationPath);
-    // // const selectedQtPaths = kit ? getQtPathsExe(kit) : undefined;
-    // const selectedQtPaths = await this.getQtPaths();
-    // coreAPI.setValue(folder, CoreKey.SELECTED_QT_PATHS, selectedQtPaths);
-    // logger.info(
-    //   `Setting selected Qt paths for ${folder.uri.fsPath} to ${selectedQtPaths}`
-    // );
-
-    // coreAPI.setValue(folder, featuresKey, features);
-    // logger.info(
-    //   `Setting workspace features for ${folder.uri.fsPath} to ${JSON.stringify(features)}`
-    // );
-
-    // coreAPI.setValue(folder, CoreKey.BUILD_DIR, this.buildDir);
-    // logger.info(
-    //   `Setting build directory for ${folder.uri.fsPath} to ${this.buildDir}`
-    // );
-    // logger.info('Config values initialized for:', folder.uri.fsPath);
-    // const message = new QtWorkspaceConfigMessage(folder);
-    // message.config.add(CoreKey.INSTALLATION_PATH);
-    // message.config.add(CoreKey.SELECTED_QT_PATHS);
-    // message.config.add(featuresKey);
-    // message.config.add(CoreKey.BUILD_DIR);
     if (!this._cmakeProject) {
       throw new Error('CMake project is not defined');
     }
-    // coreAPI.notify(message);
     const folder = this.folder;
     let features = coreAPI.getValue<QtWorkspaceFeatures>(
       folder,


### PR DESCRIPTION
## Summary

Improve CMake Presets support by removing forced disabling in recommended settings, skipping kit operations for preset projects, and detecting outdated CMake Tools versions.

## Changes

- Remove \`cmake.useCMakePresets: never\` from recommended settings to allow users to opt into CMake Presets
- Skip Qt kit scanning and updates for projects using CMake Presets (only needed for Kit-based projects)
- Add version check for CMake Tools extension to detect versions lacking \`useCMakePresets\` support
- Show error message prompting update to v1.22.16+ with dismissible "Do not show again" option
- Remove unused dead code

Task-number: [VSCODEEXT-64](https://bugreports.qt.io/browse/VSCODEEXT-64)