### PR TITLE
qt-python: Refactor Python environment handling

### DIFF
--- a/qt-python/src/env.ts
+++ b/qt-python/src/env.ts
@@ -3,67 +3,27 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { Environment } from '@vscode/python-extension';
+import {
+  PythonExtension as PyApi,
+  ResolvedEnvironment as PyEnv
+} from '@vscode/python-extension';
 
-import { isError, OSExeSuffix } from 'qt-lib';
+import { isError, OSExeSuffix, createLogger } from 'qt-lib';
 import { PySidePackageInfo } from './types';
 import { PySideCommandRunner } from './runner';
-import { pyApi } from './extension';
 import * as utils from './utils';
 import * as consts from './constants';
 
+const logger = createLogger('env');
+
 export class PySideEnv {
-  private _disposables: vscode.Disposable[] = [];
+  private _pyEnv?: PyEnv | undefined;
+  private _activeFSWatcher: vscode.FileSystemWatcher | undefined;
 
-  constructor(
-    private readonly _folder: vscode.WorkspaceFolder,
-    private _pyEnv?: Environment
-  ) {
-    const folder = this._folder;
-    const isVenv = this._pyEnv?.environment?.type === 'VirtualEnvironment';
-
-    if (isVenv) {
-      const sysPrefix = this._pyEnv?.executable.sysPrefix;
-      if (sysPrefix) {
-        const pattern = new vscode.RelativePattern(
-          vscode.Uri.file(sysPrefix),
-          '/'
-        );
-        const watcher = vscode.workspace.createFileSystemWatcher(pattern);
-        watcher.onDidDelete(() => {
-          watcher.dispose();
-          this._pyEnv = undefined;
-          if (pyApi) {
-            void pyApi.environments.updateActiveEnvironmentPath('', folder);
-          }
-        });
-        this._disposables.push(watcher);
-      }
-      return;
-    }
-
-    const pythonPathRel = path.join(
-      '.venv',
-      consts.VENV_BIN_DIR,
-      'python' + OSExeSuffix
-    );
-    const pattern = new vscode.RelativePattern(folder.uri, pythonPathRel);
-    const watcher = vscode.workspace.createFileSystemWatcher(pattern);
-    watcher.onDidCreate(() => {
-      watcher.dispose();
-      if (pyApi) {
-        const pythonPath = path.join(folder.uri.fsPath, pythonPathRel);
-        void pyApi.environments.updateActiveEnvironmentPath(pythonPath, folder);
-      }
-    });
-    this._disposables.push(watcher);
-  }
+  constructor(private readonly _folder: vscode.WorkspaceFolder) {}
 
   public dispose() {
-    this._disposables.forEach((w) => {
-      w.dispose();
-    });
-    this._disposables = [];
+    this._disposeActiveFSWatcher();
   }
 
   public isVenv(): boolean {
@@ -85,7 +45,14 @@ export class PySideEnv {
     return this._pyEnv?.executable.uri?.fsPath;
   }
 
-  public async readPySide6PackageInfo(outputHandler?: (line: string) => void) {
+  public async refresh(pyApi: PyApi) {
+    const allEnvs = pyApi.environments;
+    const activeEnvPath = allEnvs.getActiveEnvironmentPath(this._folder);
+    this._pyEnv = await allEnvs.resolveEnvironment(activeEnvPath);
+    this._setupWatcher(pyApi);
+  }
+
+  public async readPySide6PackageInfo() {
     const parsedOutput: Record<string, string> = {};
 
     try {
@@ -101,9 +68,13 @@ export class PySideEnv {
       // Requires: PySide6_Essentials, PySide6_Addons, shiboken6
       // Required-by:
 
+      const logIndented = (line: string) => {
+        logger.info(' ', line);
+      };
+
       const runner = new PySideCommandRunner(this);
-      runner.onStdout(outputHandler);
-      runner.onStderr(outputHandler);
+      runner.onStdout(logIndented);
+      runner.onStderr(logIndented);
 
       const lines = await runner.run(`pip show PySide6`, { useVenv: true });
       lines.forEach((line) => {
@@ -113,7 +84,7 @@ export class PySideEnv {
         }
       });
     } catch (e) {
-      outputHandler?.(isError(e) ? e.message : String(e));
+      logger.error(' ', isError(e) ? e.message : String(e));
       return undefined;
     }
 
@@ -121,5 +92,53 @@ export class PySideEnv {
       version: parsedOutput.Version ?? '',
       location: parsedOutput.Location ?? ''
     } as PySidePackageInfo;
+  }
+
+  private _setupWatcher(pyApi: PyApi) {
+    const folder = this._folder;
+    const isVenv = this._pyEnv?.environment?.type === 'VirtualEnvironment';
+
+    this._disposeActiveFSWatcher();
+
+    if (isVenv) {
+      const sysPrefix = this._pyEnv?.executable.sysPrefix;
+      if (sysPrefix) {
+        const pattern = new vscode.RelativePattern(
+          vscode.Uri.file(sysPrefix),
+          '/'
+        );
+        const watcher = vscode.workspace.createFileSystemWatcher(pattern);
+        watcher.onDidDelete(() => {
+          void pyApi.environments.updateActiveEnvironmentPath('', folder);
+          this._pyEnv = undefined;
+          this._disposeActiveFSWatcher();
+        });
+
+        this._activeFSWatcher = watcher;
+      }
+      return;
+    }
+
+    const pythonPathRel = path.join(
+      '.venv',
+      consts.VENV_BIN_DIR,
+      'python' + OSExeSuffix
+    );
+    const pattern = new vscode.RelativePattern(folder.uri, pythonPathRel);
+    const watcher = vscode.workspace.createFileSystemWatcher(pattern);
+    watcher.onDidCreate(() => {
+      const pythonPath = path.join(folder.uri.fsPath, pythonPathRel);
+      void pyApi.environments.updateActiveEnvironmentPath(pythonPath, folder);
+      this._disposeActiveFSWatcher();
+    });
+
+    this._activeFSWatcher = watcher;
+  }
+
+  private _disposeActiveFSWatcher() {
+    if (this._activeFSWatcher) {
+      this._activeFSWatcher.dispose();
+      this._activeFSWatcher = undefined;
+    }
   }
 }

--- a/qt-python/src/extension.ts
+++ b/qt-python/src/extension.ts
@@ -104,7 +104,7 @@ const onPyApiEnvChanged = async (e: PyApiEnvChanged) => {
   const folder = e.resource;
   if (folder) {
     logger.info(`Active environment changed: ${folder.uri.fsPath}`);
-    await projectManager.refreshEnv(folder);
+    await projectManager.refreshProjectEnv(folder);
   }
 };
 

--- a/qt-python/src/installer.ts
+++ b/qt-python/src/installer.ts
@@ -86,14 +86,11 @@ async function selectTargetProject() {
 async function checkInstallation(project: PySideProject): Promise<CheckResult> {
   const env = project.env;
   const folder = project.folder;
-  if (!env || !env.isVenv()) {
+  if (!env.isVenv()) {
     return { status: 'noVenv', folder };
   }
 
-  const logIndented = (line: string) => {
-    logger.info(' ', line);
-  };
-  const pyside = await env.readPySide6PackageInfo(logIndented);
+  const pyside = await env.readPySide6PackageInfo();
   if (!pyside) {
     return { status: 'noPySide', folder, env };
   }
@@ -194,12 +191,13 @@ async function tryInstallPySide(
         return;
       }
 
-      const pyside = await env.readPySide6PackageInfo(logIndented);
+      const pyside = await env.readPySide6PackageInfo();
       if (!pyside) {
         throw new Error('Cannot read PySide6 package information');
       }
 
-      await projectManager.refreshEnv(folder);
+      await projectManager.refreshProjectEnv(folder);
+
       void vscode.window.showInformationMessage(
         texts.install.popup.installed(
           folder.name,

--- a/qt-python/src/project-manager.ts
+++ b/qt-python/src/project-manager.ts
@@ -1,36 +1,17 @@
 // Copyright (C) 2025 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
-import _ from 'lodash';
-import * as fs from 'fs';
-import * as path from 'path';
 import * as vscode from 'vscode';
-import { parse } from 'smol-toml';
-import { PythonExtension as PyApi } from '@vscode/python-extension';
 
-import {
-  ConfigType,
-  QtWorkspaceFeatures,
-  QtWorkspaceConfigMessage,
-  ProjectManager,
-  createLogger,
-  CoreKey
-} from 'qt-lib';
-import { PySideEnv } from './env';
+import { ProjectManager } from 'qt-lib';
 import { PySideProject } from './project';
-import { PySideProjectInfo } from './types';
-import { pyApi, coreApi } from './extension';
-import * as consts from '@/constants';
-
-type Folder = vscode.WorkspaceFolder;
-type Context = vscode.ExtensionContext;
-
-const logger = createLogger('project-manager');
 
 export class PySideProjectManager extends ProjectManager<PySideProject> {
-  constructor(override readonly context: Context) {
+  constructor(override readonly context: vscode.ExtensionContext) {
     super(context, PySideProject.create);
-    this._disposables.push(this.onProjectAdded(this._onProjectAdded));
+    this._disposables.push(
+      this.onProjectAdded(PySideProjectManager._onProjectAdded)
+    );
   }
 
   public async init() {
@@ -39,100 +20,16 @@ export class PySideProjectManager extends ProjectManager<PySideProject> {
     for (const folder of folders) {
       const p = await PySideProject.create(folder, this.context);
       this.addProject(p);
-      await this._onProjectAdded(p);
+      await PySideProjectManager._onProjectAdded(p);
     }
   }
 
-  public async refreshEnv(folder: Folder) {
-    const project = this.getProject(folder);
-    if (!project) {
-      return;
-    }
-
-    const logIndented = (line: string) => {
-      logger.info(' ', line);
-    };
-
-    const env = await resolveEnv(pyApi, folder);
-    const pyside = env && (await env.readPySide6PackageInfo(logIndented));
-    const qmlImportPath = pyside?.location
-      ? path.normalize(path.join(pyside.location, consts.QML_IMPORT_SUBDIR))
-      : '';
-
-    project.env = env;
-
-    setCoreAndNotify(folder, CoreKey.PYSIDE_ENV_DATA, {
-      venvBinPath: env?.venvBinPath ?? '',
-      qmlImportPath
-    });
-
-    void vscode.commands.executeCommand(consts.COMMAND_RESTART_QMLLS);
+  public async refreshProjectEnv(folder: vscode.WorkspaceFolder) {
+    await this.getProject(folder)?.refreshEnv();
   }
 
-  private _refreshProjectInfo(folder: Folder) {
-    const project = this.getProject(folder);
-    if (!project) {
-      return;
-    }
-
-    project.info = parseToml(
-      path.join(folder.uri.fsPath, consts.TOML_PROJECT_FILE_NAME)
-    );
-
-    const key = CoreKey.WORKSPACE_FEATURES;
-    let value = coreApi?.getValue<QtWorkspaceFeatures>(folder, key);
-    value ??= { projectTypes: {} };
-    value.projectTypes.pyside = project.isValid();
-
-    setCoreAndNotify(folder, key, value);
-  }
-
-  private readonly _onProjectAdded = async (p: PySideProject) => {
-    await this.refreshEnv(p.folder);
-    this._refreshProjectInfo(p.folder);
+  private static readonly _onProjectAdded = async (p: PySideProject) => {
+    p.refreshInfo();
+    await p.refreshEnv();
   };
-}
-
-// helpers
-function setCoreAndNotify(folder: Folder, key: string, value: ConfigType) {
-  if (!coreApi) {
-    logger.error('CoreAPI is not initialized');
-    return;
-  }
-
-  logger.info(
-    `Updating core (${folder.name}): '${key}' = ${JSON.stringify(value)}`
-  );
-
-  const msg = new QtWorkspaceConfigMessage(folder);
-  msg.config.add(key);
-
-  coreApi.setValue(folder, key, value);
-  coreApi.notify(msg);
-}
-
-async function resolveEnv(pyapi: PyApi | undefined, folder: Folder) {
-  if (!pyapi) {
-    logger.error('Python API is invalid');
-    return undefined;
-  }
-
-  const envs = pyapi.environments;
-  const envPath = envs.getActiveEnvironmentPath(folder);
-  const resolved = await envs.resolveEnvironment(envPath);
-  return resolved ? new PySideEnv(folder, resolved) : undefined;
-}
-
-function parseToml(absPath: string): PySideProjectInfo | undefined {
-  try {
-    const data = fs.readFileSync(absPath, 'utf-8');
-    const dataJson = parse(data);
-
-    return {
-      name: _.get(dataJson, consts.TOML_KEY_PROJECT_NAME, '') as string,
-      files: _.get(dataJson, consts.TOML_KEY_PROJECT_FILES, []) as string[]
-    };
-  } catch (e) {
-    return undefined;
-  }
 }

--- a/qt-python/src/project.ts
+++ b/qt-python/src/project.ts
@@ -1,11 +1,24 @@
 // Copyright (C) 2025 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
+import _ from 'lodash';
+import * as fs from 'fs';
+import * as path from 'path';
 import * as vscode from 'vscode';
+import { parse } from 'smol-toml';
 
-import { Project, createLogger } from 'qt-lib';
+import {
+  Project,
+  createLogger,
+  ConfigType,
+  QtWorkspaceConfigMessage,
+  CoreKey,
+  QtWorkspaceFeatures
+} from 'qt-lib';
 import { PySideEnv } from './env';
 import { PySideProjectInfo } from './types';
+import { pyApi, coreApi } from './extension';
+import * as consts from '@/constants';
 
 type Folder = vscode.WorkspaceFolder;
 type Context = vscode.ExtensionContext;
@@ -13,24 +26,21 @@ type Context = vscode.ExtensionContext;
 const logger = createLogger('project');
 
 export class PySideProject implements Project {
-  private _env: PySideEnv | undefined;
+  private readonly _env: PySideEnv;
   private _info: PySideProjectInfo | undefined;
 
   private constructor(private readonly _folder: Folder) {
     logger.info(`Create: "${_folder.uri.fsPath}"`);
+    this._env = new PySideEnv(_folder);
   }
 
   dispose() {
     logger.info(`Dispose: "${this._folder.uri.fsPath}"`);
-    this._env?.dispose();
+    this._env.dispose();
   }
 
   get env() {
     return this._env;
-  }
-
-  set env(env: PySideEnv | undefined) {
-    this._env = env;
   }
 
   set info(info: PySideProjectInfo | undefined) {
@@ -45,8 +55,74 @@ export class PySideProject implements Project {
     return this._info !== undefined;
   }
 
+  public async refreshEnv() {
+    if (!pyApi) {
+      return;
+    }
+
+    await this._env.refresh(pyApi);
+
+    const pyside = await this._env.readPySide6PackageInfo();
+    const qmlImportPath = pyside?.location
+      ? path.normalize(path.join(pyside.location, consts.QML_IMPORT_SUBDIR))
+      : '';
+
+    this._setCoreAndNotify(CoreKey.PYSIDE_ENV_DATA, {
+      venvBinPath: this._env.venvBinPath,
+      qmlImportPath
+    });
+
+    void vscode.commands.executeCommand(consts.COMMAND_RESTART_QMLLS);
+  }
+
+  public refreshInfo() {
+    this._info = parseToml(
+      path.join(this._folder.uri.fsPath, consts.TOML_PROJECT_FILE_NAME)
+    );
+
+    const key = CoreKey.WORKSPACE_FEATURES;
+    let value = coreApi?.getValue<QtWorkspaceFeatures>(this._folder, key);
+    value ??= { projectTypes: {} };
+    value.projectTypes.pyside = this.isValid();
+
+    this._setCoreAndNotify(key, value);
+  }
+
   public static create = async (folder: Folder, context: Context) => {
     void context;
     return Promise.resolve(new PySideProject(folder));
   };
+
+  private _setCoreAndNotify(key: string, value: ConfigType) {
+    const folder = this._folder;
+    if (!coreApi) {
+      logger.error('CoreAPI is not initialized');
+      return;
+    }
+
+    logger.info(
+      `Updating core (${folder.name}): '${key}' = ${JSON.stringify(value)}`
+    );
+
+    const msg = new QtWorkspaceConfigMessage(folder);
+    msg.config.add(key);
+
+    coreApi.setValue(folder, key, value);
+    coreApi.notify(msg);
+  }
+}
+
+// helpers
+function parseToml(absPath: string): PySideProjectInfo | undefined {
+  try {
+    const data = fs.readFileSync(absPath, 'utf-8');
+    const dataJson = parse(data);
+
+    return {
+      name: _.get(dataJson, consts.TOML_KEY_PROJECT_NAME, '') as string,
+      files: _.get(dataJson, consts.TOML_KEY_PROJECT_FILES, []) as string[]
+    };
+  } catch (e) {
+    return undefined;
+  }
 }

--- a/qt-python/src/task.ts
+++ b/qt-python/src/task.ts
@@ -69,7 +69,7 @@ function createTask(project: PySideProject, taskId: TaskId) {
   const folder = project.folder;
   const action = findProjectToolAction(taskId);
   const taskName = findTaskName(taskId);
-  if (!env || !action || !taskName) {
+  if (!action || !taskName) {
     logger.info(`Cannot create: task = ${taskName}, folder = ${folder.name}`);
     return undefined;
   }


### PR DESCRIPTION
Refactor the `PySideEnv` class to have all relevant data and methods for improved maintainability.
Adjust the responsibilities of related classes such as `PySideProject`, `PySideProjectManager` and others accordingly.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
