### PR TITLE
qt-core: Include qt-python id when running `openSettings` command

### DIFF
--- a/qt-core/src/small-commands.ts
+++ b/qt-core/src/small-commands.ts
@@ -21,10 +21,11 @@ export function resetCommand() {
 
 export function registerOpenSettingsCommand() {
   return vscode.commands.registerCommand(`${EXTENSION_ID}.openSettings`, () => {
+    const extensions = ['qt-cpp', 'qt-qml', 'qt-ui', 'qt-python', EXTENSION_ID];
     telemetry.sendAction('openSettings');
     void vscode.commands.executeCommand(
       'workbench.action.openSettings',
-      `@ext:theqtcompany.qt-cpp @ext:theqtcompany.qt-qml @ext:theqtcompany.qt-ui @ext:theqtcompany.${EXTENSION_ID}`
+      extensions.map((e) => `@ext:theqtcompany.${e}`).join(' ')
     );
   });
 }

--- a/qt-core/test/suite/commands.test.mts
+++ b/qt-core/test/suite/commands.test.mts
@@ -267,7 +267,7 @@ describe('command: openSettings', () => {
   it('leads to vscode workbench action openSettings', async () => {
     const commandArgs = [
       'workbench.action.openSettings',
-      '@ext:theqtcompany.qt-cpp @ext:theqtcompany.qt-qml @ext:theqtcompany.qt-ui @ext:theqtcompany.qt-core'
+      '@ext:theqtcompany.qt-cpp @ext:theqtcompany.qt-qml @ext:theqtcompany.qt-ui @ext:theqtcompany.qt-python @ext:theqtcompany.qt-core'
     ] as [string, ...unknown[]];
     const openSettingsSpy = stubExecuteCommandWithSpy(sb, commandArgs);
     await runOpenSettingsCommand();


### PR DESCRIPTION
<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
