### PR TITLE
qt-core/webview: Fix macOS keyboard shortcuts by replacing Modal

### DIFF
--- a/qt-core/webview-ui/src/apps/new-item/Wizard.svelte
+++ b/qt-core/webview-ui/src/apps/new-item/Wizard.svelte
@@ -4,8 +4,6 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
-  import { Modal } from 'flowbite-svelte';
-
   import * as texts from '@/apps/texts';
   import LoadingMask from '@/comps/LoadingMask.svelte';
   import { ui } from './states.svelte';
@@ -15,22 +13,17 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   import WizardSectionPresets from './WizardSectionPresets.svelte';
 </script>
 
-<Modal
-  open
-  dismissable={false}
-  size="lg"
-  color="none"
-  class="qt-panel w-[80vw] h-[90vh] min-w-[500px] min-h-[500px]"
-  backdropClass="hidden"
+<div
+  class="qt-panel w-[80vw] h-[90vh] min-w-[500px] min-h-[500px] flex flex-col"
   on:close={onModalClosed}
 >
-  <svelte:fragment slot="header">
+  <div class="border-b p-4">
     <div class="qt-panel-header">
       {texts.wizard.title}
     </div>
-  </svelte:fragment>
+  </div>
 
-  <div class="w-full h-full flex flex-col gap-4">
+  <div class="w-full h-full flex flex-col gap-4 p-4">
     <WizardSectionPresets />
     <WizardSectionInput />
     <LoadingMask
@@ -40,4 +33,4 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
     />
     <WizardAllDialogs />
   </div>
-</Modal>
+</div>

--- a/qt-core/webview-ui/src/comps/ConfirmDialog.svelte
+++ b/qt-core/webview-ui/src/comps/ConfirmDialog.svelte
@@ -4,7 +4,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
-  import { Modal, Button, P } from 'flowbite-svelte';
+  import { Button, P } from 'flowbite-svelte';
 
   let {
     open = $bindable(true),
@@ -26,27 +26,30 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   }
 </script>
 
-<Modal
-  bind:open
-  color="none"
-  class="qt-popup"
-  size="sm"
-  classBackdrop="qt-popup-backdrop"
-  bodyClass="p-4"
-  outsideclose
-  on:close={() => {
-    onRejected();
+<button
+  class="qt-popup-backdrop fixed inset-0 flex items-center justify-center"
+  onclick={(e) => {
+    if (e.target === e.currentTarget) {
+      onRejectClicked();
+    }
   }}
 >
-  <P class="qt-label dialog pb-3">{text}</P>
+  <div
+    class="qt-popup w-[450px] absolute flex flex-col p-4"
+    onclose={() => {
+      onRejectClicked();
+    }}
+  >
+    <P class="qt-label dialog pb-3">{text}</P>
 
-  <div class="flex flex-row gap-2 mt-5">
-    <div class="grow"></div>
-    <Button class="qt-button" on:click={onRejectClicked}>
-      {rejectText}
-    </Button>
-    <Button class="qt-button" on:click={onAcceptClicked}>
-      {acceptText}
-    </Button>
+    <div class="flex flex-row gap-2 mt-5">
+      <div class="grow"></div>
+      <Button class="qt-button" on:click={onRejectClicked}>
+        {rejectText}
+      </Button>
+      <Button class="qt-button" on:click={onAcceptClicked}>
+        {acceptText}
+      </Button>
+    </div>
   </div>
-</Modal>
+</button>

--- a/qt-core/webview-ui/src/comps/InputDialog.svelte
+++ b/qt-core/webview-ui/src/comps/InputDialog.svelte
@@ -5,7 +5,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { Modal, Button, P } from 'flowbite-svelte';
+  import { Button, P } from 'flowbite-svelte';
 
   import InputWithIssue from './InputWithIssue.svelte';
 
@@ -51,43 +51,46 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   });
 </script>
 
-<Modal
-  bind:open
-  color="none"
-  class="qt-popup"
-  size="sm"
-  classBackdrop="qt-popup-backdrop"
-  bodyClass="p-4"
-  outsideclose
-  on:close={() => {
-    onRejectClicked();
+<button
+  class={`qt-popup-backdrop fixed inset-0 flex items-center justify-center`}
+  onclick={(e) => {
+    if (e.target === e.currentTarget) {
+      onRejectClicked();
+    }
   }}
 >
-  <P class="qt-label dialog pb-3">{text}</P>
+  <div
+    class="qt-popup w-[450px] absolute flex flex-col p-4"
+    onclose={() => {
+      onRejectClicked();
+    }}
+  >
+    <P class="qt-label dialog pb-3">{text}</P>
 
-  <div class="flex flex-col gap-2">
-    <InputWithIssue
-      bind:this={inputComp}
-      bind:value
-      {level}
-      {message}
-      alertPosition="bottom"
-      {onInput}
-      {onEnter}
-    />
+    <div class="flex flex-col gap-2">
+      <InputWithIssue
+        bind:this={inputComp}
+        bind:value
+        {level}
+        {message}
+        alertPosition="bottom"
+        {onInput}
+        {onEnter}
+      />
 
-    <div class="flex flex-row gap-2">
-      <div class="grow"></div>
-      <Button class="qt-button-flat min-w-[75px]" on:click={onRejectClicked}>
-        {rejectText}
-      </Button>
-      <Button
-        class="qt-button min-w-[75px]"
-        disabled={!acceptable}
-        on:click={onAcceptClicked}
-      >
-        {acceptText}
-      </Button>
+      <div class="flex flex-row gap-2">
+        <div class="grow"></div>
+        <Button class="qt-button-flat min-w-[75px]" on:click={onRejectClicked}>
+          {rejectText}
+        </Button>
+        <Button
+          class="qt-button min-w-[75px]"
+          disabled={!acceptable}
+          on:click={onAcceptClicked}
+        >
+          {acceptText}
+        </Button>
+      </div>
     </div>
   </div>
-</Modal>
+</button>

--- a/qt-core/webview-ui/src/comps/InputWithIssue.svelte
+++ b/qt-core/webview-ui/src/comps/InputWithIssue.svelte
@@ -41,7 +41,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
     <Alert
       border
       color="none"
-      class={`qt-alert-${level} absolute w-full z-1
+      class={`qt-alert-${level} absolute w-full z-1 text-left
         ${alertPosition === 'top' ? 'bottom-full -mb-0.5' : 'top-full -mt-0.5'}
       `}
     >


### PR DESCRIPTION
On macOS, shortcuts such as Cmd+A, Cmd+C and others with Cmd key combination
do not work when using the `Modal` from flowbite-svelte.
This reduces usability when entering text in input elements.
This patch replaces the Modal with plain HTML elements to fix this issue.

Task-number: [VSCODEEXT-260](https://bugreports.qt.io/browse/VSCODEEXT-260)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
