### PR TITLE
qt-core: Add regex to find PySide6 project entry files

### DIFF
--- a/qt-core/src/qtcli/common.ts
+++ b/qt-core/src/qtcli/common.ts
@@ -81,7 +81,12 @@ export async function openFilesUnder(baseDir: string, names: string[]) {
 
 async function findPrimaryFileUnder(dir: string) {
   try {
-    const patterns = [/Main.qml$/i, /main\.cpp$/i, /CMakeLists.txt$/];
+    const patterns = [
+      /main\.qml$/i,
+      /main\.cpp$/i,
+      /CMakeLists\.txt$/,
+      /(main|dialog|widget).*\.py$/i
+    ];
     const files = await fs.readdir(dir);
 
     for (const pattern of patterns) {


### PR DESCRIPTION
After creating a project from the template,
some files are searched and opened in text editor to improve usability.

This adds a regex to locate possible entry files (like main.py) of a generated PySide6 project.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
