### PR TITLE
qt-all-pack: Add Python keyword to package.json

### DIFF
--- a/extension_packs/qt/package.json
+++ b/extension_packs/qt/package.json
@@ -28,7 +28,8 @@
     "C++",
     "CMake",
     "Qml",
-    "scan"
+    "scan",
+    "Python"
   ],
   "qna": "marketplace",
   "pricing": "Free",


### PR DESCRIPTION
<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
