### PR TITLE
qt-all-pack: Bump version to 1.3.0 and fix version problem

### DIFF
--- a/extension_packs/qt/CHANGELOG.md
+++ b/extension_packs/qt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.3.0
+
+- Fix the version problem and override the `1.2.0` version.
+
 ## 1.1.0
 
 - Added the `qt-python` extension.

--- a/extension_packs/qt/package.json
+++ b/extension_packs/qt/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://bugreports.qt.io/projects/VSCODEEXT"
   },
-  "version": "1.1.0",
+  "version": "1.3.0",
   "engines": {
     "vscode": "^1.94.0"
   },


### PR DESCRIPTION
The latest `qt-all-pack` version on the marketplace is 1.2.0 but the `package.json` still shows 1.1.0. This PR updates the version to 1.3.0 to fix this discrepancy.
<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
