### PR TITLE
qt-core: Add option where to open a new project in new item wizard

### DIFF
--- a/qt-core/src/qtcli/common.ts
+++ b/qt-core/src/qtcli/common.ts
@@ -44,42 +44,7 @@ export function fallbackWorkingDir(): string {
   return docs;
 }
 
-export async function openUri(uri: vscode.Uri) {
-  try {
-    const stats = await fs.stat(uri.fsPath);
-
-    if (stats.isFile()) {
-      void vscode.commands.executeCommand('vscode.open', uri);
-      return;
-    }
-
-    if (stats.isDirectory()) {
-      vscode.workspace.updateWorkspaceFolders(
-        vscode.workspace.workspaceFolders?.length ?? 0,
-        null,
-        { uri }
-      );
-
-      const fileToOpen = await findPrimaryFileUnder(uri.fsPath);
-      if (fileToOpen) {
-        void vscode.commands.executeCommand(
-          'vscode.open',
-          vscode.Uri.file(fileToOpen)
-        );
-      }
-    }
-  } catch (e) {
-    logger.warn('cannot open:', uri.fsPath);
-  }
-}
-
-export async function openFilesUnder(baseDir: string, names: string[]) {
-  for (const name of names) {
-    await openUri(vscode.Uri.file(path.join(baseDir, name)));
-  }
-}
-
-async function findPrimaryFileUnder(dir: string) {
+export async function findPrimaryFileUnder(dir: string) {
   try {
     const patterns = [
       /main\.qml$/i,

--- a/qt-core/src/webview/new-item/dispatcher.ts
+++ b/qt-core/src/webview/new-item/dispatcher.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import { createLogger } from 'qt-lib';
 import * as texts from '@/texts';
 import { QtcliRestClient, QtcliRestError } from '@/qtcli/rest';
-import { openFilesUnder, openUri } from '@/qtcli/common';
+import { findPrimaryFileUnder } from '@/qtcli/common';
 import { getNewProjectBaseDir, setDefaultProjectDir } from '@/qtcli/commands';
 import { WebviewChannel } from '@/webview/channel';
 import { Command, CommandId, IsCommand } from '@/webview/shared/message';
@@ -79,20 +79,27 @@ export class NewItemDispatcher {
 
   private readonly onUiItemCreationRequested = async (cmd: Command) => {
     try {
-      const data = await this._qtcliRest.call({
+      const out = await this._qtcliRest.call({
         method: 'post',
         url: '/items',
         data: cmd.payload
       });
 
-      openItemsFromQtcliResponseData(data);
+      const outType = _.get(out, 'type', '') as string;
+      const outFilesDir = path.normalize(_.get(out, 'filesDir', '') as string);
 
-      const type = _.get(cmd.payload, 'type', '') as string;
-      const save = _.get(cmd.payload, 'saveProjectDir', false) as boolean;
-      const workingDir = _.get(data, 'workingDir', '') as string;
+      if (outType !== 'project') {
+        openFiles(outFilesDir, _.get(out, 'files', []) as string[]);
+      } else {
+        void openFolder(
+          outFilesDir,
+          _.get(cmd.payload, 'openInNewWindow', false) as boolean
+        );
 
-      if (type === 'project' && save && workingDir.length !== 0) {
-        await setDefaultProjectDir(workingDir);
+        trySaveProjectDir(
+          _.get(cmd.payload, 'workingDir', '') as string,
+          _.get(cmd.payload, 'saveProjectDir', false) as boolean
+        );
       }
 
       this._panel?.close();
@@ -212,17 +219,44 @@ export class NewItemDispatcher {
 }
 
 // helpers
-function openItemsFromQtcliResponseData(data: unknown) {
-  const type = _.get(data, 'type', '') as string;
-  const files = _.get(data, 'files', []) as string[];
-  const filesDir = _.get(data, 'filesDir', '') as string;
-  if (type.length === 0 || filesDir.length === 0) {
+function trySaveProjectDir(workingDir: string, save: boolean) {
+  if (save && workingDir) {
+    void setDefaultProjectDir(workingDir);
+  }
+}
+
+function openFiles(baseDir: string, files: string[]) {
+  files.forEach((f: string) => {
+    void execOpen(path.join(baseDir, f));
+  });
+}
+
+async function openFolder(dir: string, useNewWindow: boolean) {
+  if (useNewWindow) {
+    void execOpenFolder(dir);
     return;
   }
 
-  if (type === 'project') {
-    void openUri(vscode.Uri.file(path.normalize(filesDir)));
-  } else {
-    void openFilesUnder(path.normalize(filesDir), files);
+  vscode.workspace.updateWorkspaceFolders(
+    vscode.workspace.workspaceFolders?.length ?? 0,
+    null,
+    { uri: vscode.Uri.file(dir) }
+  );
+
+  const primary = await findPrimaryFileUnder(dir);
+  if (primary) {
+    void execOpen(primary);
   }
+}
+
+async function execOpen(fsPath: string) {
+  await vscode.commands.executeCommand('vscode.open', vscode.Uri.file(fsPath));
+}
+
+async function execOpenFolder(fsPath: string) {
+  await vscode.commands.executeCommand(
+    'vscode.openFolder',
+    vscode.Uri.file(fsPath),
+    true
+  );
 }

--- a/qt-core/webview-ui/src/apps/new-item/WizardSectionInput.svelte
+++ b/qt-core/webview-ui/src/apps/new-item/WizardSectionInput.svelte
@@ -64,6 +64,12 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
       >
         {texts.wizard.workingDirSaveCheckbox}
       </Checkbox>
+      <Checkbox
+        class="self-middle qt-checkbox mr-2"
+        bind:checked={input.openInNewWindow}
+      >
+        {texts.wizard.openInNewWindow}
+      </Checkbox>
     {:else}
       <div class="grow"></div>
     {/if}

--- a/qt-core/webview-ui/src/apps/new-item/states.svelte.ts
+++ b/qt-core/webview-ui/src/apps/new-item/states.svelte.ts
@@ -21,6 +21,7 @@ export const input = $state({
   name: 'untitled',
   workingDir: '',
   saveProjectDir: false,
+  openInNewWindow: false,
 
   issues: {
     name: new InputIssue(),

--- a/qt-core/webview-ui/src/apps/new-item/viewlogic.svelte.ts
+++ b/qt-core/webview-ui/src/apps/new-item/viewlogic.svelte.ts
@@ -119,7 +119,8 @@ export async function createItemFromSelectedPreset() {
       workingDir: input.workingDir,
       presetId: data.selected.preset?.id,
       options: $state.snapshot(ui.unsavedOptionChanges),
-      saveProjectDir: input.saveProjectDir
+      saveProjectDir: input.saveProjectDir,
+      openInNewWindow: input.openInNewWindow
     });
   } catch (e) {
     reportUiError('Error creating item', e);
@@ -265,7 +266,7 @@ async function loadPresets() {
 }
 
 function loadDefautInputs() {
-  let candidate = data.selected.type === 'file'
+  const candidate = data.selected.type === 'file'
     ? data.configs.newFileBaseDir
     : data.configs.newProjectBaseDir;
 

--- a/qt-core/webview-ui/src/apps/texts.ts
+++ b/qt-core/webview-ui/src/apps/texts.ts
@@ -34,6 +34,7 @@ export const wizard = {
   workingDir: 'Create in',
   workingDirTooltip: 'Browse',
   workingDirSaveCheckbox: 'Use as default project directory',
+  openInNewWindow: 'Open in a new window',
 
   enterNewPresetName: 'Enter a new name for the custom preset',
   confirmDeletePreset: 'Delete the preset?',


### PR DESCRIPTION
Add a checkbox next to the [Create] button for project templates only. When selected, the created folder will be opened in a new VSCode window.

Refactor related code to improve code flow clarity.

Task-number: [VSCODEEXT-224](https://qt-project.atlassian.net/browse/VSCODEEXT-224)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
