### PR TITLE
qt-cpp: Disable module filtering for Presets Projects on macOS

### DIFF
--- a/qt-cpp/src/project.ts
+++ b/qt-cpp/src/project.ts
@@ -550,13 +550,6 @@ export class CppProject implements Project {
     if (installationPath) {
       return installationPath;
     }
-    // const qtPathsExe = getQtPathsExe(kit);
-    // if (qtPathsExe) {
-    //   const qtInfo = coreAPI?.getQtInfoFromPath(qtPathsExe);
-    //   if (qtInfo) {
-    //     return qtInfo.get('QT_INSTALL_PREFIX');
-    //   }
-    // }
     return undefined;
   }
   async getInstallationPath() {

--- a/qt-cpp/src/project.ts
+++ b/qt-cpp/src/project.ts
@@ -378,7 +378,7 @@ export class CppProject implements Project {
       if (isEmpty(modules)) {
         continue;
       }
-      if (IsMacOS) {
+      if (IsMacOS && this._type === CppProjectType.Kit) {
         const majorVersion = await getMajorQtVersion();
         if (majorVersion) {
           modules = modules.map((module) => {


### PR DESCRIPTION
Since we need the Major Qt Version on MacOS and it is not available for Presets Projects without using qtpaths, we should disable it. Otherwise, it shows users a `Select a CMake Kit` prompt every time they build.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
