### PR TITLE
qt-lib, qt-core, qt-cpp, qt-qml, qt-ui: Remove installationPath from CoreAPI

### DIFF
--- a/qt-core/src/translation.ts
+++ b/qt-core/src/translation.ts
@@ -9,7 +9,6 @@ import {
   CoreKey,
   createLogger,
   exists,
-  findQtPathsInInstallationPath,
   IsMacOS,
   IsWindows,
   OSExeSuffix,
@@ -50,10 +49,6 @@ export async function openInLinguistCommand() {
     project.folder,
     CoreKey.PYSIDE_ENV_DATA
   );
-  const selectedKitPath = coreAPI?.getValue<string>(
-    project.folder,
-    CoreKey.INSTALLATION_PATH
-  );
   const selectedQtPaths = coreAPI?.getValue<string>(
     project.folder,
     CoreKey.SELECTED_QT_PATHS
@@ -69,10 +64,8 @@ export async function openInLinguistCommand() {
   }
 
   if (workspaceFeatures?.projectTypes.cmake) {
-    if (selectedKitPath) {
-      linguistPath = await locateLinguist(selectedKitPath);
-    } else if (selectedQtPaths) {
-      linguistPath = await locateLinguistFromQtPaths(selectedQtPaths);
+    if (selectedQtPaths) {
+      linguistPath = await locateLinguist(selectedQtPaths);
     }
   }
 
@@ -129,12 +122,7 @@ async function locateLinguistFromQtPaths(selectedQtPaths: string) {
   return searchForExeInQtInfo(qtInfo, getLinguistExePath);
 }
 
-async function locateLinguist(selectedKitPath: string) {
-  let linguistExePath = getLinguistExePath(path.join(selectedKitPath, 'bin'));
-  if (await exists(linguistExePath)) {
-    return linguistExePath;
-  }
-  const qtPaths = findQtPathsInInstallationPath(selectedKitPath);
+async function locateLinguist(qtPaths: string) {
   if (qtPaths) {
     const linguistPath = await locateLinguistFromQtPaths(qtPaths);
     if (linguistPath) {
@@ -143,7 +131,7 @@ async function locateLinguist(selectedKitPath: string) {
   }
 
   if (!IsWindows) {
-    linguistExePath = '/usr/bin/linguist';
+    const linguistExePath = '/usr/bin/linguist';
     if (await exists(linguistExePath)) {
       return linguistExePath;
     }

--- a/qt-cpp/src/commands/natvis.ts
+++ b/qt-cpp/src/commands/natvis.ts
@@ -55,9 +55,7 @@ export function registerNatvisCommand() {
         return '';
       }
       if (project.type === CppProjectType.Presets) {
-        const qtpaths = await project.getQtPaths({
-          includeInstallationPathSearch: true
-        });
+        const qtpaths = await project.getQtPaths();
         if (!qtpaths) {
           const error = 'Cannot find Qt Paths in the project presets';
           throw new Error(error);

--- a/qt-cpp/src/project.ts
+++ b/qt-cpp/src/project.ts
@@ -614,15 +614,6 @@ export class CppProject implements Project {
         return qtpaths;
       }
     }
-    // Check VCPKG_ROOT in environment variables and cache variables
-    // const vcpkgRoot =
-    //   presets.environment?.VCPKG_ROOT ?? presets.cacheVariables?.VCPKG_ROOT;
-    // if (isValidAndString(vcpkgRoot)) {
-    //   const qtPaths = searchForQtPathsInVCPKG(vcpkgRoot);
-    //   if (qtPaths) {
-    //     return qtPaths;
-    //   }
-    // }
     const vcpkgToolchain = await this.getToolchainFile();
     if (
       isValidAndString(vcpkgToolchain) &&

--- a/qt-cpp/src/project.ts
+++ b/qt-cpp/src/project.ts
@@ -170,7 +170,6 @@ export class CppProject implements Project {
     }
     const message = new QtWorkspaceConfigMessage(this.folder);
     const configEntries: [string, string | undefined][] = [
-      [CoreKey.INSTALLATION_PATH, await this.getInstallationPathFromPreset()],
       [CoreKey.SELECTED_QT_PATHS, await this.getQtPathsExeFromPreset()],
       [CoreKey.BUILD_DIR, await this._cmakeProject.getBuildDirectory()]
     ];
@@ -300,10 +299,7 @@ export class CppProject implements Project {
     if (vscode.env.isTelemetryEnabled && kit) {
       analyzeKit(kit);
     }
-    const installationPath = await this.getInstallationPathFromKit();
     const message = new QtWorkspaceConfigMessage(this.folder);
-    coreAPI?.setValue(this.folder, CoreKey.INSTALLATION_PATH, installationPath);
-    message.config.add(CoreKey.INSTALLATION_PATH);
 
     const selectedQtPaths = await this.getQtPaths();
     coreAPI?.setValue(this.folder, CoreKey.SELECTED_QT_PATHS, selectedQtPaths);
@@ -585,9 +581,7 @@ export class CppProject implements Project {
     }
     return undefined;
   }
-  async getQtPathsExeFromPreset({
-    includeInstallationPathSearch = false
-  } = {}) {
+  async getQtPathsExeFromPreset() {
     const presets = this._cmakeProject?.configurePreset;
     if (!presets) {
       return undefined;
@@ -613,13 +607,11 @@ export class CppProject implements Project {
       }
     }
     // Try to find Qt paths from cacheVariables and environment variables
-    if (includeInstallationPathSearch) {
-      const installationPath = await this.getInstallationPathFromPreset();
-      if (installationPath) {
-        const qtpaths = findQtPathsInInstallationPath(installationPath);
-        if (qtpaths) {
-          return qtpaths;
-        }
+    const installationPath = await this.getInstallationPathFromPreset();
+    if (installationPath) {
+      const qtpaths = findQtPathsInInstallationPath(installationPath);
+      if (qtpaths) {
+        return qtpaths;
       }
     }
     // Check VCPKG_ROOT in environment variables and cache variables
@@ -652,16 +644,21 @@ export class CppProject implements Project {
     }
     return undefined;
   }
-  async getQtPaths({ includeInstallationPathSearch = false } = {}) {
+  async getQtPaths() {
     if (this._type === CppProjectType.Kit) {
       const qtPathsExe = await this.getQtPathsExeFromKit();
       if (qtPathsExe) {
         return qtPathsExe;
       }
+      const installationPath = await this.getInstallationPathFromKit();
+      if (installationPath) {
+        const qtpaths = findQtPathsInInstallationPath(installationPath);
+        if (qtpaths) {
+          return qtpaths;
+        }
+      }
     } else if (this._type === CppProjectType.Presets) {
-      const qtPathsExe = await this.getQtPathsExeFromPreset({
-        includeInstallationPathSearch
-      });
+      const qtPathsExe = await this.getQtPathsExeFromPreset();
       if (qtPathsExe) {
         return qtPathsExe;
       }
@@ -686,7 +683,6 @@ export class CppProject implements Project {
     const message = new QtWorkspaceConfigMessage(this.folder);
     const configEntries: [string, string | undefined | QtWorkspaceFeatures][] =
       [
-        [CoreKey.INSTALLATION_PATH, await this.getInstallationPath()],
         [CoreKey.SELECTED_QT_PATHS, await this.getQtPaths()],
         [CoreKey.BUILD_DIR, await this._cmakeProject.getBuildDirectory()],
         [CoreKey.WORKSPACE_FEATURES, features]

--- a/qt-lib/src/constants.ts
+++ b/qt-lib/src/constants.ts
@@ -10,7 +10,6 @@ export const CoreKey = {
   QT_INSTALLATION_ROOT: 'qtInstallationRoot',
   PYSIDE_ENV_DATA: 'pysideEnvData',
   WORKSPACE_FEATURES: 'workspaceFeatures',
-  INSTALLATION_PATH: 'installationPath',
   SELECTED_QT_PATHS: 'selectedQtPaths',
   BUILD_DIR: 'buildDir',
   GLOBAL_WORKSPACE: 'global'

--- a/qt-qml/src/extension.ts
+++ b/qt-qml/src/extension.ts
@@ -113,17 +113,6 @@ function processMessage(message: QtWorkspaceConfigMessage) {
     }
     let updateQmlls = false;
     for (const key of message.config.keys()) {
-      if (key === CoreKey.INSTALLATION_PATH) {
-        const selectedKitPath = coreAPI?.getValue<string>(
-          message.workspaceFolder,
-          CoreKey.INSTALLATION_PATH
-        );
-        if (selectedKitPath !== project.kitPath) {
-          updateQmlls = true;
-          project.kitPath = selectedKitPath;
-        }
-        continue;
-      }
       if (key === CoreKey.SELECTED_QT_PATHS) {
         const selectedQtPaths = coreAPI?.getValue<string>(
           message.workspaceFolder,

--- a/qt-qml/src/project.ts
+++ b/qt-qml/src/project.ts
@@ -2,15 +2,8 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 import * as vscode from 'vscode';
-import path from 'path';
 
-import {
-  CoreKey,
-  Project,
-  ProjectManager,
-  createLogger,
-  findQtPathsInInstallationPath
-} from 'qt-lib';
+import { CoreKey, Project, ProjectManager, createLogger } from 'qt-lib';
 import { Qmlls } from '@/qmlls';
 import { coreAPI } from '@/extension';
 
@@ -90,12 +83,6 @@ export class QMLProject implements Project {
   async startQmlls() {
     return this.qmlls.start();
   }
-  get kitPath() {
-    return this._kitPath;
-  }
-  set kitPath(kitPath: string | undefined) {
-    this._kitPath = kitPath;
-  }
   get qtpathsExe() {
     return this._qtpathsExe;
   }
@@ -104,39 +91,17 @@ export class QMLProject implements Project {
   }
 
   getConfigValues() {
-    this.kitPath = coreAPI?.getValue<string>(
-      this.folder,
-      CoreKey.INSTALLATION_PATH
-    );
     this.qtpathsExe = coreAPI?.getValue<string>(
       this.folder,
       CoreKey.SELECTED_QT_PATHS
     );
     this.buildDir = coreAPI?.getValue<string>(this.folder, CoreKey.BUILD_DIR);
   }
-  getDocsPathFromKitDir(kitDir: string) {
-    const qtpaths = findQtPathsInInstallationPath(kitDir);
-    if (!qtpaths) {
-      logger.error(`Cannot find qtpaths in: ${this.kitPath}`);
-      return undefined;
-    }
-    const qtInfo = coreAPI?.getQtInfoFromPath(qtpaths);
-    if (!qtInfo) {
-      logger.error('Cannot find qtInfo');
-      return undefined;
-    }
-    return qtInfo.get('QT_INSTALL_DOCS');
-  }
 
   updateQmllsParams() {
     this.qmlls.clearImportPaths();
     this.qmlls.docsPath = undefined;
-    if (this.kitPath) {
-      this.qmlls.addImportPath(path.join(this.kitPath, 'qml'));
-      const docsPath = this.getDocsPathFromKitDir(this.kitPath);
-      logger.info('Setting docs path:', docsPath ?? 'undefined');
-      this.qmlls.docsPath = docsPath;
-    } else if (this.qtpathsExe) {
+    if (this.qtpathsExe) {
       const info = coreAPI?.getQtInfoFromPath(this.qtpathsExe);
       if (!info) {
         throw new Error('Cannot find Qt info');

--- a/qt-ui/src/project-manager.ts
+++ b/qt-ui/src/project-manager.ts
@@ -60,12 +60,6 @@ export class UIProjectManager extends ProjectManager<UIProject> {
     }
 
     for (const key of msg.config.keys()) {
-      if (key === CoreKey.INSTALLATION_PATH) {
-        const value = coreAPI?.getValue<string>(folder, key);
-        await project.setSelectedKitPath(value);
-        continue;
-      }
-
       if (key === CoreKey.SELECTED_QT_PATHS) {
         const value = coreAPI?.getValue<string>(folder, key);
         await project.setSelectedQtPaths(value);

--- a/qt-ui/src/project.ts
+++ b/qt-ui/src/project.ts
@@ -17,7 +17,6 @@ import { coreAPI } from '@/extension';
 import { DesignerClient } from '@/designer-client';
 import { DesignerServer } from '@/designer-server';
 import {
-  locateDesignerFromKit,
   locateDesignerFromQtPaths,
   locateDesignerFromVenvBinPaths
 } from '@/util';
@@ -44,7 +43,6 @@ export async function createUIProject(
 export class UIProject implements Project {
   private _customExePath: string | undefined;
   private _workspaceFeatures: QtWorkspaceFeatures | undefined;
-  private _selectedKitPath: string | undefined;
   private _selectedQtPaths: string | undefined;
   private _pythonEnvData: PySideEnvData | undefined;
 
@@ -90,10 +88,6 @@ export class UIProject implements Project {
       this._folder,
       CoreKey.WORKSPACE_FEATURES
     );
-    this._selectedKitPath = read<string>(
-      this._folder,
-      CoreKey.INSTALLATION_PATH
-    );
     this._selectedQtPaths = read<string>(
       this._folder,
       CoreKey.SELECTED_QT_PATHS
@@ -119,13 +113,6 @@ export class UIProject implements Project {
     if (this._workspaceFeatures !== features) {
       this._workspaceFeatures = features;
       await this._updateClient('workspaceFeatureChanged');
-    }
-  }
-
-  public async setSelectedKitPath(selectedKitPath: string | undefined) {
-    if (this._selectedKitPath !== selectedKitPath) {
-      this._selectedKitPath = selectedKitPath;
-      await this._updateClient('selectedKitPathChanged');
     }
   }
 
@@ -164,8 +151,6 @@ export class UIProject implements Project {
     // clean up
     if (reason === 'selectedKitPathChanged') {
       this._selectedQtPaths = undefined;
-    } else if (reason === 'selectedQtPathsChanged') {
-      this._selectedKitPath = undefined;
     }
   }
 
@@ -196,10 +181,6 @@ export class UIProject implements Project {
     }
 
     if (this._workspaceFeatures?.projectTypes.cmake) {
-      if (this._selectedKitPath) {
-        return locateDesignerFromKit(this._selectedKitPath);
-      }
-
       if (this._selectedQtPaths) {
         return locateDesignerFromQtPaths(this._selectedQtPaths);
       }


### PR DESCRIPTION
Remove the INSTALLATION_PATH key and all references to it across extensions.
This simplifies the configuration model by consolidating on using
SELECTED_QT_PATHS (qtpaths executable path) as the primary source for Qt
installation information.

Changes:
- Remove CoreKey.INSTALLATION_PATH from qt-lib constants
- Remove installationPath from qt-cpp project configuration messages
- Remove installationPath from qt-ui project manager and project
- Simplify getQtPaths() logic to always check installation path when needed

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
