### PR TITLE
qt-core, qt-cli: Align QRC editor and template with Qt Creator

### DIFF
--- a/qt-cli/src/assets/templates/types/qrc/file.qrc
+++ b/qt-cli/src/assets/templates/types/qrc/file.qrc
@@ -1,2 +1,3 @@
-<!DOCTYPE RCC>
-<RCC version="1.0"/>
+<RCC>
+    <qresource prefix="/"/>
+</RCC>

--- a/qt-cli/tests/e2e/expected_outputs/types_qrc/myasset.qrc
+++ b/qt-cli/tests/e2e/expected_outputs/types_qrc/myasset.qrc
@@ -1,2 +1,3 @@
-<!DOCTYPE RCC>
-<RCC version="1.0"/>
+<RCC>
+    <qresource prefix="/"/>
+</RCC>

--- a/qt-core/src/webview/qrc-editor/xml-io.ts
+++ b/qt-core/src/webview/qrc-editor/xml-io.ts
@@ -57,6 +57,8 @@ export function parseXml(data: string): RccTag | undefined {
 export function generateXml(qrc: RccTag): string {
   const builder = new XMLBuilder({
     format: true,
+    indentBy: '    ', // to be compatible with Qt Creator
+    suppressEmptyNode: true, // to be compatible with Qt Creator
     suppressBooleanAttributes: false,
     ...xmlOptions
   });
@@ -64,18 +66,11 @@ export function generateXml(qrc: RccTag): string {
   const clone = cloneAndClean(qrc);
   const xmlString = builder.build({ RCC: clone });
 
-  return `<!DOCTYPE RCC>\n${xmlString}`;
+  return xmlString;
 }
 
 export function defaultQrcLines() {
-  return [
-    '<!DOCTYPE RCC>',
-    '<RCC version="1.0">',
-    '  <qresource prefix="/">',
-    '  </qresource>',
-    '</RCC>',
-    ''
-  ];
+  return ['<RCC>', '    <qresource prefix="/"/>', '</RCC>', ''];
 }
 
 // helpers


### PR DESCRIPTION
Qt Creator-generated .qrc files differ from those created by
the VS Code extension as follows:

- Qt Creator does not include <!DOCTYPE RCC>.
- Qt Creator does not add a 'version' attribute to <RCC>.
- Qt Creator omits the closing </qresource> tag when there are no
  children.
- Qt Creator uses 4 spaces for indentation

XML builder options and hard-coded strings have been updated to align
the outputs with that of Qt Creator.

The .qrc template and test in qt-cli have been updated accordingly.

Task-number: [VSCODEEXT-265](https://qt-project.atlassian.net/browse/VSCODEEXT-265)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
