### PR TITLE
qt-core: Force text editor for .qrc files in specific extensions

### DIFF
--- a/qt-core/package.json
+++ b/qt-core/package.json
@@ -35,6 +35,11 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "configurationDefaults": {
+      "workbench.editorAssociations": {
+        "{git,gitlens,chat-editing-snapshot-text-model,copilot,git-graph,git-graph-3}:/**/*.qrc": "default"
+      }
+    },
     "commands": [
       {
         "command": "qt-core.documentationHomepage",


### PR DESCRIPTION
Configured `workbench.editorAssociations` so that git, copilot and some other extensions use the built-in text editor instead of the custom webview editor for .qrc files.

Task-number: [VSCODEEXT-265](https://qt-project.atlassian.net/browse/VSCODEEXT-265)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
