### PR TITLE
qt-python: Support installing commercial PySide6

### DIFF
--- a/qt-python/src/env.ts
+++ b/qt-python/src/env.ts
@@ -9,7 +9,7 @@ import {
 } from '@vscode/python-extension';
 
 import { isError, OSExeSuffix, createLogger } from 'qt-lib';
-import { PySidePackageInfo } from './types';
+import { PipPackageInfo } from './types';
 import { PySideCommandRunner } from './runner';
 import * as utils from './utils';
 import * as consts from './constants';
@@ -52,46 +52,12 @@ export class PySideEnv {
     this._setupWatcher(pyApi);
   }
 
+  public async readPackageInfo(name: string) {
+    return runPipShowAndParseInfo(this, name);
+  }
+
   public async readPySide6PackageInfo() {
-    const parsedOutput: Record<string, string> = {};
-
-    try {
-      // expected output from 'pip show <package>'
-      //
-      // Version: 6.10.0
-      // Summary: Python bindings for the Qt cross-platform application and UI framework
-      // Home-page:
-      // Author:
-      // Author-email: Qt for Python Team <pyside@qt-project.org>
-      // License: LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
-      // Location: /Users/bencho/ws_temp/myenv/lib/python3.9/site-packages
-      // Requires: PySide6_Essentials, PySide6_Addons, shiboken6
-      // Required-by:
-
-      const logIndented = (line: string) => {
-        logger.info(' ', line);
-      };
-
-      const runner = new PySideCommandRunner(this);
-      runner.onStdout(logIndented);
-      runner.onStderr(logIndented);
-
-      const lines = await runner.run(`pip show PySide6`, { useVenv: true });
-      lines.forEach((line) => {
-        const [key, value] = line.split(': ');
-        if (key && value) {
-          parsedOutput[key.trim()] = value.trim();
-        }
-      });
-    } catch (e) {
-      logger.error(' ', isError(e) ? e.message : String(e));
-      return undefined;
-    }
-
-    return {
-      version: parsedOutput.Version ?? '',
-      location: parsedOutput.Location ?? ''
-    } as PySidePackageInfo;
+    return runPipShowAndParseInfo(this, 'PySide6');
   }
 
   private _setupWatcher(pyApi: PyApi) {
@@ -141,4 +107,47 @@ export class PySideEnv {
       this._activeFSWatcher = undefined;
     }
   }
+}
+
+// helper
+async function runPipShowAndParseInfo(env: PySideEnv, name: string) {
+  const parsedOutput: Record<string, string> = {};
+
+  try {
+    // expected output from 'pip show <package>'
+    //
+    // Version: 6.10.0
+    // Summary: Python bindings for the Qt cross-platform application and UI framework
+    // Home-page:
+    // Author:
+    // Author-email: Qt for Python Team <pyside@qt-project.org>
+    // License: LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+    // Location: /Users/bencho/ws_temp/myenv/lib/python3.9/site-packages
+    // Requires: PySide6_Essentials, PySide6_Addons, shiboken6
+    // Required-by:
+
+    const logIndented = (line: string) => {
+      logger.info(' ', line);
+    };
+
+    const runner = new PySideCommandRunner(env);
+    runner.onStdout(logIndented);
+    runner.onStderr(logIndented);
+
+    const lines = await runner.run(`pip show ${name}`, { useVenv: true });
+    lines.forEach((line) => {
+      const [key, value] = line.split(': ');
+      if (key && value) {
+        parsedOutput[key.trim()] = value.trim();
+      }
+    });
+  } catch (e) {
+    logger.error(' ', isError(e) ? e.message : String(e));
+    return undefined;
+  }
+
+  return {
+    version: parsedOutput.Version ?? '',
+    location: parsedOutput.Location ?? ''
+  } as PipPackageInfo;
 }

--- a/qt-python/src/installer.ts
+++ b/qt-python/src/installer.ts
@@ -13,7 +13,10 @@ import {
 } from 'qt-lib';
 import { PySideEnv } from './env';
 import { PySideProject } from './project';
-import { PySideCommandRunner } from './runner';
+import {
+  PySideCommandRunner,
+  PySideCommandRunOptions as RunOptions
+} from './runner';
 import { coreApi, projectManager } from './extension';
 import { normalizeDriveLetter } from './utils';
 import * as texts from './texts';
@@ -26,7 +29,7 @@ interface TargetProjectItem extends vscode.QuickPickItem {
 }
 
 interface InstallSourceItem extends vscode.QuickPickItem {
-  source?: 'oss' | 'local' | 'download';
+  source?: 'oss' | 'commercial' | 'local' | 'download';
   env?: PySideEnv;
   localPath?: string;
 }
@@ -163,32 +166,56 @@ async function tryInstallPySide(
   const logIndented = (line: string) => {
     info(folder, ' ', line);
   };
+  const runner = new PySideCommandRunner(env);
+  runner.onStdout(logIndented);
+  runner.onStderr(logIndented);
 
   const linkText = texts.install.popup.linkShowLog;
   const linkCommand = `${consts.COMMAND_PREFIX}.${consts.COMMAND_SHOW_LOG}`;
   const linkShowLogs = `[${linkText}](command:${linkCommand})`;
 
+  const popups = texts.install.popup;
   const options = {
-    title: texts.install.popup.installing + ` (${linkShowLogs})`,
     location: vscode.ProgressLocation.Notification,
     cancellable: false
   };
 
-  await vscode.window.withProgress(options, async () => {
-    const runner = new PySideCommandRunner(env);
-    runner.onStdout(logIndented);
-    runner.onStderr(logIndented);
+  await vscode.window.withProgress(options, async (progress) => {
+    async function run(command: string, message: string, opts?: RunOptions) {
+      progress.report({ message: `${message} (${linkShowLogs})` });
+      await runner.run(command, {
+        useVenv: true,
+        ...opts
+      });
+    }
 
     try {
-      if (source.source === 'oss') {
-        await runner.run('pip install PySide6', { useVenv: true });
-      } else if (source.source === 'local' && source.localPath) {
-        await runner.run('pip install -r requirements.txt', {
-          useVenv: true,
-          cwd: source.localPath
-        });
-      } else {
-        return;
+      switch (source.source) {
+        case 'oss':
+          await run('pip install PySide6', popups.installing);
+          break;
+
+        case 'commercial': {
+          const qtpip = await env.readPackageInfo('qtpip');
+          if (!qtpip) {
+            await run('pip install qtpip', popups.installingQtPip);
+          }
+
+          await run('qtpip install PySide6', popups.installingCommercial);
+          break;
+        }
+
+        case 'local':
+          if (source.localPath) {
+            await run('pip install -r requirements.txt', popups.installing, {
+              cwd: source.localPath
+            });
+            break;
+          }
+          return;
+
+        default:
+          return;
       }
 
       const pyside = await env.readPySide6PackageInfo();
@@ -237,15 +264,21 @@ async function selectInstallSource(env: PySideEnv) {
     }
   }
 
-  items.push({
-    kind: vscode.QuickPickItemKind.Separator,
-    label: ''
-  });
-
-  items.push({
-    source: 'download',
-    label: texts.install.sourcePicker.labelDownload + ' $(globe)'
-  });
+  items.push(
+    {
+      kind: vscode.QuickPickItemKind.Separator,
+      label: ''
+    },
+    {
+      source: 'commercial',
+      label: texts.install.sourcePicker.labelCommercial,
+      env
+    },
+    {
+      source: 'download',
+      label: texts.install.sourcePicker.labelDownload + ' $(globe)'
+    }
+  );
 
   const placeHolder = texts.install.placeHolder.selectVersion;
   return vscode.window.showQuickPick(items, { placeHolder });

--- a/qt-python/src/texts.ts
+++ b/qt-python/src/texts.ts
@@ -4,6 +4,8 @@
 export const install = {
   popup: {
     installing: 'Installing PySide6...',
+    installingQtPip: 'Installing qtpip...',
+    installingCommercial: 'Installing PySide6 (Commercial)...',
     installed: (folder: string, pysideVersion: string, venv: string) =>
       `PySide ${pysideVersion} is installed for '${folder}' ` +
       `(venv: ${venv})`,
@@ -25,6 +27,7 @@ export const install = {
   },
   sourcePicker: {
     labelOss: 'Latest PySide6 from PyPI',
+    labelCommercial: 'Latest PySide6 (Commercial) by qtpip',
     labelDownload:
       'Go to https://account.qt.io/ ' +
       'to download and install the wheels manually',

--- a/qt-python/src/types.ts
+++ b/qt-python/src/types.ts
@@ -15,7 +15,7 @@ export interface PySideProjectInfo {
   files: string[];
 }
 
-export interface PySidePackageInfo {
+export interface PipPackageInfo {
   version: string;
   location: string;
 }


### PR DESCRIPTION
Add a commercial installation option to the installation source picker. 
When selected, the extension installs `qtpip` first (if needed), and then installs `PySide6` using `qtpip`.

UI texts have been updated accordingly.

Task-Number: [VSCODEEXT-266](https://qt-project.atlassian.net/browse/VSCODEEXT-266)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
