### PR TITLE
qt-cpp:natvis-test: Cover core text/bytes core type

### DIFF
--- a/qt-cpp/test/debug-golden.mts
+++ b/qt-cpp/test/debug-golden.mts
@@ -28,6 +28,41 @@ export type SnapVar = {
 };
 
 /**
+ * Describes a NatVis type that is known to be broken or unstable.
+ *
+ * - `type`: the Qt type name reported by the debugger (e.g. "QStringView").
+ * - `description`: short human description of the known issue.
+ * - `variableNames` (optional): restrict the problem to specific variable
+ *   names (e.g. only "coreTypes.qStringView"). If omitted, problem applies
+ *   to *all* variables of that type.
+ */
+export interface KnownNatvisProblem {
+  readonly type: string;
+  readonly description: string;
+  readonly variableNames?: readonly string[];
+}
+/**
+ * Central registry of known NatVis issues.
+ *
+ * These types:
+ *   - DO NOT cause the test to fail when they differ from golden.
+ *   - ARE still compared and recorded.
+ *   - Emit diagnostics in debug mode.
+ *
+ * If a known-problem type starts matching golden again, we log a
+ * "seems fixed" message so you can remove it from this list.
+ */
+export const knownNatvisProblems: readonly KnownNatvisProblem[] = [
+  {
+    type: 'QStringView',
+    description:
+      'LLDB currently fails to evaluate {m_data,[m_size]} and prints an evaluation error instead of the string contents.'
+    // variableNames: ['coreTypes.qStringView'], // optional filter if needed
+  }
+  // Add more entries here as you discover issues.
+];
+
+/**
  * Normalizes floating-point artifacts produced by GDB/LLDB/cppvsdbg.
  * Converts things like:
  *   5.0999999999999996 → 5.1
@@ -82,15 +117,25 @@ function normalizeFloatsInStruct(raw: string): string {
 export function normalizeValue(raw: string): string {
   let value = raw.trim();
 
-  // 1) Strip leading pointer-like prefixes, with optional opening quote:
+  // Strip leading pointer-like prefixes, with optional opening quote:
   //    "0x1234 "Hello World!""  or  0x1234 "Hello World!"
   value = value.replace(/^"?(0x[0-9A-Fa-f]+|0xADDR)\s*/u, '');
   value = value.trim();
 
-  // 2) Normalize floating-point artifacts everywhere (QRectF, QSizeF, etc.)
+  // Normalize floating-point artifacts everywhere (QRectF, QSizeF, etc.)
   value = normalizeFloatsInStruct(value);
 
-  // 3) If there is a final quoted payload (optional leading 'u'), extract it:
+  // Special case: QChar-style representation
+  //    Windows: "99 u'c'"
+  //    Other OSes: "99 'c'"
+  //    → normalize both to "99 'c'"
+  const qCharLike = value.match(/^(\d+)\s+u'([^']*)'$/u);
+  if (qCharLike) {
+    const [, code, ch] = qCharLike;
+    return `${code} '${ch}'`;
+  }
+
+  // If there is a final quoted payload (optional leading 'u'), extract it:
   //
   //    u"Hello World!""   -> Hello World!
   //    "Hello World!""    -> Hello World!
@@ -101,7 +146,7 @@ export function normalizeValue(raw: string): string {
     return quoted[1];
   }
 
-  // 4) Fallbacks for simpler fully-quoted forms, just in case:
+  // Fallbacks for simpler fully-quoted forms, just in case:
   if (value.startsWith('"') && value.endsWith('""') && value.length >= 3) {
     // "Hello World!"" -> Hello World!
     return value.slice(1, -2);

--- a/qt-cpp/test/projectFolderNatvis/core_types.h
+++ b/qt-cpp/test/projectFolderNatvis/core_types.h
@@ -9,9 +9,9 @@ struct CoreTypes
 {
     // text / bytes
     QByteArray   qByteArray;
-    //QChar        qChar;
+    QChar        qChar;
     QString      qString;
-    //QStringView  qStringView;
+    QStringView  qStringView;
 
     // date/time
     // QDate        qDate;
@@ -56,9 +56,9 @@ struct CoreTypes
 
 inline CoreTypes::CoreTypes()
     : qByteArray("Hello World!")
-    //, qChar(u'c')
-    , qString(QStringLiteral("Hello World!"))
-    //, qStringView(qString)
+    , qChar(u'c')
+    , qString(QStringLiteral("Hello World! Again."))
+    , qStringView(qString)
     // , qDate(QDate::currentDate())
     // , qDateTimeLocal(QDateTime::currentDateTime())
     // , qDateTimeUtc(QDateTime::currentDateTimeUtc())

--- a/qt-cpp/test/projectFolderNatvis/expected.locals.json
+++ b/qt-cpp/test/projectFolderNatvis/expected.locals.json
@@ -5,6 +5,11 @@
     "value": "Hello World!"
   },
   {
+    "name": "coreTypes.qChar",
+    "type": "QChar",
+    "value": "99 'c'"
+  },
+  {
     "name": "coreTypes.qLine",
     "type": "QLine",
     "value": "{ start point = { x = 0, y = 1 }, end point = { x = 42, y = 43 } }"
@@ -32,6 +37,11 @@
   {
     "name": "coreTypes.qString",
     "type": "QString",
-    "value": "Hello World!"
+    "value": "Hello World! Again."
+  },
+  {
+    "name": "coreTypes.qStringView",
+    "type": "QStringView",
+    "value": "Hello World! Again."
   }
 ]

--- a/qt-cpp/test/suite/natvis.test.mts
+++ b/qt-cpp/test/suite/natvis.test.mts
@@ -6,6 +6,7 @@ import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import { isDeepStrictEqual } from 'util';
 
 import { delay } from 'qt-lib';
 import {
@@ -33,9 +34,11 @@ import {
   collectTypesFromSnapshot,
   matchNatvisTypePatternsConsideringAlternatives,
   writeGolden,
-  readGolden
+  readGolden,
+  knownNatvisProblems
 } from '../debug-golden.mts';
 import { selectAndApplyQtKit } from '../qt-kits-helper.mts';
+import { forEach } from 'lodash';
 
 function getRequiredQtMajorFromCMake(projectDir: string): number {
   const cmakeListsPath = path.join(projectDir, 'CMakeLists.txt');
@@ -217,6 +220,112 @@ async function configureAndBuildMinimalQtProject(
   return { wsFolder, projectDir, buildDir, kit, errSpy };
 }
 
+/**
+ * Compare two NatVis snapshots (actual vs golden) and return only the
+ * *real* mismatches. This comparison is aware of "known NatVis problems":
+ *
+ *   - If a mismatched entry corresponds to a type listed in
+ *     knownNatvisProblems → the mismatch is *ignored* (not returned)
+ *     and a debug message is printed explaining the known issue.
+ *
+ *   - If a known-problem type appears in the actual snapshot but does
+ *     NOT mismatch the golden → a “good news” debug message is printed,
+ *     indicating that the problematic NatVis rule is now fixed.
+ *
+ *   - If a known-problem type does *not* appear in the actual snapshot
+ *     at all → a debug warning is printed to indicate that the sample
+ *     no longer covers that type (possibly accidental).
+ *
+ * Behavior summary:
+ *   1. Unknown mismatches → returned for the test to fail.
+ *   2. Known-problem mismatches → filtered out + logged.
+ *   3. Known-problem matches → logged as “fixed”.
+ *   4. Known-problem missing from snapshot → logged as “no longer present”.
+ *
+ * Output:
+ *   Returns an array of only the real, unexpected mismatches:
+ *     [{ index, actual, expected }, …]
+ *
+ * This allows the test to remain strict while still remaining stable and
+ * informative when NatVis rules are known to be broken on certain types.
+ */
+export function findMismatchedSnapshotEntries(
+  actual: any[],
+  expected: any[]
+): Array<{ index: number; actual: any; expected: any }> {
+  const mismatches: Array<{ index: number; actual: any; expected: any }> = [];
+  const len = Math.max(actual.length, expected.length);
+
+  // Track presence of problematic types
+  const actualTypes = new Set(actual.map((v) => v?.type).filter(Boolean));
+
+  // Track which known-problem types had mismatches
+  const problematicTypesWithMismatch = new Set<string>();
+
+  // ---- Main mismatch detection loop ------------------------------------
+  for (let i = 0; i < len; i++) {
+    const a = actual[i];
+    const e = expected[i];
+
+    // If equal → no issue
+    if (isDeepStrictEqual(a, e)) continue;
+
+    const t = a?.type ?? e?.type ?? undefined;
+
+    const problem = t
+      ? knownNatvisProblems.find((p) => p.type === t)
+      : undefined;
+
+    if (problem) {
+      // Known problem mismatch → ignore but record
+      problematicTypesWithMismatch.add(t!);
+
+      if (process.env.QT_TEST_DEBUG === '1') {
+        console.warn(
+          `[natvis.test][known-problem] '${t}' mismatch ignored — still broken.\n` +
+            `  Reason: ${problem.description}`
+        );
+      }
+      continue;
+    }
+
+    // Unknown mismatch → real failure
+    mismatches.push({ index: i, actual: a, expected: e });
+  }
+
+  // ---- Post-analysis reporting (debug mode only) -----------------------
+  if (process.env.QT_TEST_DEBUG === '1') {
+    for (const prob of knownNatvisProblems) {
+      const t = prob.type;
+
+      const seenInActual = actualTypes.has(t);
+      const hadMismatch = problematicTypesWithMismatch.has(t);
+
+      if (seenInActual && hadMismatch) {
+        // Known problem still broken — already logged above
+        continue;
+      }
+
+      if (seenInActual && !hadMismatch) {
+        // GOOD NEWS → actual contains the type but mismatch did not happen
+        console.warn(
+          `[natvis.test][good-news] Known problem '${t}' no longer mismatches!\n` +
+            `  Description was: ${prob.description}`
+        );
+      }
+
+      if (!seenInActual) {
+        console.warn(
+          `[natvis.test][warning] Known-problem type '${t}' no longer appears in Locals.\n` +
+            `  (Maybe it's no longer constructed or NatVis expansion changed?)`
+        );
+      }
+    }
+  }
+
+  return mismatches;
+}
+
 // ---------------------------------------------------------------------------
 // Main NatVis golden test
 // ---------------------------------------------------------------------------
@@ -381,11 +490,50 @@ describe('natvis: minimal Qt project debug (index-natvis)', function () {
           );
         }
 
-        // Compare ONLY NatVis-covered types (qRect, qByteArray, qString, etc.)
-        expect(
+        const mismatches = findMismatchedSnapshotEntries(
           natvisSnapshot,
-          'Locals mismatch vs golden (NatVis-covered types only)'
-        ).to.deep.equal(golden);
+          golden
+        );
+        forEach(mismatches, (m) => {
+          console.error(
+            `[natvis.test] Mismatch at index ${m.index}:\n` +
+              `  Actual:   ${JSON.stringify(m.actual)}\n` +
+              `  Expected: ${JSON.stringify(m.expected)}`
+          );
+        });
+        if (mismatches.length > 0) {
+          // Build a human-readable header like you have now
+          const headerLines: string[] = [];
+          headerLines.push(
+            'NatVis mismatch (after filtering known-problem types):',
+            ''
+          );
+
+          for (const m of mismatches) {
+            headerLines.push(
+              `Index ${m.index}:`,
+              `  Actual:   ${JSON.stringify(m.actual, null, 2)}`,
+              `  Expected: ${JSON.stringify(m.expected, null, 2)}`,
+              ''
+            );
+          }
+
+          const message = headerLines.join('\n');
+
+          // Take the *first* mismatch and let Chai show a full colored diff
+          const first = mismatches[0]!;
+
+          expect(
+            first.actual,
+            `${message}\nFirst mismatched snapshot vs golden (see diff below):`
+          ).to.deep.equal(first.expected);
+        }
+
+        //Compare ONLY NatVis-covered types (qRect, qByteArray, qString, etc.)
+        // expect(
+        //   natvisSnapshot,
+        //   'Locals mismatch vs golden (NatVis-covered types only)'
+        // ).to.deep.equal(golden);
 
         //    Coverage warning/error still based on full NatVis coverage
         const SHOW_COVERAGE_MISSING = process.env.NATVIS_SHOW_MISSING === '1';


### PR DESCRIPTION
Add mismatch filtering for known-problem types:
- Added findMismatchedSnapshotEntries() to deep-compare snapshot vs golden.
- Filter out mismatches for known NatVis problems (e.g. QStringView).
- If other mismatches remain, report a clear diff and fail.
- If a known problem disappears, report it as fixed.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
