### PR TITLE
qt-cpp:natvis-test: Fix session reference in debug helper

### DIFF
--- a/qt-cpp/test/debug-helper.mts
+++ b/qt-cpp/test/debug-helper.mts
@@ -157,8 +157,9 @@ export async function startDebugAndWaitForStop(
     );
 
     const trackerDisp = vscode.debug.registerDebugAdapterTrackerFactory('*', {
-      createDebugAdapterTracker: (s) => ({
-        onDidSendMessage: async (m: any) => {
+      createDebugAdapterTracker: (s) => {
+        session = s;
+        const onMessageSend = async (m: any) => {
           if (m?.event === 'stopped') {
             const reason: string | undefined = m?.body?.reason;
             let tid: number | undefined = m?.body?.threadId;
@@ -214,15 +215,15 @@ export async function startDebugAndWaitForStop(
               new Error('Debug session terminated before hitting a breakpoint')
             );
           }
-        }
-      })
+        };
+        return { onDidSendMessage: onMessageSend };
+      }
     });
   });
 
   const started = await vscode.debug.startDebugging(wsFolder, cfg);
   if (!started) throw new Error('Failed to start debug session');
 
-  session = vscode.debug.activeDebugSession!;
   await done;
   return { session, stops };
 }


### PR DESCRIPTION
The \`startDebugAndWaitForStop()\` function was using \`vscode.debug.activeDebugSession\` to capture the debug session reference after calling \`startDebugging()\`. This could result in a stale or undefined session reference by the time subsequent DAP requests were made.

The fix captures the session directly from the debug adapter tracker's \`createDebugAdapterTracker\` callback, where the actual \`DebugSession\` object is provided as a parameter. This ensures the session reference remains valid throughout the debug session's lifetime.

This resolves "No debugger available, can not send 'scopes'" errors when querying local variables after hitting a breakpoint in the natvis tests.

Task-number: [VSCODEEXT-267](https://qt-project.atlassian.net/browse/VSCODEEXT-267)