### PR TITLE
qt-core: Add split button for project creation target

### DIFF
--- a/qt-core/src/state.ts
+++ b/qt-core/src/state.ts
@@ -56,6 +56,18 @@ export class GlobalStateManager extends BaseStateManager {
     return this._update(AdditionalQtPathsName, paths);
   }
 
+  public getNewProjectOpenIn(): 'addToWorkspace' | 'newWindow' {
+    return this._get<'addToWorkspace' | 'newWindow'>(
+      'newProjectOpenIn',
+      'newWindow'
+    );
+  }
+  public setNewProjectOpenIn(
+    value: 'addToWorkspace' | 'newWindow'
+  ): Thenable<void> {
+    return this._update('newProjectOpenIn', value);
+  }
+
   public async reset() {
     await this.setQtInstallationRoot('');
     await this.setAdditionalQtPaths([]);

--- a/qt-core/src/webview/new-item/dispatcher.ts
+++ b/qt-core/src/webview/new-item/dispatcher.ts
@@ -12,6 +12,7 @@ import { openFilesUnder, openUri } from '@/qtcli/common';
 import { getNewProjectBaseDir, setDefaultProjectDir } from '@/qtcli/commands';
 import { WebviewChannel } from '@/webview/channel';
 import { Command, CommandId, IsCommand } from '@/webview/shared/message';
+import { GlobalStateManager } from '@/state';
 import type { NewItemPanel } from './panel';
 
 const logger = createLogger('new-item-handler');
@@ -23,6 +24,7 @@ export class NewItemDispatcher {
   private _comm: WebviewChannel | undefined;
   private _panel: NewItemPanel | undefined = undefined;
   private _uiConfigs: unknown = {};
+  private _context: vscode.ExtensionContext | undefined;
 
   public constructor() {
     this._handlers = new Map<CommandId, CommandHandler>([
@@ -35,7 +37,8 @@ export class NewItemDispatcher {
       [CommandId.UiGetPresetById, this.onUiGetPresetById],
       [CommandId.UiValidateInputs, this.onUiValidateInputs],
       [CommandId.UiManageCustomPreset, this.onUiManageCustomPreset],
-      [CommandId.UiSelectWorkingDir, this.onUiSelectWorkingDir]
+      [CommandId.UiSelectWorkingDir, this.onUiSelectWorkingDir],
+      [CommandId.UiSaveOpenInPreference, this.onUiSaveOpenInPreference]
     ]);
   }
 
@@ -53,6 +56,10 @@ export class NewItemDispatcher {
 
   public setUiConfigs(c: unknown) {
     this._uiConfigs = c;
+  }
+
+  public setContext(context: vscode.ExtensionContext) {
+    this._context = context;
   }
 
   public dispatch(cmd: unknown) {
@@ -85,7 +92,10 @@ export class NewItemDispatcher {
         data: cmd.payload
       });
 
-      openItemsFromQtcliResponseData(data);
+      const openIn = _.get(cmd.payload, 'openIn', 'addToWorkspace') as
+        | 'addToWorkspace'
+        | 'newWindow';
+      openItemsFromQtcliResponseData(data, openIn);
 
       const type = _.get(cmd.payload, 'type', '') as string;
       const save = _.get(cmd.payload, 'saveProjectDir', false) as boolean;
@@ -93,6 +103,12 @@ export class NewItemDispatcher {
 
       if (type === 'project' && save && workingDir.length !== 0) {
         await setDefaultProjectDir(workingDir);
+      }
+
+      // Save the openIn preference for projects
+      if (type === 'project' && this._context) {
+        const globalState = new GlobalStateManager(this._context);
+        await globalState.setNewProjectOpenIn(openIn);
       }
 
       this._panel?.close();
@@ -209,10 +225,21 @@ export class NewItemDispatcher {
       this._comm?.postDataReply(cmd, folder);
     }
   };
+
+  private readonly onUiSaveOpenInPreference = async (cmd: Command) => {
+    const value = cmd.payload as 'addToWorkspace' | 'newWindow';
+    if (this._context) {
+      const globalState = new GlobalStateManager(this._context);
+      await globalState.setNewProjectOpenIn(value);
+    }
+  };
 }
 
 // helpers
-function openItemsFromQtcliResponseData(data: unknown) {
+function openItemsFromQtcliResponseData(
+  data: unknown,
+  openIn = 'addToWorkspace'
+) {
   const type = _.get(data, 'type', '') as string;
   const files = _.get(data, 'files', []) as string[];
   const filesDir = _.get(data, 'filesDir', '') as string;
@@ -221,7 +248,12 @@ function openItemsFromQtcliResponseData(data: unknown) {
   }
 
   if (type === 'project') {
-    void openUri(vscode.Uri.file(path.normalize(filesDir)));
+    const uri = vscode.Uri.file(path.normalize(filesDir));
+    if (openIn === 'newWindow') {
+      void vscode.commands.executeCommand('vscode.openFolder', uri, true);
+    } else {
+      void openUri(uri);
+    }
   } else {
     void openFilesUnder(path.normalize(filesDir), files);
   }

--- a/qt-core/src/webview/new-item/panel.ts
+++ b/qt-core/src/webview/new-item/panel.ts
@@ -15,6 +15,7 @@ import {
 } from '@/webview/utils';
 import { EXTENSION_ID } from '@/constants';
 import { startQtcliServer } from '@/qtcli/runner';
+import { GlobalStateManager } from '@/state';
 
 // definitions for webview-panel
 const PanelColumn = vscode.ViewColumn.One;
@@ -56,6 +57,7 @@ export class NewItemPanel {
     this._panel = panel;
     this._dispatcher.setPanel(this);
     this._dispatcher.setComm(this._comm);
+    this._dispatcher.setContext(context);
 
     this._disposables = [
       panel.onDidDispose(this.dispose.bind(this)),
@@ -95,9 +97,13 @@ export class NewItemPanel {
 
     void startQtcliServer(context.extensionUri);
 
+    const globalState = new GlobalStateManager(context);
+    const savedOpenIn = globalState.getNewProjectOpenIn();
+
     NewItemPanel.instance._dispatcher.setUiConfigs({
       newFileBaseDir: getNewFileBaseDir(),
-      newProjectBaseDir: getNewProjectBaseDir()
+      newProjectBaseDir: getNewProjectBaseDir(),
+      openIn: savedOpenIn
     });
     NewItemPanel.instance._panel.reveal(PanelColumn);
   }

--- a/qt-core/src/webview/shared/message.ts
+++ b/qt-core/src/webview/shared/message.ts
@@ -15,6 +15,7 @@ export enum CommandId {
   UiValidateInputs,
   UiManageCustomPreset,
   UiSelectWorkingDir,
+  UiSaveOpenInPreference,
 
   // qrc editor
   QrcDocChanged,

--- a/qt-core/webview-ui/src/apps/new-item/WizardSectionInput.svelte
+++ b/qt-core/webview-ui/src/apps/new-item/WizardSectionInput.svelte
@@ -8,6 +8,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   import { Check, FolderOpen } from '@lucide/svelte';
 
   import IconButton from '@/comps/IconButton.svelte';
+  import SplitButton from '@/comps/SplitButton.svelte';
   import SectionLabel from '@/comps/SectionLabel.svelte';
   import InputWithIssue from '@/comps/InputWithIssue.svelte';
   import * as texts from '@/apps/texts';
@@ -16,7 +17,13 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
     onWorkingDirBrowseClicked,
     createItemFromSelectedPreset,
     validateInput,
+    onOpenInChanged
   } from './viewlogic.svelte';
+
+  const openInOptions = [
+    { value: 'newWindow', label: texts.wizard.openInOptions.newWindow },
+    { value: 'addToWorkspace', label: texts.wizard.openInOptions.addToWorkspace }
+  ];
 </script>
 
 <div
@@ -68,11 +75,23 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
       <div class="grow"></div>
     {/if}
 
-    <IconButton
-      text={texts.wizard.buttons.create}
-      icon={Check}
-      disabled={!ui.canCreate}
-      onClicked={createItemFromSelectedPreset}
-    ></IconButton>
+    {#if data.selected.type === 'project'}
+      <SplitButton
+        text={texts.wizard.buttons.create}
+        icon={Check}
+        disabled={!ui.canCreate}
+        options={openInOptions}
+        bind:selectedValue={input.openIn}
+        onClicked={createItemFromSelectedPreset}
+        onValueChanged={onOpenInChanged}
+      />
+    {:else}
+      <IconButton
+        text={texts.wizard.buttons.create}
+        icon={Check}
+        disabled={!ui.canCreate}
+        onClicked={createItemFromSelectedPreset}
+      />
+    {/if}
   </div>
 </div>

--- a/qt-core/webview-ui/src/apps/new-item/states.svelte.ts
+++ b/qt-core/webview-ui/src/apps/new-item/states.svelte.ts
@@ -7,7 +7,8 @@ export const data = $state({
   serverReady: false,
   configs: {
     newFileBaseDir: '',
-    newProjectBaseDir: ''
+    newProjectBaseDir: '',
+    openIn: 'addToWorkspace' as 'addToWorkspace' | 'newWindow'
   },
   presets: [] as Preset[],
   selected: {
@@ -21,6 +22,7 @@ export const input = $state({
   name: 'untitled',
   workingDir: '',
   saveProjectDir: false,
+  openIn: 'newWindow' as 'addToWorkspace' | 'newWindow',
 
   issues: {
     name: new InputIssue(),

--- a/qt-core/webview-ui/src/apps/new-item/viewlogic.svelte.ts
+++ b/qt-core/webview-ui/src/apps/new-item/viewlogic.svelte.ts
@@ -36,7 +36,7 @@ export function onModalClosed() {
   void vscode.post(CommandId.UiClosed);
 }
 
-export function onWorkingDirBrowseClicked() {
+export async function onWorkingDirBrowseClicked() {
   const timeout = -1;
   void vscode
     .post(CommandId.UiSelectWorkingDir, input.workingDir, timeout)
@@ -49,6 +49,14 @@ export function onWorkingDirBrowseClicked() {
     .catch((e) => {
       reportUiError('Error selecting working dir', e);
     });
+}
+
+export async function onOpenInChanged(value: 'addToWorkspace' | 'newWindow') {
+  try {
+    await vscode.post(CommandId.UiSaveOpenInPreference, value);
+  } catch (e) {
+    reportUiError('Error saving openIn preference', e);
+  }
 }
 
 export async function setPresetType(type: string) {
@@ -119,7 +127,8 @@ export async function createItemFromSelectedPreset() {
       workingDir: input.workingDir,
       presetId: data.selected.preset?.id,
       options: $state.snapshot(ui.unsavedOptionChanges),
-      saveProjectDir: input.saveProjectDir
+      saveProjectDir: input.saveProjectDir,
+      openIn: input.openIn
     });
   } catch (e) {
     reportUiError('Error creating item', e);
@@ -245,6 +254,14 @@ async function loadConfigsAndInitInputs() {
       };
 
       loadDefautInputs();
+      
+      // Load the saved openIn preference if it exists
+      if ('openIn' in data.configs && data.configs.openIn) {
+        const savedValue = data.configs.openIn as 'addToWorkspace' | 'newWindow';
+        if (savedValue === 'addToWorkspace' || savedValue === 'newWindow') {
+          input.openIn = savedValue;
+        }
+      }
     }
   } catch (e) {
     reportUiError('Error loading configs', e);

--- a/qt-core/webview-ui/src/apps/texts.ts
+++ b/qt-core/webview-ui/src/apps/texts.ts
@@ -34,6 +34,10 @@ export const wizard = {
   workingDir: 'Create in',
   workingDirTooltip: 'Browse',
   workingDirSaveCheckbox: 'Use as default project directory',
+  openInOptions: {
+    addToWorkspace: 'Add to workspace',
+    newWindow: 'Open in new window'
+  },
 
   enterNewPresetName: 'Enter a new name for the custom preset',
   confirmDeletePreset: 'Delete the preset?',

--- a/qt-core/webview-ui/src/comps/SplitButton.svelte
+++ b/qt-core/webview-ui/src/comps/SplitButton.svelte
@@ -1,0 +1,91 @@
+<!--
+Copyright (C) 2025 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { nanoid } from 'nanoid';
+  import { Button, Dropdown, P } from 'flowbite-svelte';
+  import { ChevronDown } from '@lucide/svelte';
+
+  let {
+    text = '',
+    icon = undefined,
+    disabled = false,
+    options = [] as { value: string; label: string }[],
+    selectedValue = $bindable(''),
+    onClicked = () => {},
+    onValueChanged = (_value: string) => {}
+  }: {
+    text?: string;
+    icon?: any;
+    disabled?: boolean;
+    options: { value: string; label: string }[];
+    selectedValue?: string;
+    onClicked?: () => void;
+    onValueChanged?: (value: string) => void;
+  } = $props();
+
+  const id = `splitbutton_${nanoid()}`;
+  let dropdownOpen = $state(false);
+
+  function handleOptionClick(value: string) {
+    selectedValue = value;
+    dropdownOpen = false;
+    onValueChanged(value);
+  }
+
+  function handleMainButtonClick() {
+    onClicked();
+  }
+
+  function handleDropdownToggle(e: MouseEvent) {
+    e.stopPropagation();
+    dropdownOpen = !dropdownOpen;
+  }
+
+  const selectedLabel = $derived(
+    options.find(opt => opt.value === selectedValue)?.label || text
+  );
+
+  const currentIndex = $derived(
+    options.findIndex(opt => opt.value === selectedValue)
+  );
+</script>
+
+<div class="inline-flex relative">
+  <Button
+    {disabled}
+    class="qt-button rounded-r-none border-r-0"
+    on:click={handleMainButtonClick}
+  >
+    {#if icon}
+      {@const IconComp = icon}
+      <IconComp class="mr-1" />
+    {/if}
+    {selectedLabel}
+  </Button>
+  <button
+    {disabled}
+    class="qt-button rounded-l-none px-2 {dropdownOpen ? 'active' : ''}"
+    onclick={handleDropdownToggle}
+  >
+    <ChevronDown size={16} />
+  </button>
+  <Dropdown
+    open={dropdownOpen}
+    placement="top"
+    classContainer="qt-picker-list"
+    style="min-width: 200px; width: max-content;"
+  >
+    {#each options as option, i (option.value)}
+      <P
+        role="option"
+        class={`qt-item ${i === currentIndex ? 'selected' : ''}`}
+        onclick={() => handleOptionClick(option.value)}
+      >
+        {option.label}
+      </P>
+    {/each}
+  </Dropdown>
+</div>


### PR DESCRIPTION
The New Item wizard now allows users to choose whether to open newly created projects in a new window or add them to the current workspace.

This patch introduces the following changes:
- Added SplitButton.svelte component with dropdown functionality
- Added global state management for 'openIn' preference persistence
- Modified dispatcher to respect the openIn choice when opening projects
- Updated WizardSectionInput to show split button for projects only
- Added CommandId.UiSaveOpenInPreference for saving user preference
- Default behavior: Open in New Window (matching previous behavior)

The split button appears only for project creation, not for file creation, as files are always opened in the current workspace.

Task-number: [VSCODEEXT-224](https://qt-project.atlassian.net/browse/VSCODEEXT-224)