### PR TITLE
qt-qml: Fix custom qmlls path not being resolved (backport to 1.11.0)

### DIFF
--- a/qt-qml/src/qmlls.ts
+++ b/qt-qml/src/qmlls.ts
@@ -211,15 +211,15 @@ export class Qmlls {
     try {
       if (configs.get<string>('customExePath')) {
         const customPath = configs.get<string>('customExePath') ?? '';
-        const untildifiedCustomPath = resolveConfiguration(customPath);
-        const res = spawnSync(untildifiedCustomPath, ['--help'], {
+        const resolvedCustomPath = resolveConfiguration(customPath);
+        const res = spawnSync(resolvedCustomPath, ['--help'], {
           timeout: 1000
         });
         if (res.status !== 0) {
           throw res.error ?? new Error(res.stderr.toString());
         }
         telemetry.sendAction('customQmllsUsage');
-        this.startLanguageClient(customPath);
+        this.startLanguageClient(resolvedCustomPath);
       } else {
         const installed = installer.getExpectedQmllsPath();
         if (await exists(installed)) {


### PR DESCRIPTION
Backport of commit 27a1702 to 1.11.0

This fixes the custom qmlls path not being resolved issue.

(cherry picked from commit 27a1702)

Fixes: [VSCODEEXT-268](https://qt-project.atlassian.net/browse/VSCODEEXT-268)