### PR TITLE
qt-qml: Fix documentation link for QML debugging

### DIFF
--- a/qt-qml/src/commands/debug.ts
+++ b/qt-qml/src/commands/debug.ts
@@ -30,7 +30,7 @@ export function registerDebugPort() {
           if (value === openDocumentation) {
             void vscode.env.openExternal(
               vscode.Uri.parse(
-                'https://doc-snapshots.qt.io/vscodeext-dev/vscodeext-how-debug-apps-qml.html#debug-mixed-c-c-and-qml-code'
+                'https://doc-snapshots.qt.io/vscodeext-dev/vscodeext-how-debug-qml-apps.html#debug-mixed-c-c-and-qml-code'
               )
             );
           } else if (value === copyToClipboard) {


### PR DESCRIPTION
Updates the documentation link to point to the correct URL for QML debugging documentation.