### PR TITLE
qt-qml: Fix documentation link for QML debugging (backport to 1.11.0)

### DIFF
--- a/qt-qml/src/commands/debug.ts
+++ b/qt-qml/src/commands/debug.ts
@@ -30,7 +30,7 @@ export function registerDebugPort() {
           if (value === openDocumentation) {
             void vscode.env.openExternal(
               vscode.Uri.parse(
-                'https://doc-snapshots.qt.io/vscodeext-dev/vscodeext-how-debug-apps-qml.html#debug-mixed-c-c-and-qml-code'
+                'https://doc-snapshots.qt.io/vscodeext-dev/vscodeext-how-debug-qml-apps.html#debug-mixed-c-c-and-qml-code'
               )
             );
           } else if (value === copyToClipboard) {


### PR DESCRIPTION
Backport of commit 3df5919d3c3be153ee630dba0d0d912612b978cc to 1.11.0

Updates the documentation link to point to the correct URL for QML debugging documentation.

(cherry picked from commit 3df5919d3c3be153ee630dba0d0d912612b978cc)