### PR TITLE
qt-core: Add option to disable QRC editor

### DIFF
--- a/qt-core/package.json
+++ b/qt-core/package.json
@@ -101,7 +101,7 @@
       {
         "viewType": "qt-core.qrcEditor",
         "displayName": "QRC editor",
-        "priority": "default",
+        "priority": "option",
         "selector": [
           {
             "filenamePattern": "*.qrc"
@@ -238,6 +238,12 @@
           "type": "string",
           "default": "",
           "description": "Specify the default project directory when creating new projects",
+          "scope": "machine-overridable"
+        },
+        "qt-core.enableQrcEditor": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable or disable the QRC editor. When disabled, .qrc files will open in the default text editor",
           "scope": "machine-overridable"
         }
       }

--- a/qt-core/src/webview/qrc-editor/editor-provider.ts
+++ b/qt-core/src/webview/qrc-editor/editor-provider.ts
@@ -3,6 +3,7 @@
 
 import {
   window,
+  workspace,
   Disposable,
   WebviewPanel,
   TextDocument,
@@ -20,12 +21,47 @@ import {
 import { QrcDocsManager } from './docs-manager';
 import { QrcEditorController } from './controller';
 
+function updateEditorAssociation(enableQrcEditor: boolean) {
+  const type = `${EXTENSION_ID}.qrcEditor`;
+  const editorAssociations = workspace
+    .getConfiguration('workbench')
+    .get<Record<string, string>>('editorAssociations', {});
+  const qrcAssociation = enableQrcEditor ? type : 'default';
+
+  if (editorAssociations['*.qrc'] !== qrcAssociation) {
+    void workspace.getConfiguration('workbench').update(
+      'editorAssociations',
+      { ...editorAssociations, '*.qrc': qrcAssociation },
+      true // global configuration
+    );
+  }
+}
+
 export function registerQrcEditorProvider(context: ExtensionContext) {
   const type = `${EXTENSION_ID}.qrcEditor`;
   const provider = new QrcEditorProvider(context);
   const reg = window.registerCustomEditorProvider(type, provider);
 
   context.subscriptions.push(...[provider, reg]);
+
+  // Set initial editor association based on the setting
+  const config = workspace.getConfiguration(EXTENSION_ID);
+  const enableQrcEditor = config.get<boolean>('enableQrcEditor', true);
+  updateEditorAssociation(enableQrcEditor);
+
+  // Listen for configuration changes
+  const configListener = workspace.onDidChangeConfiguration((e) => {
+    if (e.affectsConfiguration(`${EXTENSION_ID}.enableQrcEditor`)) {
+      const newConfig = workspace.getConfiguration(EXTENSION_ID);
+      const newEnableQrcEditor = newConfig.get<boolean>(
+        'enableQrcEditor',
+        true
+      );
+      updateEditorAssociation(newEnableQrcEditor);
+    }
+  });
+
+  context.subscriptions.push(configListener);
 }
 
 class QrcEditorProvider implements CustomTextEditorProvider {


### PR DESCRIPTION
Add a configuration setting 'qt-core.enableQrcEditor' that allows users
to disable the QRC custom editor and use the default text editor with
syntax highlighting instead.

Fixes: [VSCODEEXT-271](https://qt-project.atlassian.net/browse/VSCODEEXT-271)
