### PR TITLE
Backport fixes for QRC editor to 1.11

### DIFF
--- a/qt-cli/src/assets/templates/types/qrc/file.qrc
+++ b/qt-cli/src/assets/templates/types/qrc/file.qrc
@@ -1,2 +1,3 @@
-<!DOCTYPE RCC>
-<RCC version="1.0"/>
+<RCC>
+    <qresource prefix="/"/>
+</RCC>

--- a/qt-cli/tests/e2e/expected_outputs/types_qrc/myasset.qrc
+++ b/qt-cli/tests/e2e/expected_outputs/types_qrc/myasset.qrc
@@ -1,2 +1,3 @@
-<!DOCTYPE RCC>
-<RCC version="1.0"/>
+<RCC>
+    <qresource prefix="/"/>
+</RCC>

--- a/qt-core/package.json
+++ b/qt-core/package.json
@@ -35,6 +35,11 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "configurationDefaults": {
+      "workbench.editorAssociations": {
+        "{git,gitlens,chat-editing-snapshot-text-model,copilot,git-graph,git-graph-3}:/**/*.qrc": "default"
+      }
+    },
     "commands": [
       {
         "command": "qt-core.documentationHomepage",

--- a/qt-core/src/webview/qrc-editor/xml-io.ts
+++ b/qt-core/src/webview/qrc-editor/xml-io.ts
@@ -57,6 +57,8 @@ export function parseXml(data: string): RccTag | undefined {
 export function generateXml(qrc: RccTag): string {
   const builder = new XMLBuilder({
     format: true,
+    indentBy: '    ', // to be compatible with Qt Creator
+    suppressEmptyNode: true, // to be compatible with Qt Creator
     suppressBooleanAttributes: false,
     ...xmlOptions
   });
@@ -64,18 +66,11 @@ export function generateXml(qrc: RccTag): string {
   const clone = cloneAndClean(qrc);
   const xmlString = builder.build({ RCC: clone });
 
-  return `<!DOCTYPE RCC>\n${xmlString}`;
+  return xmlString;
 }
 
 export function defaultQrcLines() {
-  return [
-    '<!DOCTYPE RCC>',
-    '<RCC version="1.0">',
-    '  <qresource prefix="/">',
-    '  </qresource>',
-    '</RCC>',
-    ''
-  ];
+  return ['<RCC>', '    <qresource prefix="/"/>', '</RCC>', ''];
 }
 
 // helpers


### PR DESCRIPTION
The following commits were cherry-picked:

[qt-core, qt-cli: Align QRC editor and template with Qt Creator](https://github.com/qt-labs/vscodeext/commit/f05a19af7d6f991cc15d45f8027d9527faf456a4)
[qt-core: Force text editor for .qrc files in specific extensions](https://github.com/qt-labs/vscodeext/commit/5d36a4c27de3159ff7c1ae97ffd94d4d24787822)