### PR TITLE
Qt cpp test natvis containertypes part2

### DIFF
--- a/qt-cpp/test/debug-golden-entries.mts
+++ b/qt-cpp/test/debug-golden-entries.mts
@@ -332,6 +332,16 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '{ size=3 }'
   },
   {
+    name: 'containerTypes.qVariantList',
+    type: 'QList<QVariant>',
+    value: '{ size=2 }'
+  },
+  {
+    name: 'containerTypes.qStringListExplicit',
+    type: 'QList<QString>',
+    value: '{ size=2 }'
+  },
+  {
     name: 'containerTypes.qStringList',
     type: 'QStringList',
     value: '{ size=3 }',
@@ -340,6 +350,211 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
         'Typedef (QList<QString>). The NatVis QList<*> rule evaluation fails, so the debugger falls back to "{...}"".',
       darwin:
         'Typedef (QList<QString>). The NatVis QList<*> rule evaluation fails, so the debugger falls back to "{...}"".'
+    }
+  },
+  {
+    name: 'containerTypes.qVectorInt',
+    type: 'QVector<int>',
+    value: '{ size=3 }',
+    knownProblem: {
+      linux:
+        'The NatVis QVector<*> rule evaluation fails, so the debugger falls back to "{...}"".'
+    }
+  },
+  {
+    name: 'containerTypes.qSpanInt',
+    type: 'QSpan<int>',
+    value: '{ size=3 }',
+    knownProblem: {
+      darwin:
+        "LLDB NatVis evaluation fails (e.g. 'use of undeclared identifier m_size'), so QSpan<int> isn't reliably visualized on darwin."
+    }
+  },
+  {
+    name: 'containerTypes.qVectorPoint',
+    type: 'QVector<QPoint>',
+    value: '{ size=2 }',
+    knownProblem: {
+      linux:
+        'The NatVis QVector<*> rule evaluation fails, so the debugger falls back to "{...}"".'
+    }
+  },
+  {
+    name: 'containerTypes.qVarLengthArrayInt',
+    type: 'QVarLengthArray<int, 4>',
+    value: '{ size=3 }',
+    knownProblem: {
+      darwin:
+        "LLDB NatVis errors out: expression 's' is not resolvable ('use of undeclared identifier s'), evaluation fails."
+    }
+  },
+  {
+    name: 'containerTypes.qMapStringInt',
+    type: 'QMap<QString, int>',
+    value: '{ size=2 }',
+    knownProblem: {
+      darwin:
+        'LLDB NatVis for QMap<*,*> errors: the rule relies on intrinsic p() and MSVC std::map internals (p()->m._Mypair..._Mysize), DisplayString/TreeItems fails.',
+      linux:
+        'GDB NatVis for QMap<*,*> errors: the rule relies on intrinsic p() and MSVC std::map internals (p()->m._Mypair..._Mysize), DisplayString/TreeItems fails.'
+    }
+  },
+  {
+    name: 'containerTypes.qMultiMapStringInt',
+    type: 'QMultiMap<QString, int>',
+    value: '{ size=2 }',
+    knownProblem: {
+      darwin:
+        'LLDB NatVis for QMap<*,*> errors: the rule relies on intrinsic p() and MSVC std::map internals (p()->m._Mypair..._Mysize), DisplayString/TreeItems fails.',
+      linux:
+        'GDB NatVis for QMap<*,*> errors: the rule relies on intrinsic p() and MSVC std::map internals (p()->m._Mypair..._Mysize), DisplayString/TreeItems fails.'
+    }
+  },
+  {
+    name: 'containerTypes.qHashStringInt',
+    type: 'QHash<QString, int>',
+    value: '{ size=2 }'
+  },
+  {
+    name: 'containerTypes.qMultiHashStringInt',
+    type: 'QMultiHash<QString, int>',
+    value: '{ size=1 }'
+  },
+  {
+    name: 'containerTypes.qSetString',
+    type: 'QSet<QString>',
+    value: '{ size=2 }'
+  },
+  {
+    name: 'containerTypes.qVariantMap',
+    type: 'QVariantMap',
+    value: '{ size=2 }',
+    knownProblem: {
+      darwin:
+        "LLDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary. ",
+      linux:
+        "GDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary. "
+    }
+  },
+  {
+    name: 'containerTypes.qVariantListContainer',
+    type: 'QVariantList',
+    value: '{ size=3 }',
+    knownProblem: {
+      darwin:
+        "LLDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary. ",
+      linux:
+        "GDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary. "
+    }
+  },
+  {
+    name: 'containerTypes.qVariantHash',
+    type: 'QVariantHash',
+    value: '{ size=2 }',
+    knownProblem: {
+      darwin:
+        "LLDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary. ",
+      linux:
+        "GDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary. "
+    }
+  },
+  {
+    name: 'containerTypes.qJsonArray',
+    type: 'QJsonArray',
+    value: {
+      darwin: '{...}',
+      linux: '',
+      win32: '{a={...} }'
+    }
+  },
+  {
+    name: 'containerTypes.qJsonObject',
+    type: 'QJsonObject',
+    value: {
+      darwin: '{...}',
+      linux: '',
+      win32: '{o={...} }'
+    }
+  },
+  {
+    name: 'containerTypes.qJsonValueNull',
+    type: 'QJsonValue',
+    value: {
+      darwin: '{...}',
+      linux: 'null',
+      win32: '{n=0 container=0xADDR <NULL> t=Null (278) }'
+    }
+  },
+  {
+    name: 'containerTypes.qJsonValueInt',
+    type: 'QJsonValue',
+    value: '42',
+    knownProblem: {
+      darwin:
+        'QJsonValue NatVis formatting is currently unreliable under LLDB; value collapses to "{...}".',
+      win32:
+        "NatVis DisplayString '{value}' is not applied: debugger shows internal QJsonValue fields (n/container/t) instead of the scalar value."
+    }
+  },
+  {
+    name: 'containerTypes.qJsonValueString',
+    type: 'QJsonValue',
+    value: 'forty-two',
+    knownProblem: {
+      darwin:
+        'QJsonValue NatVis formatting is currently unreliable under LLDB; value collapses to "{...}".',
+      linux:
+        'QJsonValue NatVis formatting is currently unreliable under GDB; -var-create: unable to create variable object".',
+      win32:
+        "NatVis DisplayString '{value}' is not applied: debugger shows internal QJsonValue fields (n/container/t) instead of the scalar value."
+    }
+  },
+  {
+    name: 'containerTypes.qCborMapEmpty',
+    type: 'QCborMap',
+    value: 'empty',
+    knownProblem: {
+      darwin:
+        'QCborMap NatVis relies on Qt6Cored.dll intrinsics; cbor() cannot be evaluated, so the "empty" DisplayString is not shown.',
+      linux:
+        'QCborMap NatVis relies on Qt6Cored.dll intrinsics; cbor() cannot be evaluated, so the "empty" DisplayString is not shown.',
+      win32:
+        'QCborMap NatVis uses Qt6Cored.dll intrinsics, but intrinsic evaluation is unreliable in VS Code tests, so the "empty" DisplayString is not shown.'
+    }
+  },
+  {
+    name: 'containerTypes.qCborMap',
+    type: 'QCborMap',
+    value: {
+      darwin: '{...}',
+      linux: '',
+      win32: '{d={...} }'
+    }
+  },
+  {
+    name: 'containerTypes.qCborValueNull',
+    type: 'QCborValue',
+    value: 'null',
+    knownProblem: {
+      darwin:
+        'NatVis formatting is currently unreliable under LLDB; value collapses to "{...}".',
+      linux:
+        'NatVis formatting is currently unreliable under GDB; value collapses to "undefined".',
+      win32:
+        "NatVis DisplayString '{value}' is not applied: debugger shows internal QCborValue fields (n/container/t) instead of the scalar value."
+    }
+  },
+  {
+    name: 'containerTypes.qCborValueString',
+    type: 'QCborValue',
+    value: '{...}',
+    knownProblem: {
+      darwin:
+        'NatVis formatting is currently unreliable under LLDB; value collapses to "{...}".',
+      linux:
+        'NatVis formatting is currently unreliable under GDB; -var-create: unable to create variable object".',
+      win32:
+        "NatVis DisplayString '{value}' is not applied: debugger shows internal QCborValueString fields (n/container/t) instead of the scalar value."
     }
   },
   {
@@ -371,7 +586,12 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     type: 'QCborArray',
     value: 'unknown_invalid',
     knownProblem: {
-      all: 'QCborArray NatVis output is not stable across platforms/debuggers yet (often raw/opaque forms like "{...}", quoting artifacts, or backend-specific formatting). Keep placeholder until we decide what to assert.'
+      win32:
+        'NatVis for QCborArray relies on a Windows-specific intrinsic (Qt6Cored.dll); visualization is fragile and not reliably applied by the debugger.',
+      darwin:
+        'NatVis for QCborArray uses a Windows-only intrinsic (Qt6Cored.dll), so the rule cannot be evaluated on macOS.',
+      linux:
+        'NatVis for QCborArray uses a Windows-only intrinsic (Qt6Cored.dll), so the rule cannot be evaluated on Linux.'
     }
   },
   {

--- a/qt-cpp/test/debug-golden-entries.mts
+++ b/qt-cpp/test/debug-golden-entries.mts
@@ -24,7 +24,7 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
       darwin:
         'LLDB fails to evaluate QDate intrinsics (year(), month(), day()) and prints evaluation errors instead of the formatted date.',
       linux:
-        'LLDB fails to evaluate QDate intrinsics (year(), month(), day()) and prints evaluation errors instead of the formatted date.'
+        'GDB fails to evaluate QDate intrinsics (year(), month(), day()) and prints evaluation errors instead of the formatted date.'
     }
   },
   {
@@ -34,12 +34,12 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     knownProblem: {
       darwin:
         'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB/GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors. ',
+        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB cannot evaluate the intrinsics ' +
+        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
       linux:
         'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB/GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors. ',
+        '(e.g. Qt6Cored.dll!QDateTimePrivate), so GDB cannot evaluate the intrinsics ' +
+        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
       win32:
         'NatVis loads, but required private symbols/fields are not available ' +
         '(Qt build lacks full private debug info), so DisplayString evaluation fails and the debugger ' +
@@ -53,12 +53,12 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     knownProblem: {
       darwin:
         'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB/GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors. ',
+        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB cannot evaluate the intrinsics ' +
+        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
       linux:
         'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB/GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors. ',
+        '(e.g. Qt6Cored.dll!QDateTimePrivate), so GDB cannot evaluate the intrinsics ' +
+        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
       win32:
         'NatVis loads, but required private symbols/fields are not available ' +
         '(Qt build lacks full private debug info), so DisplayString evaluation fails and the debugger ' +
@@ -72,12 +72,12 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     knownProblem: {
       darwin:
         'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB/GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors. ',
+        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB cannot evaluate the intrinsics ' +
+        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
       linux:
         'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB/GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors. ',
+        '(e.g. Qt6Cored.dll!QDateTimePrivate), so GDB cannot evaluate the intrinsics ' +
+        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
       win32:
         'NatVis loads, but required private symbols/fields are not available ' +
         '(Qt build lacks full private debug info), so DisplayString evaluation fails and the debugger ' +
@@ -91,12 +91,12 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     knownProblem: {
       darwin:
         'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB/GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors. ',
+        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB cannot evaluate the intrinsics ' +
+        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
       linux:
         'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB/GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors. ',
+        '(e.g. Qt6Cored.dll!QDateTimePrivate), so GDB cannot evaluate the intrinsics ' +
+        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
       win32:
         'NatVis loads, but required private symbols/fields are not available ' +
         '(Qt build lacks full private debug info), so DisplayString evaluation fails and the debugger ' +
@@ -121,12 +121,12 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     knownProblem: {
       darwin:
         'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB/GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors. ',
+        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB cannot evaluate the intrinsics ' +
+        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
       linux:
         'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB/GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors. ',
+        '(e.g. Qt6Cored.dll!QDateTimePrivate), so GDB cannot evaluate the intrinsics ' +
+        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
       win32:
         'NatVis loads, but required private symbols/fields are not available ' +
         '(Qt build lacks full private debug info), so DisplayString evaluation fails and the debugger ' +
@@ -140,12 +140,12 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     knownProblem: {
       darwin:
         'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB/GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors. ',
+        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB cannot evaluate the intrinsics ' +
+        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
       linux:
         'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB/GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors. ',
+        '(e.g. Qt6Cored.dll!QDateTimePrivate), so GDB cannot evaluate the intrinsics ' +
+        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
       win32:
         'NatVis loads, but required private symbols/fields are not available ' +
         '(Qt build lacks full private debug info), so DisplayString evaluation fails and the debugger ' +
@@ -159,12 +159,12 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     knownProblem: {
       darwin:
         'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB/GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors. ',
+        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB cannot evaluate the intrinsics ' +
+        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
       linux:
         'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB/GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors. ',
+        '(e.g. Qt6Cored.dll!QDateTimePrivate), so GDB cannot evaluate the intrinsics ' +
+        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
       win32:
         'NatVis loads, but required private symbols/fields are not available ' +
         '(Qt build lacks full private debug info), so DisplayString evaluation fails and the debugger ' +
@@ -177,9 +177,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '"/path/to/normalize/projectFolderNatvis"',
     knownProblem: {
       darwin:
-        'natvis expressions reference Windows-only modules (Qt6Core[d].dll), so LLDB/GDB cannot resolve the intrinsic "d()". ',
+        'natvis expressions reference Windows-only modules (Qt6Cored.dll), so LLDB cannot resolve the intrinsic d().',
       linux:
-        'natvis expressions reference Windows-only modules (Qt6Core[d].dll), so LLDB/GDB cannot resolve the intrinsic "d()". ',
+        'natvis expressions reference Windows-only modules (Qt6Cored.dll), so GDB cannot resolve the intrinsic d().',
       win32:
         'natvis loads, but DisplayString fails due to missing or incompatible private symbols (QDirPrivate) or incomplete PDBs, causing fallback to raw {d_ptr={...}} output.'
     }
@@ -190,9 +190,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '"/path/to/normalize/projectFolderNatvis"',
     knownProblem: {
       darwin:
-        '-natvis expressions depend on Windows-only Qt6Core[d].dll symbols, so LLDB/GDB cannot evaluate "d()". ',
+        'natvis expressions depend on Windows-only Qt6Cored.dll symbols, so LLDB cannot evaluate d().',
       linux:
-        '-natvis expressions depend on Windows-only Qt6Core[d].dll symbols, so LLDB/GDB cannot evaluate "d()". ',
+        'natvis expressions depend on Windows-only Qt6Cored.dll symbols, so GDB cannot evaluate d().',
       win32:
         'natvis is loaded, but DisplayString evaluation fails (likely due to absent private symbols or reduced PDBs), leading to fallback raw formatting.'
     }
@@ -203,9 +203,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '"/path/to/normalize/projectFolderNatvis"',
     knownProblem: {
       darwin:
-        'natvis rules reference Windows-only Qt6Core[d].dll symbols, so LLDB/GDB cannot compute the "d()" intrinsic. ',
+        'natvis rules reference Windows-only Qt6Cored.dll symbols, so LLDB cannot compute the d() intrinsic.',
       linux:
-        'natvis rules reference Windows-only Qt6Core[d].dll symbols, so LLDB/GDB cannot compute the "d()" intrinsic. ',
+        'natvis rules reference Windows-only Qt6Cored.dll symbols, so GDB cannot compute the d() intrinsic.',
       win32:
         'natvis loads, but DisplayString fails because required private types or fields (QFileInfoPrivate) are not available in the CI Qt build, forcing the debugger to show raw {d_ptr={...}} output.'
     }
@@ -216,9 +216,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: 'SelectCurrent | SelectAll (3)',
     knownProblem: {
       darwin:
-        'QFlags-based SelectionFlags NatVis rule only works with the Visual Studio debugger; LLDB/GDB fall back to a raw value, so flag names are not shown.',
+        'QFlags-based SelectionFlags NatVis rule only works with the Visual Studio debugger; LLDB falls back to a raw value, so flag names are not shown.',
       linux:
-        'QFlags-based SelectionFlags NatVis rule only works with the Visual Studio debugger; LLDB/GDB fall back to a raw value, so flag names are not shown.'
+        'QFlags-based SelectionFlags NatVis rule only works with the Visual Studio debugger; GDB falls back to a raw value, so flag names are not shown.'
     }
   },
   {
@@ -241,9 +241,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     },
     knownProblem: {
       darwin:
-        'QJsonDocument NatVis relies on MSVC-specific internals (d._Mypair._Myval2) and a Qt6Cored.dll private type in Expand; LLDB/GDB cannot evaluate these, so value stays as raw "{...}" on non-Windows.',
+        'QJsonDocument NatVis relies on MSVC-specific internals (d._Mypair._Myval2) and a Qt6Cored.dll private type in Expand; LLDB cannot evaluate these, so value stays as raw "{...}" on non-Windows.',
       linux:
-        'QJsonDocument NatVis relies on MSVC-specific internals (d._Mypair._Myval2) and a Qt6Cored.dll private type in Expand; LLDB/GDB cannot evaluate these, so value stays as raw "{...}" on non-Windows.'
+        'QJsonDocument NatVis relies on MSVC-specific internals (d._Mypair._Myval2) and a Qt6Cored.dll private type in Expand; GDB cannot evaluate these, so value stays as raw "{...}" on non-Windows.'
     }
   },
   {
@@ -258,7 +258,7 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
   },
   {
     name: 'coreTypes.qPointF',
-    type: 'QPoint',
+    type: 'QPointF',
     value: '{ x = 24.5, y = 48.5 }'
   },
   {
@@ -278,7 +278,7 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
   },
   {
     name: 'coreTypes.qSizeF',
-    type: 'QSize',
+    type: 'QSizeF',
     value: '{ width = 4.1, height = 4.2 }'
   },
   {
@@ -294,7 +294,7 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
       darwin:
         'LLDB currently fails to evaluate {m_data,[m_size]} and prints an evaluation error instead of the string contents.',
       linux:
-        'LLDB currently fails to evaluate {m_data,[m_size]} and prints an evaluation error instead of the string contents.'
+        'GDB currently fails to evaluate {m_data,[m_size]} and prints an evaluation error instead of the string contents.'
     }
   },
   {
@@ -308,9 +308,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: 'https://github.com/narnaud/natvis4qt',
     knownProblem: {
       darwin:
-        'LLDB/GDB cannot evaluate the pointer-arithmetic intrinsics used to access scheme()/host()/path() relying on MSVC-specific ',
+        'LLDB cannot evaluate the pointer-arithmetic intrinsics used to access scheme()/host()/path() relying on MSVC-specific.',
       linux:
-        'LLDB/GDB cannot evaluate the pointer-arithmetic intrinsics used to access scheme()/host()/path() relying on MSVC-specific ',
+        'GDB cannot evaluate the pointer-arithmetic intrinsics used to access scheme()/host()/path() relying on MSVC-specific.',
       win32:
         'natvis loads, but DisplayString evaluation fails due to missing private QtCore symbols or reduced PDBs, causing fallback to the raw internal form.'
     }
@@ -321,9 +321,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '{12345678-1234-1234-1234-1234567890AB}',
     knownProblem: {
       darwin:
-        'QUuid NatVis uses Visual Studio–only format specifiers (Xb/nvoXb) unsupported by LLDB/GDB, causing evaluation errors on macOS/Linux.',
+        'QUuid NatVis uses Visual Studio–only format specifiers (Xb/nvoXb) unsupported by LLDB, causing evaluation errors on macOS.',
       linux:
-        'QUuid NatVis uses Visual Studio–only format specifiers (Xb/nvoXb) unsupported by LLDB/GDB, causing evaluation errors on macOS/Linux.'
+        'QUuid NatVis uses Visual Studio–only format specifiers (Xb/nvoXb) unsupported by GDB, causing evaluation errors on Linux.'
     }
   },
   {
@@ -347,9 +347,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '{ size=3 }',
     knownProblem: {
       linux:
-        'Typedef (QList<QString>). The NatVis QList<*> rule evaluation fails, so the debugger falls back to "{...}"".',
+        'Typedef (QList<QString>). The NatVis QList<*> rule evaluation fails, so the debugger falls back to {...}.',
       darwin:
-        'Typedef (QList<QString>). The NatVis QList<*> rule evaluation fails, so the debugger falls back to "{...}"".'
+        'Typedef (QList<QString>). The NatVis QList<*> rule evaluation fails, so the debugger falls back to {...}.'
     }
   },
   {
@@ -358,7 +358,7 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '{ size=3 }',
     knownProblem: {
       linux:
-        'The NatVis QVector<*> rule evaluation fails, so the debugger falls back to "{...}"".'
+        'The NatVis QVector<*> rule evaluation fails, so the debugger falls back to {...}.'
     }
   },
   {
@@ -367,7 +367,7 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '{ size=3 }',
     knownProblem: {
       darwin:
-        "LLDB NatVis evaluation fails (e.g. 'use of undeclared identifier m_size'), so QSpan<int> isn't reliably visualized on darwin."
+        "LLDB NatVis evaluation fails (e.g. 'use of undeclared identifier m_size'), so QSpan<int> isn't reliably visualized on macOS."
     }
   },
   {
@@ -376,7 +376,7 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '{ size=2 }',
     knownProblem: {
       linux:
-        'The NatVis QVector<*> rule evaluation fails, so the debugger falls back to "{...}"".'
+        'The NatVis QVector<*> rule evaluation fails, so the debugger falls back to {...}.'
     }
   },
   {
@@ -431,9 +431,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '{ size=2 }',
     knownProblem: {
       darwin:
-        "LLDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary. ",
+        "LLDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary.",
       linux:
-        "GDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary. "
+        "GDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary."
     }
   },
   {
@@ -442,9 +442,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '{ size=3 }',
     knownProblem: {
       darwin:
-        "LLDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary. ",
+        "LLDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary.",
       linux:
-        "GDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary. "
+        "GDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary."
     }
   },
   {
@@ -453,9 +453,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '{ size=2 }',
     knownProblem: {
       darwin:
-        "LLDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary. ",
+        "LLDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary.",
       linux:
-        "GDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary. "
+        "GDB NatVis evaluation fails, renders as '{...}' instead of a proper map summary."
     }
   },
   {
@@ -491,7 +491,7 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '42',
     knownProblem: {
       darwin:
-        'QJsonValue NatVis formatting is currently unreliable under LLDB; value collapses to "{...}".',
+        'QJsonValue NatVis formatting is currently unreliable under LLDB; value collapses to {...}.',
       win32:
         "NatVis DisplayString '{value}' is not applied: debugger shows internal QJsonValue fields (n/container/t) instead of the scalar value."
     }
@@ -502,9 +502,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: 'forty-two',
     knownProblem: {
       darwin:
-        'QJsonValue NatVis formatting is currently unreliable under LLDB; value collapses to "{...}".',
+        'QJsonValue NatVis formatting is currently unreliable under LLDB; value collapses to {...}.',
       linux:
-        'QJsonValue NatVis formatting is currently unreliable under GDB; -var-create: unable to create variable object".',
+        'QJsonValue NatVis formatting is currently unreliable under GDB; -var-create: unable to create variable object.',
       win32:
         "NatVis DisplayString '{value}' is not applied: debugger shows internal QJsonValue fields (n/container/t) instead of the scalar value."
     }
@@ -537,7 +537,7 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: 'null',
     knownProblem: {
       darwin:
-        'NatVis formatting is currently unreliable under LLDB; value collapses to "{...}".',
+        'NatVis formatting is currently unreliable under LLDB; value collapses to {...}.',
       linux:
         'NatVis formatting is currently unreliable under GDB; value collapses to "undefined".',
       win32:
@@ -550,9 +550,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '{...}',
     knownProblem: {
       darwin:
-        'NatVis formatting is currently unreliable under LLDB; value collapses to "{...}".',
+        'NatVis formatting is currently unreliable under LLDB; value collapses to {...}.',
       linux:
-        'NatVis formatting is currently unreliable under GDB; -var-create: unable to create variable object".',
+        'NatVis formatting is currently unreliable under GDB; -var-create: unable to create variable object.',
       win32:
         "NatVis DisplayString '{value}' is not applied: debugger shows internal QCborValueString fields (n/container/t) instead of the scalar value."
     }
@@ -563,9 +563,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '{ size=2 }',
     knownProblem: {
       linux:
-        'Typedef (QList<QByteArray>). The NatVis QList<*> rule evaluation fails, so the debugger falls back to "{...}"".',
+        'Typedef (QList<QByteArray>). The NatVis QList<*> rule evaluation fails, so the debugger falls back to {...}.',
       darwin:
-        'Typedef (QList<QByteArray>). The NatVis QList<*> rule evaluation fails, so the debugger falls back to "{...}"".'
+        'Typedef (QList<QByteArray>). The NatVis QList<*> rule evaluation fails, so the debugger falls back to {...}.'
     }
   },
   {
@@ -578,7 +578,7 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     },
     knownProblem: {
       linux:
-        'Typedef (QPair<QString, int>) ule evaluation fails, so the debugger falls back to "{...}"".'
+        'Typedef (QPair<QString, int>) rule evaluation fails, so the debugger falls back to {...}.'
     }
   },
   {
@@ -600,7 +600,7 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '42',
     knownProblem: {
       darwin:
-        'QCborValue NatVis formatting is currently unreliable under LLDB; value often collapses to an opaque "{...}" form.',
+        'QCborValue NatVis formatting is currently unreliable under LLDB; value often collapses to an opaque {...} form.',
       win32:
         'QCborValue NatVis currently fails. Debugger provides: n=42 container=0xADDR <NULL> t=Integer (0) instead of just "42".'
     }

--- a/qt-cpp/test/debug-golden.mts
+++ b/qt-cpp/test/debug-golden.mts
@@ -334,6 +334,8 @@ function decodeXmlEntities(input: string): string {
  *   - `bases` : The primary (base) type patterns declared via `<Type Name="...">`.
  *   - `alts`  : Mapping from a base type pattern to the set of its
  *               `<AlternativeType>` patterns.
+ *   - `altToBase`  : Reverse mapping from an `<AlternativeType>` pattern to its
+ *                    base type pattern, derived from the NatVis file.
  *
  * This structure is used by NatVis tests to:
  *   - Match runtime snapshot types against NatVis rules,
@@ -347,34 +349,28 @@ export type NatvisTypes = {
   all: Set<string>;
   bases: Set<string>;
   alts: Map<string, Set<string>>;
+  altToBase: Map<string, string>;
 };
 
 /**
- * Parse a NatVis (.natvis) file and extract all declared type patterns,
- * including `<AlternativeType>` relationships.
+ * Parses a NatVis (.natvis) file and extracts all declared type patterns,
+ * including base <Type Name="..."> entries and their <AlternativeType> mappings.
  *
- * This helper scans the NatVis XML and builds three complementary views:
+ * The returned structure is used for:
+ * - NatVis coverage reporting (which patterns were exercised or not),
+ * - relaxed type compatibility checks in NatVis tests
+ *   (e.g. QPoint ↔ QPointF via AlternativeType),
+ * - avoiding any hard-coded knowledge of Qt type equivalence.
  *
- *   - `all`   : every type name that can be matched by NatVis
- *               (base types + alternative types).
- *   - `bases` : the primary `<Type Name="...">` entries.
- *   - `alts`  : a mapping from each base type to its `<AlternativeType>` names.
+ * Notes:
+ * - `alts` maps a base type to its AlternativeType set as declared in NatVis.
+ * - `altToBase` provides the reverse lookup (AlternativeType → base),
+ *   built deterministically from the NatVis file.
+ * - Stray <AlternativeType> elements outside of a <Type> block (rare) are
+ *   added to `all` for completeness, but cannot be reliably associated to a base
+ *   and therefore do not populate `altToBase`.
  *
- * XML comments are stripped before parsing, and XML entities
- * (e.g. `&lt;`, `&gt;`) are decoded so the resulting type patterns are
- * human-readable and match debugger output.
- *
- * The result is used by NatVis tests to:
- *   - determine which snapshot types are covered by NatVis rules,
- *   - report NatVis patterns that were not exercised by a test run,
- *   - correctly account for alternative / alias types.
- *
- * Parsing is intentionally tolerant:
- *   - malformed or unexpected NatVis content does not throw,
- *   - on error, empty collections are returned.
- *
- * @param natvisPath  Absolute path to the NatVis file to parse.
- * @returns           Collected NatVis type information (bases, alternatives, all).
+ * NatVis is treated as the single source of truth for type equivalence.
  */
 export async function parseNatvisTypesWithAlternatives(
   natvisPath: string
@@ -382,6 +378,25 @@ export async function parseNatvisTypesWithAlternatives(
   const all = new Set<string>();
   const bases = new Set<string>();
   const alts = new Map<string, Set<string>>();
+  const altToBase = new Map<string, string>();
+
+  // Seed reverse aliases from EXTRA_NATVIS_TYPE_ALIASES.
+  // Example:
+  //   'QList<*>' : ['QByteArrayList', 'QStringList']
+  // becomes:
+  //   altToBase['QByteArrayList'] = 'QList<*>'
+  //   altToBase['QStringList']    = 'QList<*>'
+  for (const [pattern, aliasNames] of Object.entries(
+    EXTRA_NATVIS_TYPE_ALIASES
+  )) {
+    for (const alias of aliasNames) {
+      if (!altToBase.has(alias)) {
+        altToBase.set(alias, pattern);
+      }
+    }
+    all.add(pattern);
+    bases.add(pattern);
+  }
 
   try {
     const xml = await fs.readFile(natvisPath, 'utf8');
@@ -414,14 +429,26 @@ export async function parseNatvisTypesWithAlternatives(
         if (!altRaw) continue;
         const alt = decodeXmlEntities(altRaw).trim();
         if (!alt) continue;
+
         all.add(alt);
-        const set = alts.get(base) ?? new Set<string>();
+
+        let set = alts.get(base);
+        if (!set) {
+          set = new Set<string>();
+          alts.set(base, set);
+        }
         set.add(alt);
-        alts.set(base, set);
+
+        // Reverse mapping: AlternativeType → base
+        // (first writer wins deterministically)
+        if (!altToBase.has(alt)) {
+          altToBase.set(alt, base);
+        }
       }
     }
 
-    // Also catch any stray AlternativeType outside blocks (rare)
+    // Also catch any stray AlternativeType outside <Type> blocks (rare).
+    // These are recorded for coverage purposes but cannot be mapped to a base.
     const strayAltRe = /<\s*AlternativeType\b[^>]*\bName\s*=\s*"([^"]+)"/g;
     while ((m = strayAltRe.exec(withoutComments))) {
       const rawAlt = m?.[1];
@@ -430,9 +457,9 @@ export async function parseNatvisTypesWithAlternatives(
       if (alt) all.add(alt);
     }
 
-    return { all, bases, alts };
+    return { all, bases, alts, altToBase };
   } catch {
-    return { all, bases, alts };
+    return { all, bases, alts, altToBase };
   }
 }
 
@@ -457,10 +484,13 @@ function wildcardToRegex(pat: string): RegExp {
 // Extra aliases for types whose *real* NatVis rule is more generic.
 // Here: SelectionFlags is a typedef / Q_DECLARE_FLAGS wrapper around QFlags<SelectionFlag>,
 // but the debugger reports the typedef name "SelectionFlags".
-const EXTRA_NATVIS_TYPE_ALIASES: Record<string, string[]> = {
+export const EXTRA_NATVIS_TYPE_ALIASES: Record<string, string[]> = {
   // NatVis pattern       // Snapshot types to treat as covered by that pattern
   'QFlags<*>': ['SelectionFlags'],
-  'QList<*>': ['QByteArrayList', 'QStringList']
+  'QList<*>': ['QByteArrayList', 'QStringList', 'QVariantList'],
+  'QPair<*,*>': ['std::pair'],
+  'QHash<*,*>': ['QVariantHash'],
+  'QMap<*,*>': ['QVariantMap']
 };
 /**
  * A base is covered if base OR ANY of its alternatives matches a seen type.

--- a/qt-cpp/test/debug-golden.mts
+++ b/qt-cpp/test/debug-golden.mts
@@ -277,40 +277,35 @@ export function materializeLocalSnapshot(
 }
 
 /**
- * Collect all distinct `type` strings appearing in a snapshot tree.
+ * Collect all distinct debugger-reported `type` strings from a snapshot.
  *
- * This helper walks a `LocalSnapshot` hierarchy (including nested children)
- * and returns the set of debugger-reported type names that actually appeared
- * in the captured Locals.
+ * Only **top-level snapshot entries** are considered. Types appearing in
+ * NatVis-expanded children are intentionally ignored so that coverage reflects
+ * which NatVis rules were exercised by root variables, not by internal or
+ * expanded implementation details.
  *
- * It is primarily used for NatVis coverage analysis, to determine:
- *   - which NatVis type patterns were exercised by a test run,
- *   - which snapshot entries should be considered for NatVis filtering.
+ * @param s
+ *   Top-level snapshot entries (typically the promoted roots returned by
+ *   `materializeLocalSnapshot`).
  *
- * @param s  Root snapshot entries to traverse.
- * @returns  Set of unique type names found in the snapshot.
+ * @returns
+ *   Set of unique debugger-reported type names found at the top level.
  */
 export function collectTypesFromSnapshot(
   s: readonly LocalSnapshot[]
 ): Set<string> {
   const out = new Set<string>();
 
-  const visit = (xs: readonly LocalSnapshot[]): void => {
-    for (const v of xs) {
-      if (v.type) {
-        out.add(v.type);
-      }
-      if (v.children) {
-        visit(v.children);
-      }
+  for (const v of s) {
+    if (v.type) {
+      out.add(v.type);
     }
-  };
+  }
 
-  visit(s);
   return out;
 }
 
-//decode &lt; &gt; &amp; &quot; &apos; in attribute values
+// Decode &lt; &gt; &amp; &quot; &apos; in attribute values
 function decodeXmlEntities(input: string): string {
   const map: Record<string, string> = {
     '&lt;': '<',
@@ -350,6 +345,18 @@ export type NatvisTypes = {
   bases: Set<string>;
   alts: Map<string, Set<string>>;
   altToBase: Map<string, string>;
+};
+
+// Extra aliases for types whose *real* NatVis rule is more generic.
+// Here: SelectionFlags is a typedef / Q_DECLARE_FLAGS wrapper around QFlags<SelectionFlag>,
+// but the debugger reports the typedef name "SelectionFlags".
+export const EXTRA_NATVIS_TYPE_ALIASES: Record<string, string[]> = {
+  // NatVis pattern       // Snapshot types to treat as covered by that pattern
+  'QFlags<*>': ['SelectionFlags'],
+  'QList<*>': ['QByteArrayList', 'QStringList', 'QVariantList'],
+  'QPair<*,*>': ['std::pair'],
+  'QHash<*,*>': ['QVariantHash'],
+  'QMap<*,*>': ['QVariantMap']
 };
 
 /**
@@ -394,8 +401,6 @@ export async function parseNatvisTypesWithAlternatives(
         altToBase.set(alias, pattern);
       }
     }
-    all.add(pattern);
-    bases.add(pattern);
   }
 
   try {
@@ -473,28 +478,40 @@ export async function parseNatvisTypesWithAlternatives(
  * @returns    RegExp that matches strings covered by the given pattern.
  */
 function wildcardToRegex(pat: string): RegExp {
-  // Escape regex specials, then turn \* into .*
-  const rx =
-    '^' +
-    pat.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '.*') +
-    '$';
+  // Escape regex specials except '*', then translate '*' to '.*'
+  const escaped = pat.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+  const rx = '^' + escaped.replace(/\*/g, '.*') + '$';
   return new RegExp(rx);
 }
 
-// Extra aliases for types whose *real* NatVis rule is more generic.
-// Here: SelectionFlags is a typedef / Q_DECLARE_FLAGS wrapper around QFlags<SelectionFlag>,
-// but the debugger reports the typedef name "SelectionFlags".
-export const EXTRA_NATVIS_TYPE_ALIASES: Record<string, string[]> = {
-  // NatVis pattern       // Snapshot types to treat as covered by that pattern
-  'QFlags<*>': ['SelectionFlags'],
-  'QList<*>': ['QByteArrayList', 'QStringList', 'QVariantList'],
-  'QPair<*,*>': ['std::pair'],
-  'QHash<*,*>': ['QVariantHash'],
-  'QMap<*,*>': ['QVariantMap']
-};
 /**
- * A base is covered if base OR ANY of its alternatives matches a seen type.
- * Returns missing base names (not each alt).
+ * Determine NatVis coverage based on the types observed in a debugger snapshot.
+ *
+ * Coverage is evaluated **per NatVis base pattern** (`<Type Name="...">`), not per
+ * `AlternativeType`. A base is considered covered if either the base pattern itself
+ * or any of its AlternativeType patterns matches at least one observed snapshot type.
+ *
+ * Alias types listed in `EXTRA_NATVIS_TYPE_ALIASES` are treated as *covered snapshot
+ * types* for reporting purposes, but they are **not** NatVis patterns and therefore
+ * never participate in “missing NatVis pattern” reporting.
+ *
+ * @param natvis
+ *   Parsed NatVis type information extracted from the `.natvis` file:
+ *   - `bases` are the primary `<Type Name="...">` patterns that define coverage.
+ *   - `alts` map each base pattern to its declared `<AlternativeType>` patterns.
+ *
+ * @param seenTypes
+ *   Set of snapshot-reported type names (top-level locals only)
+ *   observed at runtime after debugger normalization.
+ *
+ * @returns
+ *   An object with:
+ *   - `missing`:
+ *       Sorted list of NatVis base patterns that were not exercised by the snapshot.
+ *       Alias types are never reported here.
+ *   - `coveredTypes`:
+ *       Set of snapshot-reported type names considered covered by NatVis, including
+ *       both pattern-matched types and explicit alias types.
  */
 export function matchNatvisTypePatternsConsideringAlternatives(
   natvis: NatvisTypes,
@@ -522,7 +539,7 @@ export function matchNatvisTypePatternsConsideringAlternatives(
     });
     if (!anyMatched) missing.push(base);
   }
-  // --- Alias typedef-like types to their underlying NatVis patterns ----
+  // --- Alias snapshot types to their underlying NatVis patterns ----
   for (const aliases of Object.values(EXTRA_NATVIS_TYPE_ALIASES)) {
     for (const alias of aliases) {
       if (seenTypes.has(alias)) {

--- a/qt-cpp/test/natvis-test-helper.mts
+++ b/qt-cpp/test/natvis-test-helper.mts
@@ -144,9 +144,6 @@ export function printNatvisSummary(params: {
       if (e.knownProblem && e.type) {
         problematicTypesInGolden.add(e.type);
       }
-      if (e.children && e.children.length > 0) {
-        collectKnownProblemTypes(e.children);
-      }
     }
   };
   collectKnownProblemTypes(goldenSnapshot);

--- a/qt-cpp/test/natvis-test-helper.mts
+++ b/qt-cpp/test/natvis-test-helper.mts
@@ -242,27 +242,45 @@ export interface SnapshotMismatch {
 }
 
 /**
- * Compare the promoted runtime snapshot entries against the golden snapshot
- * and return a list of mismatches.
+ * Compares a debugger snapshot against a platform-resolved golden snapshot and
+ * returns the list of real NatVis mismatches.
  *
- * Current behavior (no child-name normalization):
- * - Keys are matched by the exact snapshot `name` string.
- * - Only `type` and `value` are compared (children are ignored).
- * - Extra actual entries and missing expected entries are reported.
- * - Entries with `knownProblem` are ignored when mismatching or missing.
+ * Matching is done by variable name (exact match). The comparison proceeds in
+ * two passes:
+ *
+ * 1) Walk actual debugger locals:
+ *    - If a variable is not described by the golden snapshot, it is reported as
+ *      an extra entry.
+ *    - If the variable exists in the golden snapshot:
+ *        - Its type is first checked for semantic compatibility using NatVis
+ *          information (base types and AlternativeType rules).
+ *          Incompatible types indicate a real error (wrong variable or unsupported
+ *          NatVis rule) and cause an immediate test failure.
+ *        - If types are compatible, values are compared.
+ *        - Value mismatches are ignored when the golden entry is marked as a
+ *          platform-specific knownProblem.
+ *        - Otherwise, value mismatches are collected.
+ *
+ * 2) Walk golden entries:
+ *    - Any golden entry missing from the debugger locals is reported as a mismatch,
+ *      unless it is marked as a knownProblem for the current platform.
  *
  * Notes:
- * - This version does NOT canonicalize NatVis synthetic child naming
- *   (e.g. `.[first]` vs `.first`). We keep exact names so type/name issues
- *   cannot be hidden.
+ * - Type strings are not compared for exact equality, as they are debugger-dependent
+ *   and not dictated by NatVis. Instead, a relaxed semantic compatibility check is
+ *   used as a guardrail.
+ * - Known problems are used only to suppress expected NatVis failures; they never
+ *   suppress type incompatibility errors.
  *
- * @param actual   Promoted root snapshot entries from `materializeLocalSnapshot`.
- * @param expected Golden entries for the current platform.
- * @returns        List of mismatches (empty means the snapshots match).
+ * @param actual   Platform-normalized debugger snapshot.
+ * @param expected Platform-resolved golden snapshot (with knownProblem applied).
+ * @param natvis   Parsed NatVis type information (bases and AlternativeType rules).
+ * @returns        List of real mismatches to be asserted by the test.
  */
 export function findMismatchedSnapshotEntries(
   actual: readonly Snapshot[],
-  expected: readonly GoldenSnapshot[]
+  expected: readonly GoldenSnapshot[],
+  natvis: NatvisTypes
 ): SnapshotMismatch[] {
   const mismatches: SnapshotMismatch[] = [];
 
@@ -315,10 +333,18 @@ export function findMismatchedSnapshotEntries(
       continue;
     }
 
-    const sameType = a.type === e.type;
-    const sameValue = a.value === e.value;
+    const typesCompatible = areTypesCompatible(a.type, e.type, natvis);
 
-    if (sameType && sameValue) {
+    if (!typesCompatible) {
+      throw new Error(
+        `[natvis.test] Type incompatibility for '${e.name}' on ${process.platform}.\n` +
+          `  expected type: ${e.type ?? '<none>'}\n` +
+          `  actual type:   ${a.type ?? '<none>'}\n` +
+          `This indicates a real mismatch (wrong variable or unsupported NatVis rule).`
+      );
+    }
+    const sameValue = a.value === e.value;
+    if (sameValue) {
       if (e.knownProblem && process.env.QT_TEST_DEBUG === '1') {
         console.warn(
           `[natvis.test][good-news] Known problem for '${e.type ?? '<unknown>'}' ` +
@@ -362,4 +388,155 @@ export function findMismatchedSnapshotEntries(
   }
 
   return mismatches;
+}
+
+function normalizeType(typeText: string): string {
+  return typeText
+    .replace(/\b(class|struct|enum)\s+/g, '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s*([<>,*&])\s*/g, '$1')
+    .trim();
+}
+
+// Split only the outermost template.
+// argsText is the exact text inside the outer <...> after normalization.
+// arity counts outer args at depth 0.
+function splitOuterTemplate(typeText: string): {
+  base: string;
+  argsText: string | undefined;
+  arity: number;
+} {
+  const lt = typeText.indexOf('<');
+  if (lt < 0) return { base: typeText.trim(), argsText: undefined, arity: 0 };
+
+  const base = typeText.slice(0, lt).trim();
+
+  let depth = 0;
+  let gt = -1;
+  for (let i = lt; i < typeText.length; i++) {
+    const ch = typeText[i]!;
+    if (ch === '<') depth++;
+    else if (ch === '>') {
+      depth--;
+      if (depth === 0) {
+        gt = i;
+        break;
+      }
+    }
+  }
+  if (gt < 0)
+    return { base, argsText: typeText.slice(lt + 1).trim(), arity: 0 };
+
+  const inside = typeText.slice(lt + 1, gt);
+  const argsText = inside.trim();
+
+  // arity at depth 0
+  depth = 0;
+  let commas = 0;
+  let hasNonWs = false;
+  for (let i = 0; i < inside.length; i++) {
+    const ch = inside[i]!;
+    if (!/\s/.test(ch)) hasNonWs = true;
+    if (ch === '<') depth++;
+    else if (ch === '>') depth--;
+    else if (ch === ',' && depth === 0) commas++;
+  }
+  const arity = hasNonWs ? commas + 1 : 1;
+
+  return { base, argsText, arity };
+}
+
+function wildcard(base: string, arity: number): string {
+  if (arity <= 0) return base;
+  if (arity === 1) return `${base}<*>`;
+  return `${base}<${Array(arity).fill('*').join(',')}>`;
+}
+
+// Accept debugger-expanded templates (extra args beyond what golden asserts).
+// expected: QSpan<int>
+// actual:   QSpan<int,184467...>
+function expandedTemplateCompatible(expected: string, actual: string): boolean {
+  if (expected === actual) return true;
+  if (!expected.endsWith('>')) return false;
+
+  const expectedNoClose = expected.slice(0, -1);
+  if (!actual.startsWith(expectedNoClose)) return false;
+
+  const next = actual[expectedNoClose.length];
+  return next === '>' || next === ',' || next === ' ';
+}
+
+// Canonicalize a base type using NatVis equivalence information.
+// We try:
+// 1) base itself (handles AlternativeType entries that are non-templates),
+// 2) base<wildcard> family (handles patterns like QList<*> having AlternativeType QVector<*>),
+// 3) if NatVis defines base<wildcard>, use that as a stable family key,
+// 4) otherwise keep the base.
+function canonicalBase(
+  base: string,
+  arity: number,
+  natvis: NatvisTypes
+): string {
+  const direct = natvis.altToBase.get(base);
+  if (direct) return direct;
+
+  const w = wildcard(base, arity);
+  const wMapped = natvis.altToBase.get(w);
+  if (wMapped) return wMapped;
+
+  if (natvis.bases.has(w) || natvis.all.has(w)) return w;
+
+  return base;
+}
+
+export function areTypesCompatible(
+  actualType: string | undefined,
+  expectedType: string | undefined,
+  natvis: NatvisTypes
+): boolean {
+  if (!expectedType) return true;
+  if (!actualType) return false;
+
+  const a0 = normalizeType(actualType);
+  const e0 = normalizeType(expectedType);
+
+  if (a0 === e0) return true;
+
+  // Handle QSpan<int> vs QSpan<int,...> before any other reasoning.
+  if (expandedTemplateCompatible(e0, a0)) return true;
+
+  const a = splitOuterTemplate(a0);
+  const e = splitOuterTemplate(e0);
+
+  if (a.argsText === undefined && e.argsText === undefined) {
+    const aBase = canonicalBase(a.base, 0, natvis);
+    const eBase = canonicalBase(e.base, 0, natvis);
+    return aBase === eBase;
+  }
+  // If both have outer args and the args text matches, only compare base equivalence.
+  if (
+    a.argsText !== undefined &&
+    e.argsText !== undefined &&
+    a.argsText === e.argsText
+  ) {
+    const aBase = canonicalBase(a.base, a.arity, natvis);
+    const eBase = canonicalBase(e.base, e.arity, natvis);
+    return aBase === eBase;
+  }
+
+  // If debugger collapsed Type<A> to Type, accept if bases are equivalent.
+  if (a.argsText === undefined && e.argsText !== undefined) {
+    const aBase = canonicalBase(a.base, e.arity, natvis);
+    const eBase = canonicalBase(e.base, e.arity, natvis);
+    return aBase === eBase;
+  }
+  if (e.argsText === undefined && a.argsText !== undefined) {
+    const aBase = canonicalBase(a.base, a.arity, natvis);
+    const eBase = canonicalBase(e.base, a.arity, natvis);
+    return aBase === eBase;
+  }
+
+  // Otherwise, do not treat differing template args as compatible.
+  // Example: QList<int> vs QList<QString> should be incompatible.
+  return false;
 }

--- a/qt-cpp/test/projectFolderNatvis/container_types.h
+++ b/qt-cpp/test/projectFolderNatvis/container_types.h
@@ -7,43 +7,44 @@ struct ContainerTypes
 {
     // sequence containers
     QList<int>              qIntList;
-    //QList<QString>          qStringList;
-    //QList<QVariant>         qVariantList;
-    QByteArrayList          qByteArrayList; //Keep, e.g: Only on Windows
-    QStringList             qStringList; // Keep, e.g: Only show [0] and [1] missing [2]. Flattening problem
-    //QVector<int>            qVectorInt;
-    //QSpan<int>              qSpanInt;
-    //QVector<QPoint>         qVectorPoint;
-    //QVarLengthArray<int, 4> qVarLengthArrayInt;
+    QList<QString>          qStringListExplicit;
+    QList<QVariant>         qVariantList;
+    QByteArrayList          qByteArrayList;
+    QStringList             qStringList;
+    QVector<int>            qVectorInt;
+    QSpan<int>              qSpanInt;
+    QVector<QPoint>         qVectorPoint;
+    QVarLengthArray<int, 4> qVarLengthArrayInt;
 
     // associative containers
-    //QMap<QString, int>       qMapStringInt;
-    //QMultiMap<QString, int>  qMultiMapStringInt;
-    //QHash<QString, int>      qHashStringInt;
-    //QMultiHash<QString, int> qMultiHashStringInt;
-    //QSet<QString>            qSetString;
+    QMap<QString, int>       qMapStringInt;
+    QMultiMap<QString, int>  qMultiMapStringInt;
+    QHash<QString, int>      qHashStringInt;
+    QMultiHash<QString, int> qMultiHashStringInt;
+    QSet<QString>            qSetString;
 
     // pair
-    QPair<QString, int>      qPairStringInt; // Keep, e.g: Dysplay string not present in the golden. Only first is shown
+    QPair<QString, int>      qPairStringInt;
 
     // QVariant-based containers
-    //QVariantMap   qVariantMap;
-    //QVariantList  qVariantListContainer;
-    //QVariantHash  qVariantHash;
+    QVariantMap   qVariantMap;
+    QVariantList  qVariantListContainer;
+    QVariantHash  qVariantHash;
 
     // JSON containers (QJsonDocument itself is already in CoreTypes)
-    //QJsonArray    qJsonArray;
-    //QJsonObject   qJsonObject;
-    //QJsonValue    qJsonValueNull;
-    //QJsonValue    qJsonValueInt;
-    //QJsonValue    qJsonValueString;
+    QJsonArray    qJsonArray;
+    QJsonObject   qJsonObject;
+    QJsonValue    qJsonValueNull;
+    QJsonValue    qJsonValueInt;
+    QJsonValue    qJsonValueString;
 
     // CBOR containers
-    QCborArray    qCborArray; //Keep, e.g: "{...}"" "" "d{...}"
-    //QCborMap      qCborMap;
-    //QCborValue    qCborValueNull;
-    QCborValue    qCborValueInt; // Keep, e.g: Known problem for windows, linux 42 is correct, mac {...} is a known problem
-    //QCborValue    qCborValueString;
+    QCborArray    qCborArray;
+    QCborMap      qCborMap;
+    QCborMap      qCborMapEmpty;
+    QCborValue    qCborValueNull;
+    QCborValue    qCborValueInt;
+    QCborValue    qCborValueString;
 
     // Constructor
     ContainerTypes();
@@ -51,78 +52,80 @@ struct ContainerTypes
 
 inline ContainerTypes::ContainerTypes()
     : qIntList{1, 2, 3}
-    //, qStringList{QStringLiteral("alpha"), QStringLiteral("beta")}
-    //, qVariantList{QVariant(123), QVariant(QStringLiteral("hello"))}
+    , qStringListExplicit{QStringLiteral("alpha"), QStringLiteral("beta")}
+    , qVariantList{QVariant(123), QVariant(QStringLiteral("hello"))}
     , qByteArrayList{QByteArray("one"), QByteArray("two")}
     , qStringList{QStringLiteral("red"),
                    QStringLiteral("green"),
                    QStringLiteral("blue")}
-//     , qVectorInt{10, 20, 30}
-//     , qSpanInt() // will be set below once qVectorInt is constructed
-//     , qVectorPoint{QPoint(1, 2), QPoint(3, 4)}
-//     , qVarLengthArrayInt()
-//     , qMapStringInt({{QStringLiteral("one"), 1},
-//                      {QStringLiteral("two"), 2}})
-//     , qMultiMapStringInt()
-//     , qHashStringInt()
-//     , qMultiHashStringInt()
-//     , qSetString()
-       , qPairStringInt(QStringLiteral("pair-key"), 42)
-//     , qVariantMap()
-//     , qVariantListContainer()
-//     , qVariantHash()
-//     , qJsonArray(QJsonArray::fromVariantList(
-//           QVariantList{1, QStringLiteral("two"), 3}))
-//     , qJsonObject(QJsonObject{
-//           {QStringLiteral("a"), 1},
-//           {QStringLiteral("b"), 2},
-//       })
-//     , qJsonValueNull(QJsonValue::Null)
-//     , qJsonValueInt(42)
-//     , qJsonValueString(QStringLiteral("forty-two"))
-       , qCborArray()
-//     , qCborMap()
-//     , qCborValueNull(QCborValue()) // Null
+     , qVectorInt{10, 20, 30}
+     , qSpanInt() // will be set below once qVectorInt is constructed
+     , qVectorPoint{QPoint(1, 2), QPoint(3, 4)}
+     , qVarLengthArrayInt()
+     , qMapStringInt({{QStringLiteral("one"), 1},
+                      {QStringLiteral("two"), 2}})
+     , qMultiMapStringInt()
+     , qHashStringInt()
+     , qMultiHashStringInt()
+     , qSetString()
+     , qPairStringInt(QStringLiteral("pair-key"), 42)
+     , qVariantMap()
+     , qVariantListContainer()
+     , qVariantHash()
+     , qJsonArray(QJsonArray::fromVariantList(
+           QVariantList{1, QStringLiteral("two"), 3}))
+     , qJsonObject(QJsonObject{
+           {QStringLiteral("a"), 1},
+           {QStringLiteral("b"), 2},
+       })
+     , qJsonValueNull(QJsonValue::Null)
+     , qJsonValueInt(42)
+     , qJsonValueString(QStringLiteral("forty-two"))
+     , qCborArray()
+     , qCborMap()
+     , qCborValueNull(QCborValue()) // Null
      , qCborValueInt(QCborValue(42))
-//     , qCborValueString(QCborValue(QStringLiteral("forty-two")))
+     , qCborValueString(QCborValue(QStringLiteral("forty-two")))
 {
 //     // QVarLengthArray can't easily be filled in the member initializer list
-//     qVarLengthArrayInt.reserve(4);
-//     qVarLengthArrayInt.append(7);
-//     qVarLengthArrayInt.append(8);
-//     qVarLengthArrayInt.append(9);
+       // It doesn't have a simple, reliable initializer-list constructor that sets up its internal state
+       // the way we want for debugging, so we explicitly build it step-by-step.”
+     qVarLengthArrayInt.reserve(4);
+     qVarLengthArrayInt.append(7);
+     qVarLengthArrayInt.append(8);
+     qVarLengthArrayInt.append(9);
 
-//     qMultiMapStringInt.insert(QStringLiteral("key"), 1);
-//     qMultiMapStringInt.insert(QStringLiteral("key"), 2);
+     qMultiMapStringInt.insert(QStringLiteral("key"), 1);
+     qMultiMapStringInt.insert(QStringLiteral("key"), 2);
 
-//     qHashStringInt.insert(QStringLiteral("one"), 1);
-//     qHashStringInt.insert(QStringLiteral("two"), 2);
+     qHashStringInt.insert(QStringLiteral("one"), 1);
+     qHashStringInt.insert(QStringLiteral("two"), 2);
 
-//     qMultiHashStringInt.insert(QStringLiteral("k"), 100);
-//     qMultiHashStringInt.insert(QStringLiteral("k"), 200);
+     qMultiHashStringInt.insert(QStringLiteral("k"), 100);
+     qMultiHashStringInt.insert(QStringLiteral("k"), 200);
 
-//     qSetString.insert(QStringLiteral("apple"));
-//     qSetString.insert(QStringLiteral("banana"));
+     qSetString.insert(QStringLiteral("apple"));
+     qSetString.insert(QStringLiteral("banana"));
 
-//     qVariantMap.insert(QStringLiteral("answer"), 42);
-//     qVariantMap.insert(QStringLiteral("question"),
-//                        QStringLiteral("life"));
+     qVariantMap.insert(QStringLiteral("answer"), 42);
+     qVariantMap.insert(QStringLiteral("question"),
+                        QStringLiteral("life"));
 
-//     qVariantListContainer.append(123);
-//     qVariantListContainer.append(QStringLiteral("abc"));
-//     qVariantListContainer.append(true);
+     qVariantListContainer.append(123);
+     qVariantListContainer.append(QStringLiteral("abc"));
+     qVariantListContainer.append(true);
 
-//     qVariantHash.insert(QStringLiteral("x"), 1);
-//     qVariantHash.insert(QStringLiteral("y"), 2);
+     qVariantHash.insert(QStringLiteral("x"), 1);
+     qVariantHash.insert(QStringLiteral("y"), 2);
 
-//     qCborArray.append(1);
-//     qCborArray.append(QStringLiteral("two"));
-//     qCborArray.append(true);
+     qCborArray.append(1);
+     qCborArray.append(QStringLiteral("two"));
+     qCborArray.append(true);
 
-//     qCborMap.insert(QStringLiteral("k1"), 1);
-//     qCborMap.insert(QStringLiteral("k2"), QStringLiteral("two"));
+     qCborMap.insert(QStringLiteral("k1"), 1);
+     qCborMap.insert(QStringLiteral("k2"), QStringLiteral("two"));
 
 //     // QSpan is a view, so bind it to the QVector storage
-//     qSpanInt = QSpan<int>(qVectorInt.data(),
-//                           qVectorInt.size());
+     qSpanInt = QSpan<int>(qVectorInt.data(),
+                           qVectorInt.size());
 }

--- a/qt-cpp/test/projectFolderNatvis/container_types.h
+++ b/qt-cpp/test/projectFolderNatvis/container_types.h
@@ -125,7 +125,7 @@ inline ContainerTypes::ContainerTypes()
      qCborMap.insert(QStringLiteral("k1"), 1);
      qCborMap.insert(QStringLiteral("k2"), QStringLiteral("two"));
 
-//     // QSpan is a view, so bind it to the QVector storage
+     // QSpan is a view, so bind it to the QVector storage
      qSpanInt = QSpan<int>(qVectorInt.data(),
                            qVectorInt.size());
 }

--- a/qt-cpp/test/suite/natvis.test.mts
+++ b/qt-cpp/test/suite/natvis.test.mts
@@ -228,18 +228,6 @@ describe('natvis: minimal Qt project debug (index-natvis)', function () {
           '[natvis.test] No Locals matched any NatVis type; check project and NatVis path.'
         );
       }
-      dlog(
-        '[natvis.test] snapshot (JSON):\n' +
-          JSON.stringify(
-            snapshot.map((v) => ({
-              name: v.name,
-              type: v.type,
-              value: v.value
-            })),
-            null,
-            2
-          )
-      );
       const goldenSnapshot = materializeGoldenSnapshot(
         GOLDEN_ENTRIES,
         process.platform

--- a/qt-cpp/test/suite/natvis.test.mts
+++ b/qt-cpp/test/suite/natvis.test.mts
@@ -241,7 +241,8 @@ describe('natvis: minimal Qt project debug (index-natvis)', function () {
 
       const mismatches = findMismatchedSnapshotEntries(
         snapshot,
-        goldenSnapshot
+        goldenSnapshot,
+        natvis
       );
 
       // ---- NatVis summary: which types worked, which NatVis types are unused ----
@@ -262,6 +263,7 @@ describe('natvis: minimal Qt project debug (index-natvis)', function () {
       if (mismatches.length > 0) {
         const MAX_VALUE_PREVIEW = 200;
 
+        // type is not dictated by natvis, a perfect match is not expected
         const compactActual = mismatches.map((m) => ({
           name: m.name,
           type: m.actual?.type ?? m.expected?.type ?? '<unknown>',


### PR DESCRIPTION

This PR expands the qt-cpp NatVis integration test coverage to include the remaining Qt container types (sequence, associative, QVariant, JSON, and CBOR containers) by enabling them in the test fixture and adding corresponding golden entries with platform-specific known-problem annotations where needed. It also relaxes snapshot type comparison by introducing a NatVis-aware semantic compatibility check (including AlternativeType-to-base mapping and tolerance for debugger-expanded template spellings like QSpan<int> vs QSpan<int, ...>), while failing fast on true type incompatibilities.