### PR TITLE
Add Qt version and test suite selection to workflow

### DIFF
--- a/.github/workflows/qt-tests.yml
+++ b/.github/workflows/qt-tests.yml
@@ -14,11 +14,15 @@ on:
           description: 'Show Qt types NatVis coverage summary (NATVIS_SHOW_SUMMARY=1)'
           required: false
           default: '0'
+        qt_version_for_test:
+          description: 'Qt version to install (ex: 6.9.0, 6.10.0)'
+          required: false
+          default: '6.9.0'
 
 jobs:
   tests:
     # Job name will show up in GitHub UI as "tests (ubuntu-latest)" etc.
-    name: tests (${{ matrix.os }})
+    name: tests (${{ matrix.os }}, Qt ${{ env.QT_VERSION_FOR_TEST }})
     # Run this job on Linux, macOS, and Windows
     runs-on: ${{ matrix.os }}
     # Default shell for all `run:` commands in this job
@@ -35,7 +39,7 @@ jobs:
         # macOS  : lldb (cppdbg)
         # Windows: cppvsdbg
     env:
-      QT_VERSION_FOR_TEST: "6.9.0"
+      QT_VERSION_FOR_TEST: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.qt_version_for_test || '6.9.0' }}
       VSCODE_LOG_LEVEL: error # trace, debug, info, warn, error, off
       QT_TEST_DEBUG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug || '' }}
       NATVIS_SHOW_SUMMARY: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.natvis_show_summary || '' }}
@@ -132,7 +136,7 @@ jobs:
       - name: Set Qt root
         run: |
             echo "QT_TEST_QT_ROOT=${{ github.workspace }}/Qt" >> $GITHUB_ENV
-            echo "QT_VERSION_FOR_TEST=${QT_VERSION_FOR_TEST}" >> $GITHUB_ENV
+            echo "QT_VERSION_FOR_TEST=${QT_VERSION_FOR_TEST}"
 
       - name: Ensure gdb is installed (Linux only)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/qt-tests.yml
+++ b/.github/workflows/qt-tests.yml
@@ -18,11 +18,22 @@ on:
           description: 'Qt version to install (ex: 6.9.0, 6.10.0)'
           required: false
           default: '6.9.0'
+        test_suite:
+          description: 'Which extension tests to run'
+          required: false
+          default: 'all'
+          type: choice
+          options:
+            - all
+            - qt-core
+            - qt-cpp
+            - qt-qml
+            - qt-ui
 
 jobs:
   tests:
     # Job name will show up in GitHub UI as "tests (ubuntu-latest)" etc.
-    name: tests (${{ matrix.os }}, Qt ${{ env.QT_VERSION_FOR_TEST }})
+    name: tests (${{ matrix.os }}, Qt ${{ github.event_name == 'workflow_dispatch' && inputs.qt_version_for_test || '6.9.0' }}, suite ${{ github.event_name == 'workflow_dispatch' && inputs.test_suite || 'all' }})
     # Run this job on Linux, macOS, and Windows
     runs-on: ${{ matrix.os }}
     # Default shell for all `run:` commands in this job
@@ -45,6 +56,7 @@ jobs:
       NATVIS_SHOW_SUMMARY: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.natvis_show_summary || '' }}
       DBUS_SESSION_BUS_ADDRESS: "disabled:"
       NO_AT_BRIDGE: "1"
+      TEST_SUITE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_suite || 'all' }}
 
     steps:
       # Check out your branch code into the runner
@@ -109,34 +121,39 @@ jobs:
           dir: ${{ github.workspace }}
           cache: true
 
-      - name: Locate Designer and set QT_TEST_QT_ROOT
+      - name: Set QT_TEST_QT_ROOT (and show Qt install overview)
+        shell: bash
+        run: |
+          set -euo pipefail
+          QT_ROOT="${{ github.workspace }}/Qt"
+          echo "QT_TEST_QT_ROOT=$QT_ROOT" >> "$GITHUB_ENV"
+
+          echo "QT_VERSION_FOR_TEST=${QT_VERSION_FOR_TEST}"
+          echo "Qt root: $QT_ROOT"
+
+          echo "Top-level under $QT_ROOT:"
+          ls -la "$QT_ROOT" || true
+
+          echo "Directory tree (maxdepth 3) under $QT_ROOT:"
+          find "$QT_ROOT" -maxdepth 3 -type d -print
+
+      - name: Verify Designer is available (qt-ui only)
+        if: env.TEST_SUITE == 'all' || env.TEST_SUITE == 'qt-ui'
         shell: bash
         run: |
           set -euo pipefail
           QT_ROOT="${{ github.workspace }}/Qt"
 
-          echo "Tree under $QT_ROOT:"
-          find "$QT_ROOT" -maxdepth 3 -type d -print
-
-          # Look for Designer binaries in the typical places regardless of arch/dir naming
           DESIGNER="$(/usr/bin/find "$QT_ROOT" -type f \( -name Designer -o -name designer -o -name designer.exe \) \
                       -path '*/bin/*' -print -quit || true)"
           echo "looking for Designer under $DESIGNER"
 
           if [[ -n "$DESIGNER" ]]; then
             echo "Found Designer at: $DESIGNER"
-            echo "QT_TEST_QT_ROOT=$QT_ROOT" >> $GITHUB_ENV
           else
-            echo "::error::Designer not found under $QT_ROOT after install."
+            echo "::error::Designer not found under $QT_ROOT after install, but qt-ui tests were selected."
             exit 1
           fi
-
-
-      # Print where Qt was installed for debugging
-      - name: Set Qt root
-        run: |
-            echo "QT_TEST_QT_ROOT=${{ github.workspace }}/Qt" >> $GITHUB_ENV
-            echo "QT_VERSION_FOR_TEST=${QT_VERSION_FOR_TEST}"
 
       - name: Ensure gdb is installed (Linux only)
         if: matrix.os == 'ubuntu-latest'
@@ -150,13 +167,14 @@ jobs:
             sudo apt-get install -y gdb
           fi
 
-      - name: Run tests (all OS)
+      - name: Run tests (all OS-selected suites)
         shell: bash
         run: |
           set -euo pipefail
           echo "  Qt6_DIR=${Qt6_DIR:-<unset>}"
 
           echo "QT_TEST_DEBUG=${QT_TEST_DEBUG:-0}"
+          echo "TEST_SUITE=${TEST_SUITE:-all}"
 
           # Hide these noisy lines (match after stripping ANSI, but print original so colors stay)
           FILTER='^(NativeExtensionHostFactory[.:]|Settings Sync:|\\[CMakeTools\\]|workbench#open\(\))|.*ERROR:dbus|.*viz_main_impl|.*ERROR:gpu/'
@@ -180,15 +198,44 @@ jobs:
             fi
           }
 
+          should_run() {
+            suite="$1"
+            selected="${TEST_SUITE:-all}"
+            [[ "$selected" == "all" || "$selected" == "$suite" ]]
+          }
+
           if [[ "${RUNNER_OS}" == "Linux" ]]; then
             XVFB=(xvfb-run -a -s "-screen 0 1280x720x24")
-            run_cmd "${XVFB[@]}" npm --prefix qt-core run test:only
-            run_cmd "${XVFB[@]}" npm --prefix qt-cpp  run test:only
-            run_cmd "${XVFB[@]}" npm --prefix qt-qml  run test:only
-            run_cmd "${XVFB[@]}" npm --prefix qt-ui   run test:only
+
+            if should_run qt-core; then
+              run_cmd "${XVFB[@]}" npm --prefix qt-core run test:only
+            fi
+
+            if should_run qt-cpp; then
+              run_cmd "${XVFB[@]}" npm --prefix qt-cpp run test:only
+            fi
+
+            if should_run qt-qml; then
+              run_cmd "${XVFB[@]}" npm --prefix qt-qml run test:only
+            fi
+
+            if should_run qt-ui; then
+              run_cmd "${XVFB[@]}" npm --prefix qt-ui run test:only
+            fi
           else
-            run_cmd npm --prefix qt-core run test:only
-            run_cmd npm --prefix qt-cpp  run test:only
-            run_cmd npm --prefix qt-qml  run test:only
-            run_cmd npm --prefix qt-ui   run test:only
+            if should_run qt-core; then
+              run_cmd npm --prefix qt-core run test:only
+            fi
+
+            if should_run qt-cpp; then
+              run_cmd npm --prefix qt-cpp run test:only
+            fi
+
+            if should_run qt-qml; then
+              run_cmd npm --prefix qt-qml run test:only
+            fi
+
+            if should_run qt-ui; then
+              run_cmd npm --prefix qt-ui run test:only
+            fi
           fi


### PR DESCRIPTION
- Add manual workflow inputs to select the Qt version and the extension test suite to run.
- Keep PR runs defaulting to the full test matrix with the pinned Qt version.
- Check Qt Designer availability only when qt-ui tests are selected.