### PR TITLE
Qt cpp test natvis summary table

### DIFF
--- a/qt-cpp/test/debug-golden-entries.mts
+++ b/qt-cpp/test/debug-golden-entries.mts
@@ -547,7 +547,7 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
   {
     name: 'containerTypes.qCborValueString',
     type: 'QCborValue',
-    value: '{...}',
+    value: 'forty-two',
     knownProblem: {
       darwin:
         'NatVis formatting is currently unreliable under LLDB; value collapses to {...}.',

--- a/qt-cpp/test/debug-golden.mts
+++ b/qt-cpp/test/debug-golden.mts
@@ -4,7 +4,6 @@
 import * as fs from 'fs/promises';
 
 import type { DebugVariable } from './debug-helper.mts';
-import { dlog } from './helper.mts';
 
 /**
  * NatVis golden + snapshot utilities for qt-cpp integration tests.
@@ -268,10 +267,12 @@ export function materializeLocalSnapshot(
   }
 
   sortTree(promoted);
-  dlog(
-    '[natvis.test] Snapshot after noise filtering (JSON):\n' +
-      JSON.stringify(promoted.map(snapshotToJSON), null, 2)
-  );
+  if (process.env.NATVIS_VERBOSE === '1') {
+    console.log(
+      '[natvis.test] Snapshot after noise filtering (JSON):\n' +
+        JSON.stringify(promoted.map(snapshotToJSON), null, 2)
+    );
+  }
 
   return promoted;
 }

--- a/qt-cpp/test/natvis-test-helper.mts
+++ b/qt-cpp/test/natvis-test-helper.mts
@@ -105,6 +105,7 @@ export function printNatvisSummary(params: {
   natvisSnapshot: readonly Snapshot[];
   goldenSnapshot: readonly GoldenSnapshot[];
   mismatches: readonly SnapshotMismatch[];
+  goodNewsNames: ReadonlySet<string>;
   natvis: NatvisTypes;
   missing: readonly string[];
   natvisPath: string | undefined;
@@ -114,6 +115,7 @@ export function printNatvisSummary(params: {
     natvisSnapshot,
     goldenSnapshot,
     mismatches,
+    goodNewsNames,
     natvis,
     missing,
     natvisPath,
@@ -158,6 +160,7 @@ export function printNatvisSummary(params: {
   // Pretty printing of the summary
   // ---------------------------------------------------------------------------
   let natvisFileLabel: string = natvisPath ?? '<unknown>';
+  const printOldList = false;
 
   if (natvisPath) {
     try {
@@ -169,32 +172,44 @@ export function printNatvisSummary(params: {
       natvisFileLabel = natvisPath;
     }
   }
-  // Print all covered and successful types
   console.log(
-    `[natvis.summary] Tested Qt types successfully covered by NatVis file ${natvisFileLabel} on ${process.platform}:`
+    `[natvis.summary] Using NatVis file ${natvisFileLabel} on ${process.platform}`
   );
+  if (printOldList) {
+    // Print all covered and successful types
+    console.log(
+      `[natvis.summary] Tested Qt types successfully covered by NatVis file ${natvisFileLabel} on ${process.platform}:`
+    );
 
-  if (successfulTypes.length === 0) {
-    console.log('  (none)');
-  } else {
-    for (const t of successfulTypes) {
-      console.log(`  ${t}`);
+    if (successfulTypes.length === 0) {
+      console.log('  (none)');
+    } else {
+      for (const t of successfulTypes) {
+        console.log(`  ${t}`);
+      }
+    }
+
+    // Print Known-problem NatVis types (as marked in the golden snapshot)
+    if (problematicTypesInGolden.size > 0) {
+      console.log(
+        `[natvis.summary] Tested Qt types with unsuccessful NatVis coverage on ${process.platform} (marked as knownProblem in the golden snapshot):`
+      );
+      for (const t of [...problematicTypesInGolden].sort()) {
+        console.log(`  ${t}`);
+      }
+    } else {
+      console.log(
+        `[natvis.summary] No golden entries are marked with knownProblem on ${process.platform}.`
+      );
     }
   }
-
-  // Print Known-problem NatVis types (as marked in the golden snapshot)
-  if (problematicTypesInGolden.size > 0) {
-    console.log(
-      `[natvis.summary] Tested Qt types with unsuccessful NatVis coverage on ${process.platform} (marked as knownProblem in the golden snapshot):`
-    );
-    for (const t of [...problematicTypesInGolden].sort()) {
-      console.log(`  ${t}`);
-    }
-  } else {
-    console.log(
-      `[natvis.summary] No golden entries are marked with knownProblem on ${process.platform}.`
-    );
-  }
+  printNatvisTypeStatusTable({
+    natvisSnapshot,
+    goldenSnapshot,
+    mismatches,
+    goodNewsNames,
+    natvis
+  });
 
   // Print types with defined NatVis patterns but not exercised by this test
   const missingLines = missing.map((base) => {
@@ -214,6 +229,250 @@ export function printNatvisSummary(params: {
       '[natvis.summary] All NatVis type patterns in this file were exercised by the current snapshot.'
     );
   }
+}
+//---------------------------------------------------------------------------
+
+type TypeStatus = 'OK' | 'KP' | 'FAIL' | '-';
+type SortMode = 'status' | 'status_grouped';
+
+type NatvisTableRowLike = {
+  natvisType: string;
+  exercisedType: string;
+  varName: string;
+  root: TypeStatus;
+};
+
+const STATUS_ORDER: Readonly<Record<TypeStatus, number>> = {
+  OK: 0,
+  KP: 1,
+  FAIL: 2,
+  '-': 3
+};
+
+function getNatvisTableSortMode(): SortMode {
+  const raw = (process.env.NATVIS_TABLE_SORT ?? '').trim().toLowerCase();
+  return raw === 'status' || raw === 'status_grouped' ? raw : 'status_grouped';
+}
+
+function buildBestStatusByNatvisType<T extends NatvisTableRowLike>(
+  rows: readonly T[]
+): ReadonlyMap<string, number> {
+  const bestByNatvis = new Map<string, number>();
+
+  for (const r of rows) {
+    const rank = STATUS_ORDER[r.root];
+    const prev = bestByNatvis.get(r.natvisType);
+
+    if (prev === undefined || rank < prev) {
+      bestByNatvis.set(r.natvisType, rank);
+    }
+  }
+
+  return bestByNatvis;
+}
+
+function sortNatvisRows<T extends NatvisTableRowLike>(rows: T[]): void {
+  const mode = getNatvisTableSortMode();
+
+  if (mode === 'status') {
+    rows.sort((a, b) => {
+      const sa = STATUS_ORDER[a.root];
+      const sb = STATUS_ORDER[b.root];
+      if (sa !== sb) return sa - sb;
+
+      const byNatvis = a.natvisType.localeCompare(b.natvisType);
+      if (byNatvis !== 0) return byNatvis;
+
+      return a.varName.localeCompare(b.varName);
+    });
+    return;
+  }
+
+  // mode === 'status_grouped'
+  const bestByNatvis = buildBestStatusByNatvisType(rows);
+
+  rows.sort((a, b) => {
+    const ga = bestByNatvis.get(a.natvisType) ?? STATUS_ORDER['-'];
+    const gb = bestByNatvis.get(b.natvisType) ?? STATUS_ORDER['-'];
+    if (ga !== gb) return ga - gb;
+
+    const byNatvis = a.natvisType.localeCompare(b.natvisType);
+    if (byNatvis !== 0) return byNatvis;
+
+    const sa = STATUS_ORDER[a.root];
+    const sb = STATUS_ORDER[b.root];
+    if (sa !== sb) return sa - sb;
+
+    return a.varName.localeCompare(b.varName);
+  });
+}
+
+function computeNatvisFamily(
+  exercisedType: string,
+  natvis: NatvisTypes
+): string {
+  const t = normalizeType(exercisedType);
+  const parsed = splitOuterTemplate(t);
+  const base = canonicalBase(parsed.base, parsed.arity, natvis);
+
+  // If canonicalBase already returned a known NatVis base pattern, keep it.
+  if (natvis.bases.has(base)) {
+    return base;
+  }
+
+  // Otherwise, try a wildcard family derived from the concrete type.
+  const w = wildcard(parsed.base, parsed.arity);
+  if (natvis.bases.has(w) || natvis.all.has(w)) {
+    return w;
+  }
+
+  // Fallback: show the base (still useful for non-template types).
+  return parsed.base;
+}
+
+export function printNatvisTypeStatusTable(params: {
+  natvisSnapshot: readonly Snapshot[];
+  goldenSnapshot: readonly GoldenSnapshot[];
+  mismatches: readonly SnapshotMismatch[];
+  goodNewsNames: ReadonlySet<string>;
+  natvis: NatvisTypes;
+}): void {
+  const { natvisSnapshot, goldenSnapshot, mismatches, goodNewsNames, natvis } =
+    params;
+
+  const failNames = new Set<string>(mismatches.map((m) => m.name));
+
+  const goldenByName = new Map<string, GoldenSnapshot>();
+  for (const g of goldenSnapshot) {
+    goldenByName.set(g.name, g);
+  }
+  type Row = {
+    natvisType: string;
+    exercisedType: string;
+    varName: string;
+    root: TypeStatus;
+    children: TypeStatus;
+    kpGoodNews: boolean;
+  };
+
+  const rows: Row[] = [];
+
+  for (const a of natvisSnapshot) {
+    const varName = a.name;
+    const exercisedType = a.type ?? '<none>';
+    const natvisType = computeNatvisFamily(exercisedType, natvis);
+
+    const g = goldenByName.get(varName);
+
+    let root: TypeStatus = 'OK';
+    if (!g) {
+      // Variable present in Locals but missing from golden => real failure
+      root = 'FAIL';
+    } else if (failNames.has(varName)) {
+      root = 'FAIL';
+    } else if (g.knownProblem) {
+      root = 'KP';
+    }
+
+    const children: TypeStatus = '-';
+    const kpGoodNews = root === 'KP' && goodNewsNames.has(varName);
+
+    rows.push({
+      natvisType,
+      exercisedType,
+      varName,
+      root,
+      children,
+      kpGoodNews
+    });
+  }
+
+  const seenNames = new Set<string>(natvisSnapshot.map((s) => s.name));
+
+  for (const g of goldenSnapshot) {
+    if (seenNames.has(g.name)) continue;
+
+    const varName = g.name;
+    const exercisedType = g.type ?? '<none>';
+    const natvisType = computeNatvisFamily(exercisedType, natvis);
+
+    let root: TypeStatus = 'OK';
+    if (failNames.has(varName)) {
+      root = 'FAIL';
+    } else if (g.knownProblem) {
+      root = 'KP';
+    } else {
+      // expected but missing and not knownProblem => FAIL is already in mismatches by name,
+      // but keep this defensive:
+      root = 'FAIL';
+    }
+
+    const children: TypeStatus = '-';
+    const kpGoodNews = root === 'KP' && goodNewsNames.has(varName);
+
+    rows.push({
+      natvisType,
+      exercisedType,
+      varName,
+      root,
+      children,
+      kpGoodNews
+    });
+  }
+  sortNatvisRows(rows);
+  const header = [
+    'NatVis Type',
+    'Exercised type',
+    'Variable name',
+    'Status root',
+    'Status children'
+  ];
+
+  // Simple fixed-width formatting (good enough for logs)
+  const colWidths = [0, 0, 0, 0, 0];
+  const consider = (cols: string[]) => {
+    for (let i = 0; i < cols.length; i++) {
+      colWidths[i] = Math.max(colWidths[i]!, cols[i]!.length);
+    }
+  };
+
+  consider(header);
+  for (const r of rows) {
+    const rootLabel = r.root === 'KP' && r.kpGoodNews ? 'KP*' : r.root;
+    consider([r.natvisType, r.exercisedType, r.varName, rootLabel, r.children]);
+  }
+
+  const pad = (s: string, w: number) =>
+    s + ' '.repeat(Math.max(0, w - s.length));
+  const line = (cols: string[]) =>
+    cols.map((c, i) => pad(c, colWidths[i]!)).join(' | ');
+  console.log(
+    `[natvis.summary] Qt Type natvis status summary (covered types only):`
+  );
+  console.log('  ' + line(header));
+  console.log('  ' + colWidths.map((w) => '-'.repeat(w)).join('-|-'));
+  for (const r of rows) {
+    const rootLabel = r.root === 'KP' && r.kpGoodNews ? 'KP*' : r.root;
+    console.log(
+      '  ' +
+        line([r.natvisType, r.exercisedType, r.varName, rootLabel, r.children])
+    );
+  }
+  console.log('  ' + colWidths.map((w) => '-'.repeat(w)).join('-|-'));
+  console.log('  Columns:');
+  console.log(
+    '    root     = status of the top-level variable value vs golden'
+  );
+  console.log('    children = status of NatVis Expand children vs golden');
+  console.log('              (not explored yet, so currently always "-")');
+  console.log('  Status codes:');
+  console.log('    OK   = matches golden and not marked knownProblem');
+  console.log(
+    '    KP   = assertion disabled due to knownProblem on this platform'
+  );
+  console.log('    FAIL = mismatches golden (after knownProblem filtering)');
+  console.log('    -    = not explored');
+  console.log('  ' + colWidths.map((w) => '-'.repeat(w)).join('---'));
 }
 
 /**
@@ -272,13 +531,18 @@ export interface SnapshotMismatch {
  * @param actual   Platform-normalized debugger snapshot.
  * @param expected Platform-resolved golden snapshot (with knownProblem applied).
  * @param natvis   Parsed NatVis type information (bases and AlternativeType rules).
- * @returns        List of real mismatches to be asserted by the test.
+ * @returns        Object containing:
+ *                 - `mismatches`: list of real NatVis mismatches to be asserted by the test.
+ *                 - `goodNewsNames`: set of Qt types variable whose `knownProblem` entries unexpectedly matched
+ *                   (used for reporting progress, e.g. KP* in summaries).
  */
 export function findMismatchedSnapshotEntries(
   actual: readonly Snapshot[],
   expected: readonly GoldenSnapshot[],
   natvis: NatvisTypes
-): SnapshotMismatch[] {
+): { mismatches: SnapshotMismatch[]; goodNewsNames: ReadonlySet<string> } {
+  const goodNewsNames = new Set<string>();
+
   const mismatches: SnapshotMismatch[] = [];
 
   // Build lookup maps by variable name (exact match)
@@ -342,7 +606,8 @@ export function findMismatchedSnapshotEntries(
     }
     const sameValue = a.value === e.value;
     if (sameValue) {
-      if (e.knownProblem && process.env.QT_TEST_DEBUG === '1') {
+      if (e.knownProblem) {
+        goodNewsNames.add(e.name);
         console.warn(
           `[natvis.test][good-news] Known problem for '${e.type ?? '<unknown>'}' ` +
             `(${e.name}) no longer mismatches on ${process.platform}.\n` +
@@ -353,7 +618,7 @@ export function findMismatchedSnapshotEntries(
     }
 
     if (e.knownProblem) {
-      if (process.env.QT_TEST_DEBUG === '1') {
+      if (process.env.NATVIS_VERBOSE === '1') {
         console.warn(
           `[natvis.test][known-problem] '${e.name}' mismatch ignored.\n` +
             `  Reason: ${e.knownProblem}\n` +
@@ -384,7 +649,7 @@ export function findMismatchedSnapshotEntries(
     mismatches.push({ name: e.name, expected: e });
   }
 
-  return mismatches;
+  return { mismatches, goodNewsNames };
 }
 
 function normalizeType(typeText: string): string {

--- a/qt-cpp/test/natvis-test-helper.mts
+++ b/qt-cpp/test/natvis-test-helper.mts
@@ -215,7 +215,6 @@ export function printNatvisSummary(params: {
     goodNewsNames,
     natvis
   });
-
 }
 
 /**
@@ -604,7 +603,7 @@ export function printNatvisTypeStatusTable(params: {
   }
   console.log('  ' + colWidths.map((w) => '-'.repeat(w)).join('-|-'));
   console.log(
-  `  (covers variables from snapshot + golden expectations; excludes missing NatVis patterns list)`
+    `  (covers variables from snapshot + golden expectations; excludes missing NatVis patterns list)`
   );
   console.log('  Columns:');
   console.log(

--- a/qt-cpp/test/natvis-test-helper.mts
+++ b/qt-cpp/test/natvis-test-helper.mts
@@ -49,53 +49,40 @@ export function formatValuePreview(v: unknown, max: number = 200): string {
 }
 
 /**
- * Print a human-readable NatVis coverage summary to the test log.
+ * Print a human-readable NatVis summary to the test log.
  *
- * This function is purely diagnostic: it does not affect test pass/fail,
- * it only reports what the current snapshot and golden tell us.
+ * This function is purely diagnostic: it does not affect test pass/fail.
+ * It prints:
+ * 1) **NatVis patterns not exercised by this snapshot**
+ *    - Uses `missing` (from matchNatvisTypePatternsConsideringAlternatives) and `natvis`.
+ *    - Prints NatVis base patterns (and their AlternativeType patterns) that did not
+ *      appear in the current snapshot.
  *
- * It reports three main things:
  *
- *   1) **Successfully covered types**
- *      - Starts from `natvisSnapshot` (locals that passed through NatVis
- *        filtering and normalization).
- *      - Collects all distinct `type` values that actually appeared.
- *      - Removes:
- *          • types that had real mismatches (after filtering knownProblem),
- *          • types that are marked as `knownProblem` anywhere in the
- *            `goldenSnapshot` (including nested children).
- *      - The remaining types are printed as:
- *          "Tested Qt types successfully covered by NatVis file ..."
+ * 2) **Status summary table (variable-based)**
+ *    - Produced by `printNatvisTypeStatusTable(...)`.
+ *    - One row per *top-level variable name* (not one row per Qt type), so
+ *      repeated types (e.g. multiple QCborValue variables) appear as separate rows.
+ *    - Concrete types are grouped into a NatVis “family” (e.g. QList<int> and
+ *      QList<double> grouped under QList<*>).
+ *    - Root status codes:
+ *        • OK   = value matches golden and entry is not knownProblem
+ *        • KP   = entry is marked knownProblem on this platform (assertion disabled)
+ *        • KP*  = knownProblem entry that unexpectedly matches (“good news”)
+ *        • FAIL = real mismatch, extra variable, or missing expected variable
+ *      (Children status is reserved for future Expand/child validation.)
  *
- *   2) **Known-problem types (from the golden snapshot)**
- *      - Walks the entire `goldenSnapshot` tree recursively.
- *      - Any entry with a non-empty `knownProblem` and a `type` is recorded.
- *      - These types are printed as:
- *          "Tested Qt types with unsuccessful NatVis coverage
- *           (marked as knownProblem in the golden snapshot)"
- *      - This reflects the new model where problem annotations live in the
- *        golden rather than a separate global table.
- *
- *   3) **NatVis patterns that were not exercised**
- *      - Uses `natvis` and `missing` (the coverage result from
- *        matchNatvisTypePatternsConsideringAlternatives).
- *      - For each missing base pattern, shows the base name and its
- *        AlternativeType patterns (if any).
- *      - This tells you which NatVis rules exist in the .natvis file but
- *        did not appear in the current test snapshot.
- *
- * Additional details:
- *   - `natvisPath` and `wsFolder` are used to print the NatVis file path
- *     relative to the workspace root, for nicer logs.
- *   - `mismatches` is the final list returned by findMismatchedSnapshotEntries
- *     (after knownProblem filtering). It is used only to compute the set of
- *     "real mismatched types".
- *   - The function is intended to be called once at the end of the NatVis
- *     test when NATVIS_SHOW_SUMMARY (or similar) is enabled.
+ * Notes:
+ * - `goodNewsNames` comes from `findMismatchedSnapshotEntries` and is used only for
+ *   reporting KP* progress; it does not change pass/fail behavior.
+ * - `natvisPath` + `wsFolder` are used to print a workspace-relative NatVis path.
+ * - The old “successful types” / “known-problem types” lists are kept behind
+ *   `printOldList` (currently disabled).
  *
  * @param params.natvisSnapshot  Platform-normalized locals after NatVis filtering.
- * @param params.goldenSnapshot  Platform-resolved golden snapshot (with knownProblem).
+ * @param params.goldenSnapshot  Platform-resolved golden snapshot (with knownProblem applied).
  * @param params.mismatches      Real mismatches returned by the comparison logic.
+ * @param params.goodNewsNames   Variable names whose knownProblem unexpectedly matched (KP*).
  * @param params.natvis          Parsed NatVis type information (bases, alts, all).
  * @param params.missing         NatVis base patterns not exercised by this snapshot.
  * @param params.natvisPath      Absolute path to the NatVis file, or undefined.
@@ -162,6 +149,24 @@ export function printNatvisSummary(params: {
   let natvisFileLabel: string = natvisPath ?? '<unknown>';
   const printOldList = false;
 
+  // Print types with defined NatVis patterns but not exercised by this test
+  const missingLines = missing.map((base) => {
+    const alts = natvis.alts.get(base);
+    return alts && alts.size ? `${base} (alts: ${[...alts].join(', ')})` : base;
+  });
+
+  if (missingLines.length > 0) {
+    console.log(
+      '[natvis.summary] Qt types defined in NatVis file but not covered by this test snapshot:'
+    );
+    for (const line of missingLines) {
+      console.log(`  ${line}`);
+    }
+  } else {
+    console.log(
+      '[natvis.summary] All NatVis type patterns in this file were exercised by the current snapshot.'
+    );
+  }
   if (natvisPath) {
     try {
       const rel = path.relative(wsFolder.uri.fsPath, natvisPath);
@@ -211,37 +216,58 @@ export function printNatvisSummary(params: {
     natvis
   });
 
-  // Print types with defined NatVis patterns but not exercised by this test
-  const missingLines = missing.map((base) => {
-    const alts = natvis.alts.get(base);
-    return alts && alts.size ? `${base} (alts: ${[...alts].join(', ')})` : base;
-  });
-
-  if (missingLines.length > 0) {
-    console.log(
-      '[natvis.summary] Qt types defined in NatVis file but not covered by this test snapshot:'
-    );
-    for (const line of missingLines) {
-      console.log(`  ${line}`);
-    }
-  } else {
-    console.log(
-      '[natvis.summary] All NatVis type patterns in this file were exercised by the current snapshot.'
-    );
-  }
 }
-//---------------------------------------------------------------------------
 
+/**
+ * Status of a NatVis table entry at a given validation level.
+ *
+ * Meanings:
+ *   - 'OK'   : Variable value matches the golden snapshot and is not marked
+ *              as a knownProblem.
+ *   - 'KP'   : Validation is disabled because the golden entry is marked
+ *              as knownProblem on this platform.
+ *   - 'FAIL' : A real mismatch detected after knownProblem filtering
+ *              (value mismatch, extra variable, or missing expected variable).
+ *   - '-'    : Not evaluated yet (reserved for future use, e.g. child/Expand checks).
+ */
 type TypeStatus = 'OK' | 'KP' | 'FAIL' | '-';
+
+/**
+ * Sorting mode for the NatVis status summary table.
+ *
+ *   - 'status'          : Sort rows strictly by status severity (OK → KP → FAIL → '-'),
+ *                         then by NatVis type and variable name.
+ *   - 'status_grouped'  : Group rows by NatVis type, ordered by the *best*
+ *                         status seen for that NatVis type, then sort within
+ *                         each group by variable status and name.
+ */
 type SortMode = 'status' | 'status_grouped';
 
+/**
+ * Minimal shape of a row in the NatVis status summary table.
+ *
+ * This is the common interface used by sorting and grouping helpers.
+ * Each row represents one top-level debugger variable.
+ */
 type NatvisTableRowLike = {
+  /** Canonical NatVis family (e.g. QList<*>, QCborValue) */
   natvisType: string;
+  /** Concrete C++ type reported by the debugger (e.g. QList<int>) */
   exercisedType: string;
+  /** Fully qualified variable name in the debugger snapshot */
   varName: string;
+  /** Root-level validation status for this variable */
   root: TypeStatus;
 };
 
+/**
+ * Numeric ordering for TypeStatus values.
+ *
+ * Lower numbers are "better" and sort first.
+ * Used to:
+ *   - Order rows by severity.
+ *   - Compute the best (least severe) root status for a NatVis type group.
+ */
 const STATUS_ORDER: Readonly<Record<TypeStatus, number>> = {
   OK: 0,
   KP: 1,
@@ -249,11 +275,37 @@ const STATUS_ORDER: Readonly<Record<TypeStatus, number>> = {
   '-': 3
 };
 
+/**
+ * Resolve the NatVis summary table sort mode from the environment.
+ *
+ * Controlled via the NATVIS_TABLE_SORT environment variable.
+ *
+ * Supported values:
+ *   - 'status'          : Sort rows strictly by status severity.
+ *   - 'status_grouped'  : Group rows by NatVis type and order groups by their
+ *                         best (least severe) status.
+ *
+ * Any unset or invalid value defaults to 'status_grouped', which provides
+ * a more compact and NatVis-centric view.
+ */
 function getNatvisTableSortMode(): SortMode {
   const raw = (process.env.NATVIS_TABLE_SORT ?? '').trim().toLowerCase();
   return raw === 'status' || raw === 'status_grouped' ? raw : 'status_grouped';
 }
 
+/**
+ * Compute the best (least severe) root status observed for each NatVis type.
+ *
+ * This helper is used by the 'status_grouped' sort mode to determine
+ * the ordering of NatVis type groups.
+ *
+ * For each NatVis family (e.g. QList<*>), the smallest numeric rank
+ * from STATUS_ORDER is kept:
+ *   OK < KP < FAIL < '-'
+ *
+ * @param rows  Table rows representing individual variables.
+ * @returns     Map from NatVis type to its best (lowest-severity) status rank.
+ */
 function buildBestStatusByNatvisType<T extends NatvisTableRowLike>(
   rows: readonly T[]
 ): ReadonlyMap<string, number> {
@@ -271,6 +323,32 @@ function buildBestStatusByNatvisType<T extends NatvisTableRowLike>(
   return bestByNatvis;
 }
 
+/**
+ * Sort NatVis summary table rows according to the selected sort mode.
+ *
+ * Two sorting strategies are supported:
+ *
+ * 1) **'status'**
+ *    - Sort rows directly by root status severity (OK < KP < FAIL < '-').
+ *    - Tie-breakers:
+ *        a) NatVis type (alphabetical)
+ *        b) Variable name (alphabetical)
+ *
+ *    This mode emphasizes individual variable failures.
+ *
+ * 2) **'status_grouped'** (default)
+ *    - Group rows by NatVis type (e.g. QList<*>).
+ *    - Order NatVis type groups by their *best* (least severe) status
+ *      observed across all variables in that group.
+ *    - Within each group:
+ *        a) Root status severity
+ *        b) Variable name
+ *
+ *    This mode provides a compact, NatVis-centric overview where related
+ *    concrete types stay visually grouped.
+ *
+ * @param rows  Mutable list of NatVis table rows to be sorted in place.
+ */
 function sortNatvisRows<T extends NatvisTableRowLike>(rows: T[]): void {
   const mode = getNatvisTableSortMode();
 
@@ -307,6 +385,30 @@ function sortNatvisRows<T extends NatvisTableRowLike>(rows: T[]): void {
   });
 }
 
+/**
+ * Compute the "NatVis family" key used to group concrete exercised types into
+ * a single NatVis type bucket for the summary table.
+ *
+ * Examples:
+ * - "QList<int>"      -> "QList<*>"
+ * - "QList<QString>"  -> "QList<*>"
+ * - "QStringList"     -> "QList<*>" (if NatVis declares it as an AlternativeType)
+ * - "QByteArray"      -> "QByteArray" (non-template types stay as-is)
+ *
+ * The algorithm:
+ * 1) Normalize the raw debugger type string (strip class/struct, normalize spaces).
+ * 2) Split only the outermost template to get (base, arity).
+ * 3) Canonicalize the base using NatVis AlternativeType relationships so that
+ *    equivalent types share a stable bucket key.
+ * 4) Prefer returning an *existing* NatVis base pattern when possible.
+ * 5) Otherwise derive a wildcard pattern (e.g. base<*,*>), but only keep it if
+ *    NatVis actually defines that pattern.
+ * 6) Final fallback: return the base name.
+ *
+ * @param exercisedType  Concrete type string as reported by the debugger (may be noisy).
+ * @param natvis         Parsed NatVis type metadata (base patterns and AlternativeType rules).
+ * @returns              A stable grouping key used as the "NatVis Type" column in the table.
+ */
 function computeNatvisFamily(
   exercisedType: string,
   natvis: NatvisTypes
@@ -330,6 +432,48 @@ function computeNatvisFamily(
   return parsed.base;
 }
 
+/**
+ * Print a compact, per-variable NatVis status table to the test log.
+ *
+ * The table is intended as a quick “at a glance” overview of what the current
+ * NatVis run produced, using variable names as the primary key (not types).
+ *
+ * Each row represents one top-level variable, and includes:
+ *  - `natvisType`: the NatVis “family key” derived from the concrete type
+ *    (e.g. QList<int> and QList<double> group under QList<*> when applicable).
+ *  - `exercisedType`: the concrete debugger type for that variable (or "<none>").
+ *  - `varName`: the variable name (matches how snapshots/golden are compared).
+ *  - `root`: status of the top-level DisplayString value vs golden.
+ *  - `children`: status of Expand children vs golden (not implemented yet, so "-").
+ *
+ * Status semantics (root column):
+ *  - OK:  variable exists in both snapshot and golden, is not knownProblem, and
+ *         does not appear in the mismatch list.
+ *  - KP:  golden marks this variable as knownProblem for the current platform
+ *         (assertion disabled even if it mismatches).
+ *  - KP*: same as KP, but the variable unexpectedly matched; the variable name
+ *         is present in `goodNewsNames` (“progress” indicator).
+ *  - FAIL: any real mismatch for this variable (after knownProblem filtering),
+ *          including:
+ *            • variable present in snapshot but missing from golden
+ *            • variable missing from snapshot but present in golden (unless KP)
+ *            • value mismatch with no knownProblem
+ *
+ * Row construction uses two passes:
+ *  1) Iterate `natvisSnapshot` to report observed variables (including
+ *     snapshot-only extras).
+ *  2) Iterate `goldenSnapshot` to add golden-only variables missing from
+ *     the snapshot (so missing expectations are visible as FAIL/KP).
+ *
+ * Sorting is delegated to `sortNatvisRows` and can be influenced via
+ * NATVIS_TABLE_SORT ("status" or "status_grouped").
+ *
+ * @param params.natvisSnapshot Platform-normalized locals after NatVis filtering.
+ * @param params.goldenSnapshot Platform-resolved golden snapshot (with knownProblem).
+ * @param params.mismatches     Real mismatches returned by the comparison logic.
+ * @param params.goodNewsNames  Variable names whose knownProblem entries matched (KP*).
+ * @param params.natvis         Parsed NatVis type information (bases and AlternativeType rules).
+ */
 export function printNatvisTypeStatusTable(params: {
   natvisSnapshot: readonly Snapshot[];
   goldenSnapshot: readonly GoldenSnapshot[];
@@ -459,6 +603,9 @@ export function printNatvisTypeStatusTable(params: {
     );
   }
   console.log('  ' + colWidths.map((w) => '-'.repeat(w)).join('-|-'));
+  console.log(
+  `  (covers variables from snapshot + golden expectations; excludes missing NatVis patterns list)`
+  );
   console.log('  Columns:');
   console.log(
     '    root     = status of the top-level variable value vs golden'

--- a/qt-cpp/test/suite/natvis.test.mts
+++ b/qt-cpp/test/suite/natvis.test.mts
@@ -491,4 +491,3 @@ describe('natvis: minimal Qt project debug (index-natvis)', function () {
     }
   });
 });
-

--- a/qt-cpp/test/suite/natvis.test.mts
+++ b/qt-cpp/test/suite/natvis.test.mts
@@ -239,7 +239,7 @@ describe('natvis: minimal Qt project debug (index-natvis)', function () {
         );
       }
 
-      const mismatches = findMismatchedSnapshotEntries(
+      const { mismatches, goodNewsNames } = findMismatchedSnapshotEntries(
         snapshot,
         goldenSnapshot,
         natvis
@@ -253,6 +253,7 @@ describe('natvis: minimal Qt project debug (index-natvis)', function () {
           natvisSnapshot: snapshot,
           goldenSnapshot,
           mismatches,
+          goodNewsNames,
           natvis,
           missing,
           natvisPath,

--- a/qt-cpp/test/suite/natvis.test.mts
+++ b/qt-cpp/test/suite/natvis.test.mts
@@ -84,6 +84,203 @@ before('cpptools is installed and activated', async () => {
 });
 
 // ---------------------------------------------------------------------------
+// Snippet-based debug: lightweight sanity test using Qt debug snippets
+// ---------------------------------------------------------------------------
+describe('Debugging using Qt debug snippets (Qt: Debug with …)', function () {
+  this.timeout(150_000);
+
+  it('launches via Qt debug snippet and shows Locals formatted by our NatVis rules (lightweight sanity test)', async function () {
+    const {
+      wsFolder,
+      projectDir,
+      buildDir
+      // kit, errSpy (already asserted in helper)
+    } = await configureAndBuildMinimalQtProject(this, '[snippet-test]', sb);
+
+    let session: vscode.DebugSession | undefined;
+    let removeBps: (() => void) | undefined;
+
+    try {
+      // --- Set breakpoints in source file (same as golden test) --------
+      const { doc, breakpoints } = await prepareBreakpointsFromMarkers(
+        projectDir,
+        'main.cpp',
+        'BREAK_HERE'
+      );
+      removeBps = addBreakpoints(breakpoints);
+
+      await waitForVSCodeIdle();
+
+      const lines = doc.getText().split('\n');
+      const markerIdxs = lines
+        .map((ln, i) => (ln.includes('BREAK_HERE') ? i : -1))
+        .filter((i) => i >= 0);
+
+      expect(
+        markerIdxs.length,
+        '[snippet-test] No // BREAK_HERE markers found in source'
+      ).to.be.greaterThan(0);
+
+      dlog(
+        '[snippet-test] CMAKE_BUILD_TYPE:',
+        readCMakeCacheVar(buildDir, 'CMAKE_BUILD_TYPE')
+      );
+      dlog(
+        '[snippet-test] cmake.buildConfig:',
+        vscode.workspace.getConfiguration('cmake').get('buildConfig')
+      );
+
+      // --- Resolve NatVis and commands used by the snippet -------------
+      const nvPath =
+        await vscode.commands.executeCommand<string>('qt-cpp.natvis');
+      dlog('[snippet-test] visualizer path:', nvPath);
+      expect(
+        nvPath,
+        '[snippet-test] qt-cpp.natvis did not resolve to a path'
+      ).to.be.a('string').and.not.empty;
+
+      const program = await vscode.commands.executeCommand<string>(
+        'cmake.launchTargetPath'
+      );
+      const cwd = await vscode.commands.executeCommand<string>(
+        'cmake.getLaunchTargetDirectory'
+      );
+
+      expect(!!program, '[snippet-test] cmake.launchTargetPath did not resolve')
+        .to.be.true;
+      expect(
+        !!cwd,
+        '[snippet-test] cmake.getLaunchTargetDirectory did not resolve'
+      ).to.be.true;
+
+      // --- Build debug config from package.json snippet -----------------
+      const snippetCfg = getQtCppSnippetDebugConfiguration();
+      const platformCfg =
+        materializeSnippetConfigForCurrentPlatform(snippetCfg);
+
+      const cfg: vscode.DebugConfiguration = {
+        ...platformCfg,
+        // Force concrete paths for the test project, while keeping all
+        // snippet-specific fields (MIMode, environment, sourceFileMap, etc.)
+        program: program!,
+        cwd: cwd!,
+        visualizerFile: nvPath!
+      };
+
+      if (process.env.QT_TEST_DEBUG === '1') {
+        dlog(
+          '[snippet-test] Debug config type:',
+          cfg.type,
+          'MIMode:',
+          (cfg as any).MIMode ?? '<none>',
+          'miDebuggerPath:',
+          (cfg as any).miDebuggerPath ?? '<none>'
+        );
+      }
+
+      console.log(
+        '[snippet-test] Debug config from snippet (after patching):',
+        JSON.stringify(cfg, null, 2)
+      );
+      const fsExists = fs.existsSync(cfg.program ?? '');
+      console.log(
+        '[snippet-test] program exists?',
+        fsExists,
+        'program =',
+        cfg.program
+      );
+      const timeoutMs = 60000;
+      const { session: s, stops } = await startDebugAndWaitForStop(
+        wsFolder,
+        cfg,
+        { timeoutMs }
+      );
+      session = s;
+
+      // --- Inspect backend for sanity ----------------------------------
+      if (session) {
+        const dbgType = session.type;
+        const miMode = (session.configuration as any)?.MIMode;
+
+        dlog('[snippet-test] Debugger backend:', dbgType);
+        if (dbgType === 'cppdbg') {
+          dlog('[snippet-test] MIMode:', miMode);
+        }
+      }
+
+      expect(
+        stops.length,
+        '[snippet-test] Debugger did not stop on a breakpoint'
+      ).to.be.greaterThan(0);
+      dlog(
+        '[snippet-test] stops:',
+        stops.map((st) => `${st.source}:${st.line}`).join(', ')
+      );
+
+      const stop = stops[0]!;
+      const frameId = stop.frameId!;
+      const locals = await getLocals(session, frameId);
+      dlog(
+        '[snippet-test] Locals at top frame:',
+        locals.map((v: any) => v.name).join(', ')
+      );
+      const flatLocals = await getFlattenedLocals(session, frameId);
+      dlog(
+        'Locals at top frame (flattened):',
+        flatLocals.map((v: DebugVariable) => v.name).join(', ')
+      );
+      const vRect =
+        flatLocals.find((v) => v.name === 'coreTypes.qRect') ??
+        flatLocals.find((v) => v.name === 'qRect');
+      const vBA =
+        flatLocals.find((v) => v.name === 'coreTypes.qByteArray') ??
+        flatLocals.find((v) => v.name === 'qByteArray');
+      const vStr =
+        flatLocals.find((v) => v.name === 'coreTypes.qString') ??
+        flatLocals.find((v) => v.name === 'qString');
+
+      expect(vRect, '[snippet-test] qRect not found in Locals').to.exist;
+      expect(vBA, '[snippet-test] qByteArray not found in Locals').to.exist;
+      expect(vStr, '[snippet-test] qString not found in Locals').to.exist;
+
+      // Make TS happy: if any is missing, bail out
+      if (!vRect || !vBA || !vStr) {
+        throw new Error(
+          '[snippet-test] Required locals missing despite existence checks'
+        );
+      }
+
+      // Light NatVis sanity check: same idea as golden, but without golden compare
+      expect(
+        String(vRect.value),
+        '[snippet-test] qRect value does not look NatVis-formatted'
+      ).to.match(/height.*/i);
+
+      expect(
+        String(vRect.value),
+        '[snippet-test] qRect.x did not match expected NatVis output'
+      ).to.match(/x\s*=\s*5/i);
+      expect(
+        String(vRect.value),
+        '[snippet-test] qRect.y did not match expected NatVis output'
+      ).to.match(/y\s*=\s*6/i);
+      expect(
+        String(vRect.value),
+        '[snippet-test] qRect.width did not match expected NatVis output'
+      ).to.match(/width\s*=\s*41/i);
+      expect(
+        String(vStr.value),
+        '[snippet-test] qString did not contain expected text'
+      ).to.match(/Hello World!?/);
+    } finally {
+      removeBps?.();
+      await stopDebugSession(session);
+      await waitForVSCodeIdle();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Main NatVis golden test
 // ---------------------------------------------------------------------------
 describe('natvis: minimal Qt project debug (index-natvis)', function () {
@@ -295,199 +492,3 @@ describe('natvis: minimal Qt project debug (index-natvis)', function () {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Snippet-based debug: lightweight sanity test using Qt debug snippets
-// ---------------------------------------------------------------------------
-describe('Debugging using Qt debug snippets (Qt: Debug with …)', function () {
-  this.timeout(150_000);
-
-  it('launches via Qt debug snippet and shows Locals formatted by our NatVis rules (lightweight sanity test)', async function () {
-    const {
-      wsFolder,
-      projectDir,
-      buildDir
-      // kit, errSpy (already asserted in helper)
-    } = await configureAndBuildMinimalQtProject(this, '[snippet-test]', sb);
-
-    let session: vscode.DebugSession | undefined;
-    let removeBps: (() => void) | undefined;
-
-    try {
-      // --- Set breakpoints in source file (same as golden test) --------
-      const { doc, breakpoints } = await prepareBreakpointsFromMarkers(
-        projectDir,
-        'main.cpp',
-        'BREAK_HERE'
-      );
-      removeBps = addBreakpoints(breakpoints);
-
-      await waitForVSCodeIdle();
-
-      const lines = doc.getText().split('\n');
-      const markerIdxs = lines
-        .map((ln, i) => (ln.includes('BREAK_HERE') ? i : -1))
-        .filter((i) => i >= 0);
-
-      expect(
-        markerIdxs.length,
-        '[snippet-test] No // BREAK_HERE markers found in source'
-      ).to.be.greaterThan(0);
-
-      dlog(
-        '[snippet-test] CMAKE_BUILD_TYPE:',
-        readCMakeCacheVar(buildDir, 'CMAKE_BUILD_TYPE')
-      );
-      dlog(
-        '[snippet-test] cmake.buildConfig:',
-        vscode.workspace.getConfiguration('cmake').get('buildConfig')
-      );
-
-      // --- Resolve NatVis and commands used by the snippet -------------
-      const nvPath =
-        await vscode.commands.executeCommand<string>('qt-cpp.natvis');
-      dlog('[snippet-test] visualizer path:', nvPath);
-      expect(
-        nvPath,
-        '[snippet-test] qt-cpp.natvis did not resolve to a path'
-      ).to.be.a('string').and.not.empty;
-
-      const program = await vscode.commands.executeCommand<string>(
-        'cmake.launchTargetPath'
-      );
-      const cwd = await vscode.commands.executeCommand<string>(
-        'cmake.getLaunchTargetDirectory'
-      );
-
-      expect(!!program, '[snippet-test] cmake.launchTargetPath did not resolve')
-        .to.be.true;
-      expect(
-        !!cwd,
-        '[snippet-test] cmake.getLaunchTargetDirectory did not resolve'
-      ).to.be.true;
-
-      // --- Build debug config from package.json snippet -----------------
-      const snippetCfg = getQtCppSnippetDebugConfiguration();
-      const platformCfg =
-        materializeSnippetConfigForCurrentPlatform(snippetCfg);
-
-      const cfg: vscode.DebugConfiguration = {
-        ...platformCfg,
-        // Force concrete paths for the test project, while keeping all
-        // snippet-specific fields (MIMode, environment, sourceFileMap, etc.)
-        program: program!,
-        cwd: cwd!,
-        visualizerFile: nvPath!
-      };
-
-      if (process.env.QT_TEST_DEBUG === '1') {
-        dlog(
-          '[snippet-test] Debug config type:',
-          cfg.type,
-          'MIMode:',
-          (cfg as any).MIMode ?? '<none>',
-          'miDebuggerPath:',
-          (cfg as any).miDebuggerPath ?? '<none>'
-        );
-      }
-
-      console.log(
-        '[snippet-test] Debug config from snippet (after patching):',
-        JSON.stringify(cfg, null, 2)
-      );
-      const fsExists = fs.existsSync(cfg.program ?? '');
-      console.log(
-        '[snippet-test] program exists?',
-        fsExists,
-        'program =',
-        cfg.program
-      );
-      const timeoutMs = 60000;
-      const { session: s, stops } = await startDebugAndWaitForStop(
-        wsFolder,
-        cfg,
-        { timeoutMs }
-      );
-      session = s;
-
-      // --- Inspect backend for sanity ----------------------------------
-      if (session) {
-        const dbgType = session.type;
-        const miMode = (session.configuration as any)?.MIMode;
-
-        dlog('[snippet-test] Debugger backend:', dbgType);
-        if (dbgType === 'cppdbg') {
-          dlog('[snippet-test] MIMode:', miMode);
-        }
-      }
-
-      expect(
-        stops.length,
-        '[snippet-test] Debugger did not stop on a breakpoint'
-      ).to.be.greaterThan(0);
-      dlog(
-        '[snippet-test] stops:',
-        stops.map((st) => `${st.source}:${st.line}`).join(', ')
-      );
-
-      const stop = stops[0]!;
-      const frameId = stop.frameId!;
-      const locals = await getLocals(session, frameId);
-      dlog(
-        '[snippet-test] Locals at top frame:',
-        locals.map((v: any) => v.name).join(', ')
-      );
-      const flatLocals = await getFlattenedLocals(session, frameId);
-      dlog(
-        'Locals at top frame (flattened):',
-        flatLocals.map((v: DebugVariable) => v.name).join(', ')
-      );
-      const vRect =
-        flatLocals.find((v) => v.name === 'coreTypes.qRect') ??
-        flatLocals.find((v) => v.name === 'qRect');
-      const vBA =
-        flatLocals.find((v) => v.name === 'coreTypes.qByteArray') ??
-        flatLocals.find((v) => v.name === 'qByteArray');
-      const vStr =
-        flatLocals.find((v) => v.name === 'coreTypes.qString') ??
-        flatLocals.find((v) => v.name === 'qString');
-
-      expect(vRect, '[snippet-test] qRect not found in Locals').to.exist;
-      expect(vBA, '[snippet-test] qByteArray not found in Locals').to.exist;
-      expect(vStr, '[snippet-test] qString not found in Locals').to.exist;
-
-      // Make TS happy: if any is missing, bail out
-      if (!vRect || !vBA || !vStr) {
-        throw new Error(
-          '[snippet-test] Required locals missing despite existence checks'
-        );
-      }
-
-      // Light NatVis sanity check: same idea as golden, but without golden compare
-      expect(
-        String(vRect.value),
-        '[snippet-test] qRect value does not look NatVis-formatted'
-      ).to.match(/height.*/i);
-
-      expect(
-        String(vRect.value),
-        '[snippet-test] qRect.x did not match expected NatVis output'
-      ).to.match(/x\s*=\s*5/i);
-      expect(
-        String(vRect.value),
-        '[snippet-test] qRect.y did not match expected NatVis output'
-      ).to.match(/y\s*=\s*6/i);
-      expect(
-        String(vRect.value),
-        '[snippet-test] qRect.width did not match expected NatVis output'
-      ).to.match(/width\s*=\s*41/i);
-      expect(
-        String(vStr.value),
-        '[snippet-test] qString did not contain expected text'
-      ).to.match(/Hello World!?/);
-    } finally {
-      removeBps?.();
-      await stopDebugSession(session);
-      await waitForVSCodeIdle();
-    }
-  });
-});


### PR DESCRIPTION
- Introduce a NatVis status summary table in NatVis integration tests, with per-variable rows grouped by NatVis “family” (for    example QList<*>, QCborValue).
	- show status codes: OK, KP, KP* (“good news”), and FAIL (real mismatches, including extra or missing variables).

- Add NATVIS_VERBOSE to gate detailed known-problem diagnostics and reduce log noise.
- Fix golden expected value for qCborValueString.
- Reorder NatVis tests so the summary table appears at the end of the main NatVis test in CI logs.
- Clean up code and update documentation around the new summary logic.