### PR TITLE
Qtcpp natvis state type coverage

### DIFF
--- a/qt-cpp/test/debug-golden-entries.mts
+++ b/qt-cpp/test/debug-golden-entries.mts
@@ -616,7 +616,11 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
       darwin:
         'QObject NatVis relies on Windows-only Qt6Cored.dll intrinsics (QObjectPrivate via d_ptr), so LLDB cannot evaluate objectName DisplayString.',
       linux:
-        'QObject NatVis relies on Windows-only Qt6Cored.dll intrinsics (QObjectPrivate via d_ptr), so GDB cannot evaluate objectName DisplayString.'
+        'QObject NatVis relies on Windows-only Qt6Cored.dll intrinsics (QObjectPrivate via d_ptr), so GDB cannot evaluate objectName DisplayString.',
+      win32:
+        'NatVis loads, but required private symbols/fields are not available ' +
+        '(Qt build lacks full private debug info), so DisplayString evaluation fails and the debugger ' +
+        'falls back to a raw "{d_ptr={...}}" representation instead of objectName.'
     }
   },
   // QVariant
@@ -624,6 +628,10 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     name: 'coreStateTypes.qVariantNull',
     type: 'QVariant',
     value: '(null)',
+    knownProblem: {
+      win32:
+        'On win32 CI, QVariant NatVis is not applied; debugger shows raw internal "{d={...}}" structure instead of DisplayString.'
+    }
   },
   {
     name: 'coreStateTypes.qVariantInt',
@@ -633,7 +641,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
       darwin:
         "QVariant NatVis evaluation fails under LLDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'.",
       linux:
-        "QVariant NatVis evaluation fails under GDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'."
+        "QVariant NatVis evaluation fails under GDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'.",
+      win32:
+        'On win32 CI, QVariant NatVis is not applied; debugger shows raw internal "{d={...}}" structure instead of DisplayString.'
     }
   },
   {
@@ -644,7 +654,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
       darwin:
         "QVariant NatVis evaluation fails under LLDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'.",
       linux:
-        "QVariant NatVis evaluation fails under GDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'."
+        "QVariant NatVis evaluation fails under GDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'.",
+      win32:
+        'On win32 CI, QVariant NatVis is not applied; debugger shows raw internal "{d={...}}" structure instead of DisplayString.'
     }
   },
   {
@@ -655,7 +667,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
       darwin:
         "QVariant NatVis evaluation fails under LLDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'.",
       linux:
-        "QVariant NatVis evaluation fails under GDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'."
+        "QVariant NatVis evaluation fails under GDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'.",
+      win32:
+        'On win32 CI, QVariant NatVis is not applied; debugger shows raw internal "{d={...}}" structure instead of DisplayString.'
     }
   },
   // QFlags (NatVis for QFlags<*> is numeric: {($T1)i})
@@ -667,7 +681,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
       darwin:
         'QFlags<*> NatVis is not applied under LLDB; value falls back to {...} instead of the numeric DisplayString.',
       linux:
-        'QFlags<*> NatVis is not applied under GDB; value falls back to "" instead of the numeric DisplayString.'
+        'QFlags<*> NatVis is not applied under GDB; value falls back to "" instead of the numeric DisplayString.',
+      win32:
+        'QFlags<*> NatVis is not applied on win32; value falls back to "None (0)" instead of the numeric DisplayString.'
     }
   },
   {
@@ -680,7 +696,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
       darwin:
         'QFlags<*> NatVis is not applied under LLDB; value falls back to {...} instead of the numeric DisplayString.',
       linux:
-        'QFlags<*> NatVis is not applied under GDB; value falls back to "" instead of the numeric DisplayString.'
+        'QFlags<*> NatVis is not applied under GDB; value falls back to "" instead of the numeric DisplayString.',
+      win32:
+        'QFlags<*> NatVis is not applied on win32; value falls back to "Read | Write (3)" instead of the numeric DisplayString.'
     }
   },
   // Atomics
@@ -704,7 +722,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
       darwin:
         'QBasicAtomicPointer<*> NatVis is not applied under LLDB; value falls back to {...} instead of {_q_value}/empty.',
       linux:
-        'QBasicAtomicPointer<*> NatVis is not applied under GDB; value falls back to "" instead of {_q_value}/empty.'
+        'QBasicAtomicPointer<*> NatVis is not applied under GDB; value falls back to "" instead of {_q_value}/empty.',
+      win32:
+        'On win32 CI, atomic pointer formatting differs (shows "{123}" / raw) instead of address-like DisplayString.'
     }
   },
   {
@@ -715,7 +735,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
       darwin:
         'QBasicAtomicPointer<*> NatVis is not applied under LLDB; value falls back to {...} instead of {_q_value}/empty.',
       linux:
-        'QBasicAtomicPointer<*> NatVis is not applied under GDB; value falls back to "" instead of {_q_value}/empty.'
+        'QBasicAtomicPointer<*> NatVis is not applied under GDB; value falls back to "" instead of {_q_value}/empty.',
+      win32:
+        'On win32 CI, atomic pointer formatting differs (shows empty string / raw) instead of address-like DisplayString.'
     }
   },
   {

--- a/qt-cpp/test/debug-golden-entries.mts
+++ b/qt-cpp/test/debug-golden-entries.mts
@@ -604,6 +604,121 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
       win32:
         'QCborValue NatVis currently fails. Debugger provides: n=42 container=0xADDR <NULL> t=Integer (0) instead of just "42".'
     }
+  },
+  // ---------------------------------------------------------------------------
+  // core_state_types
+  // ---------------------------------------------------------------------------
+  {
+    name: 'coreStateTypes.qObject',
+    type: 'QObject',
+    value: 'core_state_types.qObject',
+    knownProblem: {
+      darwin:
+        'QObject NatVis relies on Windows-only Qt6Cored.dll intrinsics (QObjectPrivate via d_ptr), so LLDB cannot evaluate objectName DisplayString.',
+      linux:
+        'QObject NatVis relies on Windows-only Qt6Cored.dll intrinsics (QObjectPrivate via d_ptr), so GDB cannot evaluate objectName DisplayString.'
+    }
+  },
+  // QVariant
+  {
+    name: 'coreStateTypes.qVariantNull',
+    type: 'QVariant',
+    value: '(null)',
+  },
+  {
+    name: 'coreStateTypes.qVariantInt',
+    type: 'QVariant',
+    value: '42',
+    knownProblem: {
+      darwin:
+        "QVariant NatVis evaluation fails under LLDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'."
+    }
+  },
+  {
+    name: 'coreStateTypes.qVariantString',
+    type: 'QVariant',
+    value: 'variant-string',
+    knownProblem: {
+      darwin:
+        "QVariant NatVis evaluation fails under LLDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'."
+    }
+  },
+  {
+    name: 'coreStateTypes.qVariantBool',
+    type: 'QVariant',
+    value: 'true',
+    knownProblem: {
+      darwin:
+        "QVariant NatVis evaluation fails under LLDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'."
+    }
+  },
+  // QFlags (NatVis for QFlags<*> is numeric: {($T1)i})
+  {
+    name: 'coreStateTypes.qFlagsNone',
+    type: 'CoreStateFlags',
+    value: '0',
+    knownProblem: {
+      darwin:
+        'QFlags<*> NatVis is not applied under LLDB; value falls back to {...} instead of the numeric DisplayString.'
+    }
+  },
+  {
+    // This is the typedef created by Q_DECLARE_FLAGS(CoreStateFlags, CoreStateFlag)
+    // NatVis applies via the underlying QFlags<*> rule.
+    name: 'coreStateTypes.qFlags',
+    type: 'CoreStateFlags',
+    value: '3',
+    knownProblem: {
+      darwin:
+        'QFlags<*> NatVis is not applied under LLDB; value falls back to {...} instead of the numeric DisplayString.'
+    }
+  },
+  // Atomics
+  {
+    name: 'coreStateTypes.qAtomicInt',
+    type: 'QBasicAtomicInteger<int>',
+    value: '7',
+    knownProblem: {
+      darwin:
+        'QBasicAtomicInteger<*> NatVis is not applied under LLDB; value falls back to {...} instead of the numeric DisplayString.'
+    }
+  },
+  // Atomic pointers: non-null prints {_q_value} (address-like), null prints "empty"
+  {
+    name: 'coreStateTypes.qAtomicPtr',
+    type: 'QBasicAtomicPointer<int>',
+    value: '0xADDR',
+    knownProblem: {
+      darwin:
+        'QBasicAtomicPointer<*> NatVis is not applied under LLDB; value falls back to {...} instead of {_q_value}/empty.'
+    }
+  },
+  {
+    name: 'coreStateTypes.qAtomicVoidPtr',
+    type: 'QBasicAtomicPointer<void>',
+    value: '0xADDR',
+    knownProblem: {
+      darwin:
+        'QBasicAtomicPointer<*> NatVis is not applied under LLDB; value falls back to {...} instead of {_q_value}/empty.'
+    }
+  },
+  {
+    name: 'coreStateTypes.qAtomicPtrNull',
+    type: 'QBasicAtomicPointer<int>',
+    value: 'empty',
+    knownProblem: {
+      darwin:
+        'QBasicAtomicPointer<*> NatVis is not applied under LLDB; value falls back to {...} instead of {_q_value}/empty.'
+    }
+  },
+  {
+    name: 'coreStateTypes.qAtomicVoidPtrNull',
+    type: 'QBasicAtomicPointer<void>',
+    value: 'empty',
+    knownProblem: {
+      darwin:
+        'QBasicAtomicPointer<*> NatVis is not applied under LLDB; value falls back to {...} instead of {_q_value}/empty.'
+    }
   }
 ] as const;
 

--- a/qt-cpp/test/debug-golden-entries.mts
+++ b/qt-cpp/test/debug-golden-entries.mts
@@ -631,7 +631,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '42',
     knownProblem: {
       darwin:
-        "QVariant NatVis evaluation fails under LLDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'."
+        "QVariant NatVis evaluation fails under LLDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'.",
+      linux:
+        "QVariant NatVis evaluation fails under GDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'."
     }
   },
   {
@@ -640,7 +642,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: 'variant-string',
     knownProblem: {
       darwin:
-        "QVariant NatVis evaluation fails under LLDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'."
+        "QVariant NatVis evaluation fails under LLDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'.",
+      linux:
+        "QVariant NatVis evaluation fails under GDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'."
     }
   },
   {
@@ -649,7 +653,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: 'true',
     knownProblem: {
       darwin:
-        "QVariant NatVis evaluation fails under LLDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'."
+        "QVariant NatVis evaluation fails under LLDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'.",
+      linux:
+        "QVariant NatVis evaluation fails under GDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'."
     }
   },
   // QFlags (NatVis for QFlags<*> is numeric: {($T1)i})
@@ -659,7 +665,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '0',
     knownProblem: {
       darwin:
-        'QFlags<*> NatVis is not applied under LLDB; value falls back to {...} instead of the numeric DisplayString.'
+        'QFlags<*> NatVis is not applied under LLDB; value falls back to {...} instead of the numeric DisplayString.',
+      linux:
+        'QFlags<*> NatVis is not applied under GDB; value falls back to "" instead of the numeric DisplayString.'
     }
   },
   {
@@ -670,7 +678,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '3',
     knownProblem: {
       darwin:
-        'QFlags<*> NatVis is not applied under LLDB; value falls back to {...} instead of the numeric DisplayString.'
+        'QFlags<*> NatVis is not applied under LLDB; value falls back to {...} instead of the numeric DisplayString.',
+      linux:
+        'QFlags<*> NatVis is not applied under GDB; value falls back to "" instead of the numeric DisplayString.'
     }
   },
   // Atomics
@@ -680,7 +690,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '7',
     knownProblem: {
       darwin:
-        'QBasicAtomicInteger<*> NatVis is not applied under LLDB; value falls back to {...} instead of the numeric DisplayString.'
+        'QBasicAtomicInteger<*> NatVis is not applied under LLDB; value falls back to {...} instead of the numeric DisplayString.',
+      linux:
+        'QBasicAtomicInteger<*> NatVis is not applied under GDB; value falls back to {...} instead of the numeric DisplayString.'
     }
   },
   // Atomic pointers: non-null prints {_q_value} (address-like), null prints "empty"
@@ -690,7 +702,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '0xADDR',
     knownProblem: {
       darwin:
-        'QBasicAtomicPointer<*> NatVis is not applied under LLDB; value falls back to {...} instead of {_q_value}/empty.'
+        'QBasicAtomicPointer<*> NatVis is not applied under LLDB; value falls back to {...} instead of {_q_value}/empty.',
+      linux:
+        'QBasicAtomicPointer<*> NatVis is not applied under GDB; value falls back to "" instead of {_q_value}/empty.'
     }
   },
   {
@@ -699,7 +713,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: '0xADDR',
     knownProblem: {
       darwin:
-        'QBasicAtomicPointer<*> NatVis is not applied under LLDB; value falls back to {...} instead of {_q_value}/empty.'
+        'QBasicAtomicPointer<*> NatVis is not applied under LLDB; value falls back to {...} instead of {_q_value}/empty.',
+      linux:
+        'QBasicAtomicPointer<*> NatVis is not applied under GDB; value falls back to "" instead of {_q_value}/empty.'
     }
   },
   {
@@ -708,7 +724,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: 'empty',
     knownProblem: {
       darwin:
-        'QBasicAtomicPointer<*> NatVis is not applied under LLDB; value falls back to {...} instead of {_q_value}/empty.'
+        'QBasicAtomicPointer<*> NatVis is not applied under LLDB; value falls back to {...} instead of {_q_value}/empty.',
+      linux:
+        'QBasicAtomicPointer<*> NatVis is not applied under GDB; value falls back to "" instead of {_q_value}/empty.'
     }
   },
   {
@@ -717,7 +735,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: 'empty',
     knownProblem: {
       darwin:
-        'QBasicAtomicPointer<*> NatVis is not applied under LLDB; value falls back to {...} instead of {_q_value}/empty.'
+        'QBasicAtomicPointer<*> NatVis is not applied under LLDB; value falls back to {...} instead of {_q_value}/empty.',
+      linux:
+        'QBasicAtomicPointer<*> NatVis is not applied under GDB; value falls back to "" instead of {_q_value}/empty.'
     }
   }
 ] as const;

--- a/qt-cpp/test/debug-golden.mts
+++ b/qt-cpp/test/debug-golden.mts
@@ -346,6 +346,7 @@ export type NatvisTypes = {
   bases: Set<string>;
   alts: Map<string, Set<string>>;
   altToBase: Map<string, string>;
+  extraAliases?: ReadonlyMap<string, readonly string[]>;
 };
 
 // Extra aliases for types whose *real* NatVis rule is more generic.
@@ -357,7 +358,8 @@ export const EXTRA_NATVIS_TYPE_ALIASES: Record<string, string[]> = {
   'QList<*>': ['QByteArrayList', 'QStringList', 'QVariantList'],
   'QPair<*,*>': ['std::pair'],
   'QHash<*,*>': ['QVariantHash'],
-  'QMap<*,*>': ['QVariantMap']
+  'QMap<*,*>': ['QVariantMap'],
+  CoreStateFlags: ['QFlags<CoreStateFlag>']
 };
 
 /**
@@ -387,6 +389,11 @@ export async function parseNatvisTypesWithAlternatives(
   const bases = new Set<string>();
   const alts = new Map<string, Set<string>>();
   const altToBase = new Map<string, string>();
+  // keep the forward alias table around for type-compatibility checks
+  // (typedef vs expanded template spelling, etc.)
+  const extraAliases = new Map<string, readonly string[]>(
+    Object.entries(EXTRA_NATVIS_TYPE_ALIASES)
+  );
 
   // Seed reverse aliases from EXTRA_NATVIS_TYPE_ALIASES.
   // Example:
@@ -463,9 +470,9 @@ export async function parseNatvisTypesWithAlternatives(
       if (alt) all.add(alt);
     }
 
-    return { all, bases, alts, altToBase };
+    return { all, bases, alts, altToBase, extraAliases };
   } catch {
-    return { all, bases, alts, altToBase };
+    return { all, bases, alts, altToBase, extraAliases };
   }
 }
 

--- a/qt-cpp/test/debug-golden.mts
+++ b/qt-cpp/test/debug-golden.mts
@@ -151,6 +151,14 @@ export function normalizeValue(raw: string): string {
  * 5. Promotes children of top-level “holder” structs (e.g. `coreTypes`,
  *    `containerTypes`) so that the resulting roots match the golden snapshot
  *    entries (e.g. `coreTypes.qByteArray`).
+ * Skipping support variables:
+ * - Variables whose dotted path contains a segment starting with `support_`
+ *   (e.g. `coreStateTypes.support_atomicTarget`) are intentionally skipped.
+ * - These support variables exist only to back other variables (e.g. as stable
+ *   pointer targets) and are not part of the NatVis coverage surface.
+ * - Skipping happens before the snapshot tree is built so support variables
+ *   cannot appear as promoted roots, mismatches, or rows in the summary table.
+
  *
  * Important design notes:
  * - Only the promoted root entries are intended to be compared against golden
@@ -179,6 +187,12 @@ export function materializeLocalSnapshot(
   };
 
   const byName = new Map<string, MutableSnap>();
+  const shouldSkipSnapshotVar = (fullName: string): boolean => {
+    // Skip any variable whose dotted path contains a "support_" segment.
+    // Example: "coreStateTypes.support_atomicTarget"
+    const parts = fullName.split('.');
+    return parts.some((p) => p.startsWith('support_'));
+  };
 
   const getOrCreate = (name: string): MutableSnap => {
     const existing = byName.get(name);
@@ -200,6 +214,13 @@ export function materializeLocalSnapshot(
   for (const v of vars) {
     const name = v.name ?? '';
     if (!name) continue;
+
+    if (shouldSkipSnapshotVar(name)) {
+      if (process.env.NATVIS_VERBOSE === '1') {
+        console.log(`[natvis.test][skip] Skipping support variable '${name}'`);
+      }
+      continue;
+    }
 
     const node = getOrCreate(name);
 

--- a/qt-cpp/test/natvis-test-helper.mts
+++ b/qt-cpp/test/natvis-test-helper.mts
@@ -910,6 +910,20 @@ export function areTypesCompatible(
 
   if (a0 === e0) return true;
 
+  // Allow explicit aliases (typedef vs expanded template spelling, etc.).
+  // Example: expected "CoreStateFlags" vs actual "QFlags<CoreStateFlag>" on win32.
+  const expectedAliases = natvis.extraAliases?.get(e0);
+  if (expectedAliases) {
+    for (const alias of expectedAliases) {
+      const aliasNorm = normalizeType(alias);
+
+      if (aliasNorm === a0) return true;
+
+      // Also allow expanded-template variants if the alias is the shorter form.
+      if (expandedTemplateCompatible(aliasNorm, a0)) return true;
+    }
+  }
+
   // Handle QSpan<int> vs QSpan<int,...> before any other reasoning.
   if (expandedTemplateCompatible(e0, a0)) return true;
 

--- a/qt-cpp/test/projectFolderNatvis/core_state_types.h
+++ b/qt-cpp/test/projectFolderNatvis/core_state_types.h
@@ -1,0 +1,94 @@
+// Copyright (C) 2025 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+#pragma once
+
+// -----------------------------------------------------------------------------
+// core_state_types
+//
+// QtCore types that represent dynamic, indirect, or state-carrying concepts,
+// rather than plain value types or containers.
+//
+// This group exists for NatVis coverage and includes:
+// - QVariant          : type-erased runtime values
+// - QObject           : object identity and runtime state
+// - QFlags<*>         : configuration / option state
+// - QBasicAtomic*     : shared / atomic state
+//
+// The grouping is taxonomy-based (semantic role), not value-based.
+// -----------------------------------------------------------------------------
+
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QVariant>
+#include <QtCore/QFlags>
+#include <QtCore/qbasicatomic.h>
+
+// Simple enum to force a real QFlags<Enum> instantiation
+enum class CoreStateFlag : unsigned int {
+  None    = 0x0,
+  Read    = 0x1,
+  Write   = 0x2,
+  Execute = 0x4
+};
+
+Q_DECLARE_FLAGS(CoreStateFlags, CoreStateFlag)
+Q_DECLARE_OPERATORS_FOR_FLAGS(CoreStateFlags)
+
+class CoreStateTypes
+{
+public:
+  CoreStateTypes()
+  {
+    // QObject
+    qObject.setObjectName(QStringLiteral("core_state_types.qObject"));
+
+    // QVariant (type-erased values)
+    qVariantNull   = QVariant(); // NatVis: (null)
+    qVariantInt    = QVariant::fromValue(42);
+    qVariantString = QVariant::fromValue(QStringLiteral("variant-string"));
+    qVariantBool   = QVariant::fromValue(true);
+
+    // QFlags
+    qFlagsNone = CoreStateFlags(); // 0
+    qFlags     = CoreStateFlag::Read | CoreStateFlag::Write;
+
+    // Atomics
+    qAtomicInt.storeRelaxed(7);
+
+    // Non-null pointers
+    qAtomicPtr.storeRelaxed(&support_atomicTarget);
+    qAtomicVoidPtr.storeRelaxed(static_cast<void*>(&support_atomicTarget));
+
+    // Null pointers (NatVis: empty)
+    qAtomicPtrNull.storeRelaxed(nullptr);
+    qAtomicVoidPtrNull.storeRelaxed(nullptr);
+  }
+
+  // QObject (object identity / runtime state)
+  QObject qObject;
+
+  // QVariant
+  QVariant qVariantNull;
+  QVariant qVariantInt;
+  QVariant qVariantString;
+  QVariant qVariantBool;
+
+  // QFlags
+  CoreStateFlags qFlagsNone;
+  CoreStateFlags qFlags;
+
+  // Atomics
+  QBasicAtomicInteger<int> qAtomicInt;
+
+  // Support-only backing storage for atomic pointers (skip in snapshot/summary)
+  int support_atomicTarget = 123;
+
+  // Non-null atomic pointers
+  QBasicAtomicPointer<int> qAtomicPtr;
+  QBasicAtomicPointer<void> qAtomicVoidPtr;
+
+  // Null atomic pointers (NatVis: empty)
+  QBasicAtomicPointer<int> qAtomicPtrNull;
+  QBasicAtomicPointer<void> qAtomicVoidPtrNull;
+};

--- a/qt-cpp/test/projectFolderNatvis/main.cpp
+++ b/qt-cpp/test/projectFolderNatvis/main.cpp
@@ -5,12 +5,15 @@
 
 #include "core_types.h"
 #include "container_types.h"
+#include "core_state_types.h"
 
 int main(int argc, char** argv) {
   QCoreApplication app(argc, argv);
 
   auto coreTypes = CoreTypes();
   auto containerTypes = ContainerTypes();
+  auto coreStateTypes = CoreStateTypes();
+
   // BREAK_HERE
   return 0;
 }


### PR DESCRIPTION
Extends the qt-cpp NatVis integration test fixture and goldens to cover a new core_state_types group (QVariant, QFlags, QBasicAtomic* pointers/integers, QObject)

Key changes
	•	Add core_state_types coverage: introduce the new fixture, wire it into main.cpp, and add corresponding golden entries.
	•	Per-platform known problems: record expected NatVis failures for darwin/linux and win32 where the debugger does not apply the NatVis rules.
	•	Fix win32 type incompatibility: extend NatVis type aliasing so CoreStateFlags goldens can match the debugger-reported expanded template type QFlags<CoreStateFlag> on Windows.
	•	Ignore support_ helper variables: skip support_* variables when materializing the snapshot so they do not appear as promoted roots, mismatches, or summary table entries.
