### PR TITLE
qt-cpp-pack: qt-wasm-pack: Remove twxs.cmake from the extension packs

### DIFF
--- a/extension_packs/cpp/CHANGELOG.md
+++ b/extension_packs/cpp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.2
+
+- Removed the `twxs.cmake` extension from the extension pack.
+
 ## 1.0.1
 
 - Removed the `pre-release` tag.

--- a/extension_packs/cpp/package.json
+++ b/extension_packs/cpp/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://qt-project.atlassian.net/jira/software/c/projects/VSCODEEXT/issues"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "engines": {
     "vscode": "^1.94.0"
   },
@@ -38,8 +38,7 @@
     "theqtcompany.qt-core",
     "theqtcompany.qt-ui",
     "ms-vscode.cmake-tools",
-    "ms-vscode.cpptools",
-    "twxs.cmake"
+    "ms-vscode.cpptools"
   ],
   "scripts": {
     "vscode:prepublish": "git rev-parse HEAD > commit",

--- a/extension_packs/wasm/CHANGELOG.md
+++ b/extension_packs/wasm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.2
+
+- Removed the `twxs.cmake` extension from the extension pack.
+
 ## 1.0.1
 
 - Removed the `pre-release` tag.

--- a/extension_packs/wasm/package.json
+++ b/extension_packs/wasm/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://qt-project.atlassian.net/jira/software/c/projects/VSCODEEXT/issues"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "engines": {
     "vscode": "^1.94.0"
   },
@@ -41,7 +41,6 @@
     "theqtcompany.qt-ui",
     "ms-vscode.cmake-tools",
     "ms-vscode.cpptools",
-    "twxs.cmake",
     "ms-vscode.wasm-dwarf-debugging",
     "ms-vscode.live-server"
   ],


### PR DESCRIPTION
Fixes: [VSCODEEXT-276](https://qt-project.atlassian.net/browse/VSCODEEXT-276)
