### PR TITLE
qt-qml: Use globalStorageUri for QML Language Server installation

### DIFF
--- a/qt-qml/src/extension.mts
+++ b/qt-qml/src/extension.mts
@@ -18,6 +18,7 @@ import { registerDownloadQmllsCommand } from '@cmd/download-qmlls.mjs';
 import { registerDebugPort } from '@cmd/debug.mjs';
 import { registerCheckQmllsUpdateCommand } from '@cmd/check-qmlls-update.mjs';
 import { getDoNotAskForDownloadingQmlls, Qmlls } from '@/qmlls.mjs';
+import * as installer from '@/installer.mjs';
 import * as consts from '@/constants.js';
 import { QMLProjectManager, createQMLProject } from '@/project.mjs';
 import { registerResetCommand } from '@cmd/reset.mjs';
@@ -37,6 +38,9 @@ const logger = createLogger('extension');
 export async function activate(context: vscode.ExtensionContext) {
   initLogger(consts.EXTENSION_ID);
   telemetry.activate(context);
+
+  installer.initialize(context.globalStorageUri);
+
   projectManager = new QMLProjectManager(context);
   coreAPI = await getCoreApi();
   if (!coreAPI) {

--- a/qt-qml/src/installer.mts
+++ b/qt-qml/src/installer.mts
@@ -7,7 +7,12 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { spawnSync } from 'child_process';
 
-import { OSExeSuffix, fetchWithAbort, createLogger } from 'qt-lib';
+import {
+  OSExeSuffix,
+  fetchWithAbort,
+  createLogger,
+  UserLocalDir
+} from 'qt-lib';
 import * as unzipper from '@/unzipper.js';
 import * as downloader from '@/downloader.js';
 import { setDoNotAskForDownloadingQmlls } from '@/qmlls.mjs';
@@ -35,6 +40,41 @@ export function initialize(globalStorageUri: vscode.Uri) {
   QmllsExePath = path.join(InstallDir, 'files', 'qmlls' + OSExeSuffix);
   ReleaseJsonPath = path.join(InstallDir, 'release.json');
   logger.info(`Installer initialized with path: ${InstallDir}`);
+
+  // Clean up old installation directory that polluted the user file system
+  cleanupOldInstallation();
+}
+
+/**
+ * Removes the old qmlls installation directory from the user's local data directory.
+ * This cleanup is needed because we previously installed qmlls in UserLocalDir/qmlls,
+ * which polluted the user's file system. We now use VS Code's globalStorageUri.
+ */
+function cleanupOldInstallation() {
+  if (!UserLocalDir) {
+    return;
+  }
+
+  const oldInstallDir = path.join(UserLocalDir, 'qmlls');
+
+  // Only attempt cleanup if the old directory exists and is different from the new one
+  if (oldInstallDir === InstallDir) {
+    return;
+  }
+
+  if (fs.existsSync(oldInstallDir)) {
+    try {
+      logger.info(
+        `Removing old qmlls installation directory: ${oldInstallDir}`
+      );
+      fs.rmSync(oldInstallDir, { recursive: true, force: true });
+      logger.info('Old qmlls installation directory removed successfully');
+    } catch (error) {
+      logger.warn(
+        `Failed to remove old qmlls installation directory: ${String(error)}`
+      );
+    }
+  }
 }
 
 interface Asset {

--- a/qt-qml/src/installer.mts
+++ b/qt-qml/src/installer.mts
@@ -7,12 +7,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { spawnSync } from 'child_process';
 
-import {
-  UserLocalDir,
-  OSExeSuffix,
-  fetchWithAbort,
-  createLogger
-} from 'qt-lib';
+import { OSExeSuffix, fetchWithAbort, createLogger } from 'qt-lib';
 import * as unzipper from '@/unzipper.js';
 import * as downloader from '@/downloader.js';
 import { setDoNotAskForDownloadingQmlls } from '@/qmlls.mjs';
@@ -20,12 +15,27 @@ import { setDoNotAskForDownloadingQmlls } from '@/qmlls.mjs';
 const ReleaseInfoUrl = 'https://qtccache.qt.io/QMLLS/LatestRelease';
 const ReleaseInfoTimeout = 10 * 1000;
 const DownloadDir = os.tmpdir();
-const InstallDir = installerDir();
-const ExtractDir = path.join(InstallDir, 'files');
-const QmllsExePath = path.join(InstallDir, 'files', 'qmlls' + OSExeSuffix);
-const ReleaseJsonPath = path.join(InstallDir, 'release.json');
+
+let InstallDir: string;
+let ExtractDir: string;
+let QmllsExePath: string;
+let ReleaseJsonPath: string;
 
 const logger = createLogger('installer');
+
+/**
+ * Initialize the installer with the global storage URI from VS Code extension context.
+ * Must be called before using any other installer functions.
+ * @param globalStorageUri The URI to the extension's global storage directory
+ */
+export function initialize(globalStorageUri: vscode.Uri) {
+  const globalStoragePath = globalStorageUri.fsPath;
+  InstallDir = path.join(globalStoragePath, 'qmlls');
+  ExtractDir = path.join(InstallDir, 'files');
+  QmllsExePath = path.join(InstallDir, 'files', 'qmlls' + OSExeSuffix);
+  ReleaseJsonPath = path.join(InstallDir, 'release.json');
+  logger.info(`Installer initialized with path: ${InstallDir}`);
+}
 
 interface Asset {
   id: string;
@@ -35,12 +45,6 @@ interface Asset {
   created_at: string;
 }
 
-function installerDir() {
-  if (!UserLocalDir) {
-    throw new Error('Cannot determine the user local directory');
-  }
-  return path.join(UserLocalDir, 'qmlls');
-}
 export interface AssetWithTag extends Asset {
   tag_name: string;
 }


### PR DESCRIPTION
Replace custom file system location with VS Code's globalStorageUri
to ensure automatic cleanup when the extension is uninstalled.

Fixes: [VSCODEEXT-280](https://qt-project.atlassian.net/browse/VSCODEEXT-280)
