### PR TITLE
qt-qml: Add operation queue to prevent qmlls race conditions

### DIFF
--- a/qt-qml/src/extension.mts
+++ b/qt-qml/src/extension.mts
@@ -86,7 +86,7 @@ function startQmlls() {
   // Perform the release check asynchronously in the background
   const shouldCheck = !getDoNotAskForDownloadingQmlls();
   if (shouldCheck) {
-    void Qmlls.checkAssetAndDecide();
+    Qmlls.checkAssetAndDecide();
   }
 }
 
@@ -137,7 +137,7 @@ function processMessage(message: QtWorkspaceConfigMessage) {
     }
     if (updateQmlls) {
       project.updateQmllsParams();
-      void project.qmlls.restart();
+      void project.restartQmlls();
     }
   } catch (e) {
     const err = e as Error;

--- a/qt-qml/src/project.mts
+++ b/qt-qml/src/project.mts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import { CoreKey, Project, ProjectManager, createLogger } from 'qt-lib';
 import { Qmlls } from '@/qmlls.mjs';
 import { coreAPI } from '@/extension.mjs';
+import { QmllsOperationQueue, QmllsOperationType } from '@/qmlls-queue.mjs';
 
 const logger = createLogger('project');
 
@@ -17,35 +18,72 @@ export async function createQMLProject(
 }
 
 export class QMLProjectManager extends ProjectManager<QMLProject> {
+  private readonly _qmllsQueue = new QmllsOperationQueue();
+
   constructor(override readonly context: vscode.ExtensionContext) {
     super(context, createQMLProject);
     this.onProjectAdded((project) => {
       logger.info('Adding project:', project.folder.uri.fsPath);
       project.getConfigValues();
       project.updateQmllsParams();
-      void project.qmlls.start();
+      void this.startQmllsForProject(project);
     });
   }
+
+  /**
+   * Get the QMLLS operation queue for serializing operations.
+   */
+  get qmllsQueue() {
+    return this._qmllsQueue;
+  }
+
+  /**
+   * Start qmlls for a single project through the queue.
+   */
+  private async startQmllsForProject(project: QMLProject) {
+    return this._qmllsQueue.enqueue(QmllsOperationType.Start, async () => {
+      await project.qmlls.start();
+    });
+  }
+
+  /**
+   * Stop all qmlls instances. This is called internally during install,
+   * so it does NOT go through the queue to avoid deadlock.
+   */
   async stopQmlls() {
-    const promises = [];
-    for (const project of this.getProjects()) {
-      promises.push(project.qmlls.stop());
-    }
-    return Promise.all(promises);
+    return this._qmllsQueue.enqueue(QmllsOperationType.Stop, async () => {
+      const promises = [];
+      for (const project of this.getProjects()) {
+        promises.push(project.qmlls.stop());
+      }
+      return Promise.all(promises);
+    });
   }
+
+  /**
+   * Start all qmlls instances through the queue.
+   */
   async startQmlls() {
-    const promises = [];
-    for (const project of this.getProjects()) {
-      promises.push(project.qmlls.start());
-    }
-    return Promise.all(promises);
+    return this._qmllsQueue.enqueue(QmllsOperationType.Start, async () => {
+      const promises = [];
+      for (const project of this.getProjects()) {
+        promises.push(project.qmlls.start());
+      }
+      return Promise.all(promises);
+    });
   }
+
+  /**
+   * Restart all qmlls instances through the queue.
+   */
   async restartQmlls() {
-    const promises = [];
-    for (const project of this.getProjects()) {
-      promises.push(project.qmlls.restart());
-    }
-    return Promise.all(promises);
+    return this._qmllsQueue.enqueue(QmllsOperationType.Restart, async () => {
+      const promises = [];
+      for (const project of this.getProjects()) {
+        promises.push(project.qmlls._restartInternal());
+      }
+      return Promise.all(promises);
+    });
   }
   updateQmllsParams() {
     for (const project of this.getProjects()) {
@@ -82,6 +120,13 @@ export class QMLProject implements Project {
   }
   async startQmlls() {
     return this.qmlls.start();
+  }
+
+  /**
+   * Restart qmlls for this project (goes through the queue).
+   */
+  async restartQmlls() {
+    return this.qmlls.restart();
   }
   get qtpathsExe() {
     return this._qtpathsExe;

--- a/qt-qml/src/qmlls-queue.mts
+++ b/qt-qml/src/qmlls-queue.mts
@@ -1,0 +1,66 @@
+// Copyright (C) 2026 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import { Mutex } from 'async-mutex';
+import { createLogger } from 'qt-lib';
+
+const logger = createLogger('qmlls-queue');
+
+export enum QmllsOperationType {
+  Install = 'install',
+  Start = 'start',
+  Stop = 'stop',
+  Restart = 'restart',
+  Update = 'update'
+}
+
+/**
+ * A mutex-based queue that serializes QMLLS operations to prevent race conditions.
+ * Operations like install, update, start, stop, and restart are executed
+ * one at a time using async-mutex.
+ */
+export class QmllsOperationQueue {
+  private readonly _mutex = new Mutex();
+  private _currentOperation: QmllsOperationType | undefined;
+
+  /**
+   * Enqueue an operation to be executed.
+   * Operations are serialized using a mutex to prevent race conditions.
+   */
+  async enqueue<T>(
+    type: QmllsOperationType,
+    operation: () => Promise<T> | T
+  ): Promise<T> {
+    logger.info(`Enqueueing ${type} operation`);
+
+    return this._mutex.runExclusive(async () => {
+      this._currentOperation = type;
+      logger.info(`Processing ${type} operation`);
+
+      try {
+        const result = await operation();
+        logger.info(`Completed ${type} operation`);
+        return result;
+      } catch (error) {
+        logger.error(`Failed ${type} operation: ${String(error)}`);
+        throw error;
+      } finally {
+        this._currentOperation = undefined;
+      }
+    });
+  }
+
+  /**
+   * Check if the queue is currently processing an operation.
+   */
+  get isProcessing(): boolean {
+    return this._mutex.isLocked();
+  }
+
+  /**
+   * Get the current operation type being processed.
+   */
+  get currentOperation(): QmllsOperationType | undefined {
+    return this._currentOperation;
+  }
+}

--- a/qt-qml/src/qmlls.mts
+++ b/qt-qml/src/qmlls.mts
@@ -27,6 +27,7 @@ import {
 import { coreAPI, projectManager } from '@/extension.mjs';
 import { EXTENSION_ID } from '@/constants.js';
 import * as installer from '@/installer.mjs';
+import { QmllsOperationType } from '@/qmlls-queue.mjs';
 
 const logger = createLogger('qmlls');
 const QMLLS_CONFIG = `${EXTENSION_ID}.qmlls`;
@@ -120,7 +121,6 @@ export async function fetchAssetAndDecide(options?: {
 }
 
 export class Qmlls {
-  private static _isInstalling = false;
   private _docsPath: string | undefined;
   private readonly _disposables: vscode.Disposable[] = [];
   private readonly _importPaths = new Set<string>();
@@ -170,41 +170,33 @@ export class Qmlls {
   }
 
   public static async install(asset: installer.AssetWithTag) {
-    // Prevent concurrent installations
-    if (Qmlls._isInstalling) {
-      logger.info('Installation already in progress, skipping');
-      void vscode.window.showWarningMessage(
-        'QML language server installation is already in progress. Please wait for it to complete.'
-      );
-      return QmllsStatus.stopped;
-    }
+    return projectManager.qmllsQueue.enqueue(QmllsOperationType.Install, () => {
+      try {
+        logger.info('Stopping QML language server to install new version');
+        void projectManager.stopQmlls();
 
-    Qmlls._isInstalling = true;
+        logger.info(`Installing: ${asset.name}, ${asset.tag_name}`);
+        void installer.install(asset);
+        logger.info('Installation done');
 
-    try {
-      logger.info('Stopping QML language server to install new version');
-      await projectManager.stopQmlls();
+        projectManager.updateQmllsParams();
+        void projectManager.startQmlls();
+      } catch (error) {
+        logger.warn(isError(error) ? error.message : String(error));
+      }
 
-      logger.info(`Installing: ${asset.name}, ${asset.tag_name}`);
-      await installer.install(asset);
-      logger.info('Installation done');
-    } catch (error) {
-      logger.warn(isError(error) ? error.message : String(error));
-    } finally {
-      Qmlls._isInstalling = false;
-    }
-
-    void projectManager.startQmlls();
-    return QmllsStatus.running;
+      return QmllsStatus.running;
+    });
   }
-  public static async checkAssetAndDecide() {
+  public static checkAssetAndDecide() {
     // Do not show the progress bar during the startup
-    const result = await fetchAssetAndDecide({ silent: true });
-    if (result.code === DecisionCode.NeedToUpdate && result.asset) {
-      logger.info('Updating QML language server');
-      return Qmlls.install(result.asset);
-    }
-    return QmllsStatus.stopped;
+    void fetchAssetAndDecide({ silent: true }).then((result) => {
+      if (result.code === DecisionCode.NeedToUpdate && result.asset) {
+        logger.info('Updating QML language server');
+        // Install and start are queued - no need to await
+        void Qmlls.install(result.asset);
+      }
+    });
   }
 
   public async start() {
@@ -429,9 +421,26 @@ export class Qmlls {
     }
   }
 
-  public async restart() {
+  /**
+   * Internal restart method - does not go through the queue.
+   * Use this when already inside a queued operation.
+   */
+  async _restartInternal() {
     await this.stop();
     await this.start();
+  }
+
+  /**
+   * Restart the language server. This goes through the operation queue
+   * to prevent race conditions with install/update operations.
+   */
+  public async restart() {
+    return projectManager.qmllsQueue.enqueue(
+      QmllsOperationType.Restart,
+      async () => {
+        await this._restartInternal();
+      }
+    );
   }
 }
 


### PR DESCRIPTION
Serialize QMLLS operations (install, start, stop, restart) using
async-mutex to prevent race conditions when updating the language
server with multiple workspace folders open.

Previously, race conditions occurred when:
- Extension activation started servers while an update check ran in parallel
- coreAPI config changes triggered restarts during an ongoing install

This caused the qmlls executable to be in an inconsistent state,
leading to failures in starting or updating the server.
