### PR TITLE
Qt cpp make MinGW detection resilient across platforms

### DIFF
--- a/qt-cpp/src/kit-manager.ts
+++ b/qt-cpp/src/kit-manager.ts
@@ -505,8 +505,6 @@ export class KitManager {
   ) {
     const promiseCmakeQtToolchainPath =
       qtPath.locateCMakeQtToolchainFile(installation);
-
-    const promiseMingwPath = qtPath.locateMingwBinDirPath(qtInsRoot);
     let qtPathEnv = KitManager.generateEnvPathForQtInstallation(installation);
     let locatedNinjaExePath = '';
     if (!commandExists.sync('ninja')) {
@@ -555,7 +553,7 @@ export class KitManager {
         );
         return;
       } else if (platform.startsWith('mingw')) {
-        const mingwDirPath = await promiseMingwPath;
+        const mingwDirPath = await qtPath.locateMingwBinDirPath(qtInsRoot);
         logger.info(`Mingw dir path: ${mingwDirPath}`);
         if (mingwDirPath) {
           newKit.environmentVariables.PATH = [

--- a/qt-cpp/src/util/get-qt-paths.ts
+++ b/qt-cpp/src/util/get-qt-paths.ts
@@ -3,6 +3,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import type { Dirent } from 'fs';
 
 import * as fsutil from '@util/fs';
 import { OSExeSuffix, IsMacOS } from 'qt-lib';
@@ -76,7 +77,15 @@ export async function locateNinjaExecutable(qtRootDir: string) {
 export async function locateMingwBinDirPath(qtRootDir: string) {
   // TODO: check if g++ exists in PATH already
   const qtToolsDir = qtToolsDirByQtRootDir(qtRootDir);
-  const items = await fs.readdir(qtToolsDir, { withFileTypes: true });
+  let items: Dirent[];
+  try {
+    items = await fs.readdir(qtToolsDir, { withFileTypes: true });
+  } catch (err: unknown) {
+    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
+      return undefined;
+    }
+    throw err;
+  }
   const mingws = items.filter((item) =>
     item.name.toLowerCase().startsWith('mingw')
   );


### PR DESCRIPTION
Two related fixes are included:
- Call locateMingwBinDirPath only on Windows
The MinGW lookup is Windows-specific. Invoking it on macOS or Linux could probe a non-existent Qt/Tools directory and trigger an unhandled ENOENT, sometimes crashing the NatVis test suite.
- Tolerate missing Qt/Tools on Windows
Some Windows Qt installations do not ship a Qt/Tools directory. locateMingwBinDirPath now treats this case as “no MinGW found” instead of throwing, preventing kit updates from failing.
