### PR TITLE
qt-cpp: Add setting to disable automatic kit generation on activation

### DIFF
--- a/qt-cpp/package.json
+++ b/qt-cpp/package.json
@@ -80,6 +80,12 @@
           "type": "boolean",
           "default": false,
           "description": "Do not show a warning when the installed CMake Tools extension is too old for CMake Presets support."
+        },
+        "qt-cpp.disableAutoKitGenerationOnOpen": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Disable automatic CMake kit generation on extension activation.\n\nWhen enabled, the extension will not automatically scan and update `cmake-kits.json` when VS Code starts. Kits will still be updated when you manually change Qt settings or run the `Qt: Scan for Qt Kits` command.\n\nThis is useful if you manage your kits manually or check `cmake-kits.json` into version control.",
+          "scope": "machine-overridable"
         }
       }
     },

--- a/qt-cpp/src/commands/launch-variables.ts
+++ b/qt-cpp/src/commands/launch-variables.ts
@@ -19,6 +19,18 @@ import { CppProjectType, getActiveProject } from '@/project';
 
 const logger = createLogger('launch-variables');
 
+function getDebugPathVariant(basePath: string) {
+  return path.join(basePath, 'debug');
+}
+
+function replacePathWithDebugVariant(
+  pathString: string,
+  basePath: string,
+  debugPath: string
+) {
+  return pathString.replace(path.normalize(basePath), debugPath);
+}
+
 export function registerlaunchTargetFilenameWithoutExtension() {
   return vscode.commands.registerCommand(
     `${EXTENSION_ID}.launchTargetFilenameWithoutExtension`,
@@ -97,7 +109,7 @@ function getQtDirFromQtPaths(pathsExe: string, toolchainFile?: string) {
           if (value.endsWith('bin')) {
             const installPrefix = info.get('QT_INSTALL_PREFIX');
             if (installPrefix) {
-              const installPrefixDebug = path.join(installPrefix, 'debug');
+              const installPrefixDebug = getDebugPathVariant(installPrefix);
               const newValue = value.replace(installPrefix, installPrefixDebug);
               paths.push(newValue);
             }
@@ -206,10 +218,11 @@ async function findQtPluginPath(qtpaths: string) {
       // we need to return the debug version of the plugin path
       const installPrefix = info.get('QT_INSTALL_PREFIX');
       if (installPrefix) {
-        const installPrefixDebug = path.join(installPrefix, 'debug');
+        const installPrefixDebug = getDebugPathVariant(installPrefix);
         if (pluginPath) {
-          const pluginPathDebug = pluginPath.replace(
-            path.normalize(installPrefix),
+          const pluginPathDebug = replacePathWithDebugVariant(
+            pluginPath,
+            installPrefix,
             installPrefixDebug
           );
           return pluginPathDebug;
@@ -282,10 +295,11 @@ async function getQmlImportPathFromQtPaths(qtpaths: string) {
     // we need to return the debug version of the import path
     const installPrefix = info.get('QT_INSTALL_PREFIX');
     if (installPrefix) {
-      const installPrefixDebug = path.join(installPrefix, 'debug');
+      const installPrefixDebug = getDebugPathVariant(installPrefix);
       if (importPath) {
-        const importPathDebug = importPath.replace(
-          path.normalize(installPrefix),
+        const importPathDebug = replacePathWithDebugVariant(
+          importPath,
+          installPrefix,
           installPrefixDebug
         );
         return importPathDebug;

--- a/qt-cpp/src/commands/scan-qt-kits.ts
+++ b/qt-cpp/src/commands/scan-qt-kits.ts
@@ -14,7 +14,7 @@ export function registerScanForQtKitsCommand() {
       if (IsWindows) {
         await vscode.commands.executeCommand('cmake.scanForKits');
       }
-      await kitManager.checkForAllQtInstallations();
+      await kitManager.checkForAllQtInstallations(true);
     }
   );
 }

--- a/qt-cpp/src/kit-manager.ts
+++ b/qt-cpp/src/kit-manager.ts
@@ -184,15 +184,42 @@ export class KitManager {
     return path.join(folder.uri.fsPath, '.vscode', 'cmake-kits.json');
   }
 
-  public async checkForAllQtInstallations() {
+  private static isAutoKitGenerationDisabled(
+    workspaceFolder?: vscode.WorkspaceFolder
+  ): boolean {
+    const config = vscode.workspace.getConfiguration(
+      EXTENSION_ID,
+      workspaceFolder
+    );
+    return config.get<boolean>('disableAutoKitGenerationOnOpen', false);
+  }
+
+  private static shouldSkipAutoKitGeneration(
+    force: boolean,
+    workspaceFolder?: vscode.WorkspaceFolder
+  ): boolean {
+    if (force) {
+      return false;
+    }
+    return KitManager.isAutoKitGenerationDisabled(workspaceFolder);
+  }
+
+  public async checkForAllQtInstallations(force = false) {
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
         title: 'Updating kits'
       },
       async () => {
-        await this.checkForGlobalQtInstallations();
-        await this.checkForWorkspaceFolderQtInstallations();
+        // Check global setting for global installations
+        if (!KitManager.shouldSkipAutoKitGeneration(force)) {
+          await this.checkForGlobalQtInstallations();
+        } else {
+          logger.info(
+            'Auto-kit generation on activation is disabled globally, skipping global kit check'
+          );
+        }
+        await this.checkForWorkspaceFolderQtInstallations(force);
       }
     );
   }
@@ -233,9 +260,16 @@ export class KitManager {
     await this.checkForQtInstallations();
   }
 
-  private async checkForWorkspaceFolderQtInstallations() {
+  private async checkForWorkspaceFolderQtInstallations(force = false) {
     for (const project of this.projects) {
       if (project.type === CppProjectType.Kit) {
+        // Check workspace-specific setting
+        if (KitManager.shouldSkipAutoKitGeneration(force, project.folder)) {
+          logger.info(
+            `Auto-kit generation on activation is disabled for workspace '${project.folder.name}', skipping kit check`
+          );
+          continue;
+        }
         await this.checkForQtInstallations(project);
       }
     }


### PR DESCRIPTION
Introduce qt-cpp.disableAutoKitGenerationOnOpen setting to prevent
automatic CMake kit updates when VS Code starts. Kits are still updated
when Qt settings are manually changed or when running the
"Qt: Scan for Qt Kits" command.

The setting supports both global and workspace-level configuration:
- Global setting disables auto-generation for all global Qt installations
- Workspace setting disables auto-generation on activation for specific workspaces
- Manual kit scan command bypasses the setting with force parameter

Fixes: [VSCODEEXT-231](https://qt-project.atlassian.net/browse/VSCODEEXT-231)
