### PR TITLE
Qtcpp natvis: fix coverage reporting for overlapping NatVis types

### DIFF
--- a/qt-cpp/test/debug-golden.mts
+++ b/qt-cpp/test/debug-golden.mts
@@ -6,6 +6,97 @@ import * as fs from 'fs/promises';
 import type { DebugVariable } from './debug-helper.mts';
 
 /**
+ * NatVis `<Type Name="...">` patterns that should not be treated as “missing coverage”.
+ *
+ * These are support / helper / internal implementation types that are exercised
+ * indirectly when the corresponding public-facing Qt types are present in the snapshot.
+ *
+ * Notes:
+ * - We intentionally do NOT skip QBasicAtomicPointer<void>. If it is uncovered, add a
+ *   top-level sample variable to exercise it.
+ * - QPropertyData<*> is skipped until the test validates Expand/children. Today we only
+ *   validate root DisplayString values, so requiring QPropertyData<*> would be misleading.
+ */
+export const SKIP_COVERAGE_BASES: ReadonlySet<string> = new Set<string>([
+  // QProperty support: exercised via QProperty<T>, but only observable once Expand/children is validated
+  'QPropertyData<*>',
+
+  // Qt Quick support: exercised via QQuickItem (d_ptr.d expands into QQuickItemPrivate)
+  'QQuickItemPrivate',
+
+  // CBOR/JSON backend support: exercised via QCborArray/QCborMap/QCborValue and QJsonObject/QJsonArray/QJsonDocument
+  'QCborContainerPrivate',
+  'QtCbor::ByteData',
+  'QtCbor::Element',
+  'QJsonDocumentPrivate',
+  'QJsonValueRef',
+  'QJsonValueConstRef',
+
+  // QHash internals: exercised via QHash<*,*> and QMultiHash<*,*>
+  'QHashPrivate::Node<*,*>',
+  'QHashPrivate::Node<*,QHashDummyValue>',
+  'QHashPrivate::MultiNode<*,*>',
+
+  // Legacy / compat helper
+  'QStringRef',
+
+  // Qt internal helper template; not a direct “fixture type”
+  'QSpecialInteger<*>'
+]);
+
+export const SKIP_COVERAGE_REASONS: ReadonlyMap<string, string> = new Map([
+  [
+    'QPropertyData<*>',
+    'Internal support for QProperty<T>; observable only once children/Expand is validated'
+  ],
+  [
+    'QQuickItemPrivate',
+    'Qt Quick private backing type; exercised indirectly via QQuickItem'
+  ],
+  [
+    'QCborContainerPrivate',
+    'CBOR/JSON backend type; exercised indirectly via QCbor*/QJson* public types'
+  ],
+  [
+    'QtCbor::ByteData',
+    'CBOR backend helper; exercised indirectly via QCborValue/containers'
+  ],
+  [
+    'QtCbor::Element',
+    'CBOR backend helper; exercised indirectly via QCborValue/containers'
+  ],
+  [
+    'QJsonDocumentPrivate',
+    'JSON backend private; exercised indirectly via QJsonDocument'
+  ],
+  [
+    'QJsonValueRef',
+    'JSON ref helper; exercised indirectly via QJsonArray/QJsonObject element access'
+  ],
+  [
+    'QJsonValueConstRef',
+    'JSON const-ref helper; exercised indirectly via QJsonArray/QJsonObject element access'
+  ],
+  [
+    'QHashPrivate::Node<*,*>',
+    'QHash internal node; exercised indirectly via QHash/QMultiHash'
+  ],
+  [
+    'QHashPrivate::Node<*,QHashDummyValue>',
+    'QHash internal node; exercised indirectly via QHash/QMultiHash'
+  ],
+  [
+    'QHashPrivate::MultiNode<*,*>',
+    'QHash internal node; exercised indirectly via QHash/QMultiHash'
+  ],
+  [
+    'QStringRef',
+    'Legacy/compat type; intentionally not required by the fixture'
+  ],
+  ['QSpecialInteger<*>', 'Internal helper template; not a fixture surface type']
+]);
+
+/**
  * NatVis golden + snapshot utilities for qt-cpp integration tests.
  *
  * This module contains the core data model and helpers used by natvis tests:
@@ -311,27 +402,62 @@ function decodeXmlEntities(input: string): string {
 }
 
 /**
- * Structured representation of NatVis type patterns extracted from a `.natvis` file.
+ * Structured representation of NatVis type metadata used by the test framework.
  *
- * This type captures the *logical shape* of NatVis coverage rules after parsing,
- * including base type patterns and their declared alternative forms.
+ * `NatvisTypes` is a *test-oriented abstraction* built from parsing a `.natvis`
+ * file. It captures the logical structure of NatVis type rules in a form that
+ * supports:
+ *
+ *   - Coverage analysis (which NatVis rules were exercised or missed),
+ *   - Type-family grouping in the summary table,
+ *   - Relaxed type compatibility checks (via AlternativeType and aliases),
+ *   - Explicit exclusion of internal / helper rules from coverage reporting.
+ *
+ * It is **not** a full NatVis schema model; it only represents the information
+ * needed by the NatVis tests.
  *
  * Fields:
- *   - `all`   : All type patterns defined in the NatVis file, including bases
- *               and AlternativeType entries.
- *   - `bases` : The primary (base) type patterns declared via `<Type Name="...">`.
- *   - `alts`  : Mapping from a base type pattern to the set of its
- *               `<AlternativeType>` patterns.
- *   - `altToBase`  : Reverse mapping from an `<AlternativeType>` pattern to its
- *                    base type pattern, derived from the NatVis file.
+ * - `all`
+ *     All type patterns declared in the NatVis file, including base `<Type Name="…">`
+ *     entries *and* `<AlternativeType>` patterns.
  *
- * This structure is used by NatVis tests to:
- *   - Match runtime snapshot types against NatVis rules,
- *   - Reason about coverage (which rules were exercised or missed),
- *   - Correctly handle AlternativeType equivalence during comparison.
+ * - `bases`
+ *     The primary NatVis base patterns, corresponding exactly to
+ *     `<Type Name="…">` entries in the NatVis file.
+ *     These are the units used for coverage reporting.
  *
- * It is a test-oriented abstraction and does not attempt to model the full
- * NatVis schema or debugger behavior.
+ * - `alts`
+ *     Mapping from a NatVis base pattern to the set of its declared
+ *     `<AlternativeType>` patterns.
+ *
+ * - `altToBase`
+ *     Reverse lookup mapping an AlternativeType (or equivalent alias)
+ *     back to its canonical NatVis base pattern.
+ *     Used to normalize concrete debugger types into stable NatVis “families”.
+ *
+ * - `extraAliases`
+ *     Test-defined aliases that supplement NatVis `<AlternativeType>` rules.
+ *     This is used to bridge gaps where the debugger reports typedefs or
+ *     expanded template spellings not explicitly covered by NatVis.
+ *     (e.g. `SelectionFlags` → `QFlags<*>`).
+ *
+ * - `skipCoverageBases`
+ *     Set of NatVis base patterns that should be *excluded* from “missing coverage”
+ *     reporting.
+ *
+ *     These typically represent:
+ *       - private implementation types (e.g. `QQuickItemPrivate`)
+ *       - internal support structures (e.g. `QHashPrivate::*`)
+ *       - helper templates not observable at the root level
+ *         until children/Expand validation exists (e.g. `QPropertyData<*>`)
+ *
+ *     Skipped bases are considered exercised *indirectly* when their associated
+ *     public-facing Qt types are present in the snapshot.
+ *
+ * - `skipCoverageReasons`
+ *     Optional human-readable explanations for entries in `skipCoverageBases`.
+ *     Used only for verbose diagnostic output to make coverage decisions
+ *     explicit and auditable in test logs.
  */
 export type NatvisTypes = {
   all: Set<string>;
@@ -339,6 +465,8 @@ export type NatvisTypes = {
   alts: Map<string, Set<string>>;
   altToBase: Map<string, string>;
   extraAliases?: ReadonlyMap<string, readonly string[]>;
+  skipCoverageBases?: ReadonlySet<string>;
+  skipCoverageReasons?: ReadonlyMap<string, string>; // optional but useful
 };
 
 // Extra aliases for types whose *real* NatVis rule is more generic.
@@ -355,24 +483,35 @@ export const EXTRA_NATVIS_TYPE_ALIASES: Record<string, string[]> = {
 };
 
 /**
- * Parses a NatVis (.natvis) file and extracts all declared type patterns,
- * including base <Type Name="..."> entries and their <AlternativeType> mappings.
+ * Parse a NatVis `.natvis` file and extract the type-pattern metadata needed by the tests.
  *
- * The returned structure is used for:
- * - NatVis coverage reporting (which patterns were exercised or not),
- * - relaxed type compatibility checks in NatVis tests
- *   (e.g. QPoint ↔ QPointF via AlternativeType),
- * - avoiding any hard-coded knowledge of Qt type equivalence.
+ * This is the canonical “NatVis ingestion” step for the test suite. It reads the XML,
+ * removes comments, and collects:
+ *
+ *   - Base NatVis patterns from `<Type Name="...">` into `bases`
+ *   - All declared patterns (bases + `<AlternativeType Name="...">`) into `all`
+ *   - Forward AlternativeType mapping (`alts`: base → alternatives)
+ *   - Reverse AlternativeType mapping (`altToBase`: alternative → base)
+ *
+ * In addition, this function seeds `altToBase` with test-defined aliases from
+ * `EXTRA_NATVIS_TYPE_ALIASES` to cover debugger-reported typedef names or template
+ * spellings that are not explicitly declared in the NatVis file.
+ *
+ * Robustness / failure behavior:
+ *   - If the file cannot be read or parsed, the function returns empty NatVis sets/maps,
+ *     but still includes the test’s coverage-skip policy (`skipCoverageBases` and
+ *     `skipCoverageReasons`) so the rest of the reporting code can behave consistently.
  *
  * Notes:
- * - `alts` maps a base type to its AlternativeType set as declared in NatVis.
- * - `altToBase` provides the reverse lookup (AlternativeType → base),
- *   built deterministically from the NatVis file.
- * - Stray <AlternativeType> elements outside of a <Type> block (rare) are
- *   added to `all` for completeness, but cannot be reliably associated to a base
- *   and therefore do not populate `altToBase`.
+ *   - XML entities in attribute values (e.g. `&lt;`, `&gt;`, `&amp;`) are decoded so
+ *     type patterns match the debugger’s type spelling.
+ *   - “Stray” `<AlternativeType>` elements outside a `<Type>` block are added to `all`
+ *     for completeness, but cannot be reliably associated with a base type and therefore
+ *     do not populate `altToBase` unless explicitly seeded via aliases.
  *
- * NatVis is treated as the single source of truth for type equivalence.
+ * @param natvisPath Absolute path to the NatVis file to parse.
+ * @returns          A populated `NatvisTypes` structure used for coverage, grouping,
+ *                   and type-compatibility checks.
  */
 export async function parseNatvisTypesWithAlternatives(
   natvisPath: string
@@ -462,9 +601,25 @@ export async function parseNatvisTypesWithAlternatives(
       if (alt) all.add(alt);
     }
 
-    return { all, bases, alts, altToBase, extraAliases };
+    return {
+      all,
+      bases,
+      alts,
+      altToBase,
+      extraAliases,
+      skipCoverageBases: SKIP_COVERAGE_BASES,
+      skipCoverageReasons: SKIP_COVERAGE_REASONS
+    };
   } catch {
-    return { all, bases, alts, altToBase, extraAliases };
+    return {
+      all,
+      bases,
+      alts,
+      altToBase,
+      extraAliases,
+      skipCoverageBases: SKIP_COVERAGE_BASES,
+      skipCoverageReasons: SKIP_COVERAGE_REASONS
+    };
   }
 }
 

--- a/qt-cpp/test/natvis-test-helper.mts
+++ b/qt-cpp/test/natvis-test-helper.mts
@@ -349,6 +349,139 @@ function sortNatvisRows<T extends NatvisTableRowLike>(rows: T[]): void {
   });
 }
 
+function isWildcardTemplatePattern(typePattern: string): boolean {
+  const parsed = splitOuterTemplate(typePattern);
+  if (parsed.arity <= 0) return false;
+
+  const args = (parsed.argsText ?? '').split(',').map((s) => s.trim());
+  return args.length > 0 && args.every((a) => a === '*');
+}
+
+function parseArity(typePattern: string): { base: string; arity: number } {
+  const p = splitOuterTemplate(typePattern);
+  return { base: p.base, arity: p.arity };
+}
+/**
+ * Compute the set of NatVis base `<Type Name="...">` patterns that should be
+ * considered **covered** when the debugger reports a concrete exercised runtime type.
+ *
+ * Why this exists:
+ * - A single concrete type can match multiple NatVis rules at once.
+ *   Example: `QBasicAtomicPointer<void>` matches both:
+ *     • `QBasicAtomicPointer<void>` (exact specialization)
+ *     • `QBasicAtomicPointer<*>`    (generic wildcard)
+ * - Coverage accounting must mark *all* matching NatVis bases as covered, otherwise
+ *   the specialized rule can incorrectly show up as “missing” while the wildcard
+ *   rule shows up as “covered”.
+ *
+ * How it works:
+ * 1) Normalize the exercised type spelling (strip class/struct noise, normalize spaces).
+ * 2) Derive candidate keys that might match NatVis bases:
+ *    - exact normalized spelling (covers specializations)
+ *    - wildcard family form (base<*>, base<*,*>, ...)
+ *    - canonical base via AlternativeType / extra alias mapping
+ * 3) Filter candidates down to only real NatVis base patterns present in `natvis.bases`,
+ *    also resolving any `altToBase` mappings to ensure AlternativeType spellings count
+ *    as covering their base rule.
+ *
+ * Output:
+ * - A set of NatVis base patterns to add to `coveredNatvisBases` for coverage reporting.
+ *
+ * Note:
+ * - This is for coverage accounting only. Table display should still pick a single
+ *   “best” base (see `pickMostSpecificNatvisBase`) for readability.
+ */
+function computeCoveredNatvisBasesForType(
+  exercisedType: string,
+  natvis: NatvisTypes
+): ReadonlySet<string> {
+  const t = normalizeType(exercisedType);
+  const parsed = splitOuterTemplate(t);
+
+  const keys = new Set<string>();
+
+  // 1) Exact spelling (covers specializations like QBasicAtomicPointer<void>)
+  keys.add(t);
+
+  // 2) Wildcard family (covers patterns like QBasicAtomicPointer<*>)
+  if (parsed.arity > 0) {
+    keys.add(wildcard(parsed.base, parsed.arity));
+  }
+
+  // 3) Canonicalization via AlternativeType / aliases (helps typedef-style names)
+  //    base-only canonicalization for non-templates
+  keys.add(canonicalBase(parsed.base, parsed.arity, natvis));
+
+  const out = new Set<string>();
+  for (const k of keys) {
+    if (natvis.bases.has(k)) {
+      out.add(k);
+    }
+    const mapped = natvis.altToBase.get(k);
+    if (mapped && natvis.bases.has(mapped)) {
+      out.add(mapped);
+    }
+  }
+
+  for (const basePattern of natvis.bases) {
+    const p = parseArity(basePattern);
+    if (p.base !== parsed.base) continue;
+    if (!isWildcardTemplatePattern(basePattern)) continue;
+
+    if (parsed.arity === 0 || parsed.arity >= p.arity) {
+      out.add(basePattern);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Choose the single NatVis `<Type Name="...">` base pattern to *display* in the
+ * NatVis status summary table when a concrete exercised runtime type matches
+ * multiple NatVis rules.
+ *
+ * Why this exists:
+ * - Some types have both a generic wildcard rule and a specialization in the NatVis file
+ *   (example: `QBasicAtomicPointer<*>` and `QBasicAtomicPointer<void>`).
+ * - For coverage accounting we mark *all* matching NatVis bases as covered, but the
+ *   summary table needs exactly one “NatVis Type” label per row.
+ *
+ * Selection strategy (most specific wins):
+ * - Prefer patterns without `*` (exact specializations) over wildcard families.
+ * - If still tied, prefer longer patterns as a stable tie-breaker.
+ *
+ * Fallback:
+ * - If there are no candidates, fall back to `computeNatvisFamily(...)` so behavior
+ *   remains consistent with older logic.
+ *
+ * Note:
+ * - This function does not affect coverage (covered vs missing). It is only for
+ *   table readability and correct attribution of specializations.
+ */
+function pickMostSpecificNatvisBase(
+  candidates: ReadonlySet<string>,
+  exercisedType: string,
+  natvis: NatvisTypes
+): string {
+  if (candidates.size === 0) {
+    // Keep existing behavior as a fallback
+    return computeNatvisFamily(exercisedType, natvis);
+  }
+
+  const scored = [...candidates].map((c) => {
+    // Specificity rules:
+    // - Prefer no wildcard '*'
+    // - Prefer exact template spellings over wildcard family
+    // - Prefer longer strings as a tie-breaker
+    const hasStar = c.includes('*');
+    const score = (hasStar ? 0 : 10) + c.length / 1000;
+    return { c, score };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored[0]!.c;
+}
 /**
  * Compute the "NatVis family" key used to group concrete exercised types into
  * a single NatVis type bucket for the summary table.
@@ -476,9 +609,19 @@ export function printNatvisTypeStatusTable(params: {
   for (const a of natvisSnapshot) {
     const varName = a.name;
     const exercisedType = a.type ?? '<none>';
-    const natvisType = computeNatvisFamily(exercisedType, natvis);
+    const coveredBasesForVar = computeCoveredNatvisBasesForType(
+      exercisedType,
+      natvis
+    );
+    for (const b of coveredBasesForVar) {
+      coveredNatvisFamilies.add(b);
+    }
 
-    coveredNatvisFamilies.add(natvisType);
+    const natvisType = pickMostSpecificNatvisBase(
+      coveredBasesForVar,
+      exercisedType,
+      natvis
+    );
 
     const g = goldenByName.get(varName);
 

--- a/qt-cpp/test/natvis-test-helper.mts
+++ b/qt-cpp/test/natvis-test-helper.mts
@@ -49,13 +49,42 @@ export function formatValuePreview(v: unknown, max: number = 200): string {
 }
 
 /**
- * Print NatVis base patterns that were not exercised by the current snapshot.
+ * Print NatVis base `<Type Name="...">` patterns that were *not exercised* by the
+ * current debugger snapshot.
  *
- * Coverage is derived from the set of NatVis family keys that the status table
- * computed from snapshot entries (via `computeNatvisFamily(...)`).
+ * This function is part of the NatVis **coverage reporting** logic. It answers the
+ * question:
  *
- * Note: This does not perform wildcard matching against concrete snapshot types.
- * It only checks whether a NatVis base pattern appears in the computed family set.
+ *   “Which NatVis rules exist in the .natvis file but were not exercised by any
+ *    variable in this test run?”
+ *
+ * How it works:
+ * - Starts from `natvis.bases`, i.e. all `<Type Name="...">` entries declared
+ *   in the NatVis file.
+ * - Removes any bases listed in `natvis.skipCoverageBases`:
+ *     • These represent internal / helper / private types that are expected
+ *       to be exercised *indirectly* by public-facing Qt types.
+ *     • Skipped bases are *not* considered missing coverage.
+ * - Removes any bases that appear in `coveredNatvisFamilies`, which represents
+ *   the NatVis “family keys” derived from actual debugger variables.
+ *
+ * Output:
+ * - If uncovered bases remain, prints a list under:
+ *     “[natvis.summary] Qt types defined in NatVis file but not covered…”
+ * - Otherwise prints a success message indicating full coverage.
+ *
+ * Verbose diagnostics:
+ * - When `NATVIS_VERBOSE=1` is set, this function also prints the list of
+ *   skipped coverage bases along with their human-readable reasons
+ *   (`natvis.skipCoverageReasons`), to make coverage decisions explicit
+ *   and auditable in logs.
+ *
+ * Notes:
+ * - This function is **purely diagnostic**; it does not affect test pass/fail.
+ * - Coverage is evaluated at the NatVis *base type* level, not per concrete
+ *   template instantiation.
+ * - This intentionally avoids wildcard matching against concrete snapshot
+ *   types; grouping is handled upstream via NatVis family computation.
  */
 export function printUncoveredNatvisBases(params: {
   natvis: NatvisTypes;
@@ -63,7 +92,10 @@ export function printUncoveredNatvisBases(params: {
 }): void {
   const { natvis, coveredNatvisFamilies } = params;
 
+  const skip = natvis.skipCoverageBases ?? new Set<string>();
+
   const uncoveredBases = [...natvis.bases]
+    .filter((base) => !skip.has(base))
     .filter((base) => !coveredNatvisFamilies.has(base))
     .sort((a, b) => a.localeCompare(b));
 
@@ -71,6 +103,18 @@ export function printUncoveredNatvisBases(params: {
     const alts = natvis.alts.get(base);
     return alts && alts.size ? `${base} (alts: ${[...alts].join(', ')})` : base;
   });
+
+  if (process.env.NATVIS_VERBOSE === '1') {
+    const reasons = natvis.skipCoverageReasons;
+    if (reasons && reasons.size) {
+      for (const base of skip) {
+        const reason = reasons.get(base);
+        if (reason) {
+          console.log(`[natvis.summary][skip-coverage] ${base}: ${reason}`);
+        }
+      }
+    }
+  }
 
   if (uncoveredLines.length > 0) {
     console.log(


### PR DESCRIPTION
Improve NatVis coverage reporting for skipped
and overlapping type rules.

Introduce an explicit skip list for internal
NatVis <Type> patterns that are exercised
indirectly. This improves coverage diagnostics
without changing test pass/fail behavior.

Fix coverage accounting when a runtime type
matches multiple NatVis rules (generic vs
specialized, collapsed or expanded templates).
All matching NatVis bases are now marked as
covered, while the summary table shows the
most specific applicable rule.

This prevents valid NatVis types such as
QBasicAtomicPointer<void>, QPair<*,*>, and
QSpan<*> from being reported as uncovered
on some platforms.