### PR TITLE
tsconfig: Remove baseUrl

### DIFF
--- a/qt-core/tsconfig.json
+++ b/qt-core/tsconfig.json
@@ -22,10 +22,9 @@
     "exactOptionalPropertyTypes": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "baseUrl": "./",
     "paths": {
-      "@/*": ["src/*"],
-      "@cmd/*": ["src/commands/*"]
+      "@/*": ["./src/*"],
+      "@cmd/*": ["./src/commands/*"]
     }
   },
   "include": ["src/**/*", "test/**/*"],

--- a/qt-cpp/tsconfig.json
+++ b/qt-cpp/tsconfig.json
@@ -22,12 +22,11 @@
     "exactOptionalPropertyTypes": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "baseUrl": "./",
     "paths": {
-      "@/*": ["src/*"],
-      "@cmd/*": ["src/commands/*"],
-      "@task/*": ["src/tasks/*"],
-      "@util/*": ["src/util/*"]
+      "@/*": ["./src/*"],
+      "@cmd/*": ["./src/commands/*"],
+      "@task/*": ["./src/tasks/*"],
+      "@util/*": ["./src/util/*"]
     }
   },
   //"exclude": ["node_modules", ".vscode-test", "src/test/**/*"],

--- a/qt-python/tsconfig.json
+++ b/qt-python/tsconfig.json
@@ -19,12 +19,11 @@
     "exactOptionalPropertyTypes": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "baseUrl": "./",
     "paths": {
-      "@/*": ["src/*"],
-      "@cmd/*": ["src/commands/*"],
-      "@task/*": ["src/tasks/*"],
-      "@util/*": ["src/util/*"]
+      "@/*": ["./src/*"],
+      "@cmd/*": ["./src/commands/*"],
+      "@task/*": ["./src/tasks/*"],
+      "@util/*": ["./src/util/*"]
     }
   },
   "include": ["src/**/*"]

--- a/qt-qml/tsconfig.json
+++ b/qt-qml/tsconfig.json
@@ -22,13 +22,12 @@
     "exactOptionalPropertyTypes": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "baseUrl": "./",
     "paths": {
-      "@/*": ["src/*"],
-      "@cmd/*": ["src/commands/*"],
-      "@task/*": ["src/tasks/*"],
-      "@util/*": ["src/util/*"],
-      "@debug/*": ["src/debug/*"]
+      "@/*": ["./src/*"],
+      "@cmd/*": ["./src/commands/*"],
+      "@task/*": ["./src/tasks/*"],
+      "@util/*": ["./src/util/*"],
+      "@debug/*": ["./src/debug/*"]
     }
   },
   "include": ["src/**/*", "test/**/*"]

--- a/qt-ui/tsconfig.json
+++ b/qt-ui/tsconfig.json
@@ -22,10 +22,9 @@
     "exactOptionalPropertyTypes": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "baseUrl": "./",
     "paths": {
-      "@/*": ["src/*"],
-      "@cmd/*": ["src/commands/*"]
+      "@/*": ["./src/*"],
+      "@cmd/*": ["./src/commands/*"]
     }
   },
   "include": ["src/**/*", "test/**/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,9 +19,8 @@
     "exactOptionalPropertyTypes": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "baseUrl": "./",
     "paths": {
-      "@/*": ["scripts/*"]
+      "@/*": ["./scripts/*"]
     }
   },
   "include": ["scripts/**/*"]


### PR DESCRIPTION
Since baseUrl is deprecated, we can remove it and adjust the paths
accordingly.

For more information, see the TypeScript issue:
https://github.com/microsoft/TypeScript/issues/62508#issuecomment-3348649259
