### PR TITLE
qt-qml: Restore download command overwriting behavior

### DIFF
--- a/qt-qml/src/commands/download-qmlls.mts
+++ b/qt-qml/src/commands/download-qmlls.mts
@@ -16,6 +16,7 @@ export function registerDownloadQmllsCommand() {
 
       switch (decision.code) {
         case DecisionCode.NeedToUpdate:
+        case DecisionCode.AlreadyUpToDate:
           if (decision.asset) {
             try {
               await Qmlls.install(decision.asset);


### PR DESCRIPTION
After commit 8de6d2b81b25ec97b1457ac865ae363a758e5f33, the download
command would skip installation when the latest version was already
installed. Allow reinstallation when explicitly running the command by
handling `AlreadyUpToDate` case.

Amends: 8de6d2b81b25ec97b1457ac865ae363a758e5f33
