### PR TITLE
qt-cpp: qt-lib: Add architecture to CMake Kit name

### DIFF
--- a/qt-core/src/api.ts
+++ b/qt-core/src/api.ts
@@ -36,15 +36,39 @@ export class CoreAPIImpl implements CoreAPI {
     return this._onValueChanged.event;
   }
 
-  private static obtainArch(content: string) {
+  private static obtainArchs(content: string) {
     const keysToCheck = ['QT_ARCHS', 'QT_TARGET_ARCH', 'QT_ARCH'];
     for (const k of keysToCheck) {
-      const match = content.match(new RegExp(`${k}\\s*\\=\\s*(.*)`));
+      const match = content.match(
+        new RegExp(`${k}\\s*\\=\\s*(?!.*\\$\\$)(.*)`)
+      );
       if (match) {
         return match[1];
       }
     }
     return undefined;
+  }
+
+  private static obtainKeyFromConfigPri(content: string, key: string) {
+    const match = content.match(
+      new RegExp(`${key}\\s*\\=\\s*(?!.*\\$\\$)(.*)`)
+    );
+    if (match) {
+      return match[1];
+    }
+    return undefined;
+  }
+
+  private static obtainArch(content: string) {
+    return CoreAPIImpl.obtainKeyFromConfigPri(content, 'QT_ARCH');
+  }
+
+  private static obtainTargetArch(content: string) {
+    return CoreAPIImpl.obtainKeyFromConfigPri(content, 'QT_TARGET_ARCH');
+  }
+
+  private static obtainTargetArchs(content: string) {
+    return CoreAPIImpl.obtainKeyFromConfigPri(content, 'QT_ARCHS');
   }
 
   private static getQConfigPriContent(qtInfo: QtInfo) {
@@ -188,13 +212,37 @@ export class CoreAPIImpl implements CoreAPI {
     }
     const qconfigPriContent = CoreAPIImpl.getQConfigPriContent(result);
     if (qconfigPriContent) {
-      const arch = CoreAPIImpl.obtainArch(qconfigPriContent);
-      if (arch) {
-        result.set('ARCH', arch);
-      } else {
-        logger.warn(
-          `Cannot determine architecture for ${qtAdditionalPath.path}`
-        );
+      // Architecture configurations using map to avoid code duplication
+      const archConfigs = [
+        {
+          obtainFn: (content: string) => CoreAPIImpl.obtainArchs(content),
+          resultKey: 'ARCH',
+          warningMsg: `Cannot determine architecture for ${qtAdditionalPath.path}`
+        },
+        {
+          obtainFn: (content: string) => CoreAPIImpl.obtainTargetArch(content),
+          resultKey: 'QT_TARGET_ARCH',
+          warningMsg: `Cannot determine target architecture for ${qtAdditionalPath.path}`
+        },
+        {
+          obtainFn: (content: string) => CoreAPIImpl.obtainTargetArchs(content),
+          resultKey: 'QT_ARCHS',
+          warningMsg: `Cannot determine target architectures for ${qtAdditionalPath.path}`
+        },
+        {
+          obtainFn: (content: string) => CoreAPIImpl.obtainArch(content),
+          resultKey: 'QT_ARCH',
+          warningMsg: `Cannot determine target architectures for ${qtAdditionalPath.path}`
+        }
+      ];
+
+      for (const config of archConfigs) {
+        const value = config.obtainFn(qconfigPriContent);
+        if (value) {
+          result.set(config.resultKey, value);
+        } else {
+          logger.warn(config.warningMsg);
+        }
       }
       const msvcVersion = CoreAPIImpl.obtainMSVCVersions(qconfigPriContent);
       result.set('MSVC_MAJOR_VERSION', msvcVersion.major.toString());

--- a/qt-cpp/src/util/get-qt-paths.ts
+++ b/qt-cpp/src/util/get-qt-paths.ts
@@ -6,7 +6,13 @@ import * as fs from 'fs/promises';
 import type { Dirent } from 'fs';
 
 import * as fsutil from '@util/fs';
-import { OSExeSuffix, IsMacOS } from 'qt-lib';
+import {
+  OSExeSuffix,
+  IsMacOS,
+  findQtPathsInInstallationPath,
+  getArchInfoFromQtInfo
+} from 'qt-lib';
+import { coreAPI } from '@/extension';
 
 const QtToolchainCMakeFileName = 'qt.toolchain.cmake';
 const NinjaFileName = 'ninja' + OSExeSuffix;
@@ -26,14 +32,24 @@ function qtToolsDirByQtRootDir(qtRootDir: string): string {
   return path.normalize(path.join(qtRootDir, 'Tools'));
 }
 
-export function mangleQtInstallation(
-  qtInsRoot: string,
-  installation: string
-): string {
+export function mangleQtInstallation(qtInsRoot: string, installation: string) {
   const relativeInstallationPath = path.relative(qtInsRoot, installation);
   const pathParts = relativeInstallationPath.split(path.sep).filter(String);
   pathParts.unshift(path.basename(qtInsRoot));
-  return pathParts.slice().join('-');
+  const kitName = pathParts.slice().join('-');
+
+  const qtPaths = findQtPathsInInstallationPath(installation);
+  if (qtPaths) {
+    const qtInfo = coreAPI?.getQtInfoFromPath(qtPaths);
+    if (qtInfo) {
+      const archInfo = getArchInfoFromQtInfo(qtInfo);
+      if (archInfo) {
+        return kitName + '-' + archInfo;
+      }
+    }
+  }
+
+  return kitName;
 }
 
 export function mangleMsvcKitName(installation: string): string {

--- a/qt-lib/src/util.ts
+++ b/qt-lib/src/util.ts
@@ -175,11 +175,47 @@ export function isPathToQtPathsOrQMake(filePath: string): boolean {
     : false;
 }
 
-export function generateDefaultQtPathsName(qtInfo: QtInfo): string {
+export function getArchInfoFromQtInfo(qtInfo: QtInfo) {
+  const targetArch = qtInfo.get('QT_TARGET_ARCH');
+  if (targetArch) {
+    return targetArch;
+  }
+
+  const targetArchs = qtInfo.get('QT_ARCHS');
+  if (targetArchs) {
+    const targetArchsParts = targetArchs.split(' ');
+    if (targetArchsParts.length > 0) {
+      return targetArchsParts.join('-');
+    }
+  }
+
+  const arch = qtInfo.get('QT_ARCH');
+  if (arch) {
+    return arch;
+  }
+  return undefined;
+}
+
+export function generateDefaultQtPathsName(qtInfo: QtInfo) {
   const qtVersion = qtInfo.get('QT_VERSION');
   const targetMkSpec = qtInfo.get('QMAKE_XSPEC');
   const vcpkg = qtInfo.isVCPKG ? 'vcpkg-' : '';
-  return 'Qt-' + vcpkg + qtVersion + '-' + targetMkSpec;
+  let name = 'Qt-';
+  if (vcpkg) {
+    name += vcpkg;
+  }
+  if (qtVersion) {
+    name += qtVersion;
+  }
+  if (targetMkSpec) {
+    name += '-' + targetMkSpec;
+  }
+  const archInfo = getArchInfoFromQtInfo(qtInfo);
+  if (archInfo) {
+    name += '-' + archInfo;
+  }
+
+  return name;
 }
 
 export function inVCPKGRoot(p: string) {


### PR DESCRIPTION
- Prevent regex matching of values containing $$ when parsing qconfig.pri
- Include QT_TARGET_ARCH and QT_ARCHS in generated kit and paths names

Fixes: [VSCODEEXT-215](https://qt-project.atlassian.net/browse/VSCODEEXT-215)
