### PR TITLE
qt-core/webview-ui: Fix incorrect usage of Tailwind CSS classes

### DIFF
--- a/qt-core/webview-ui/src/apps/qml-trace/QmlTraceApp.svelte
+++ b/qt-core/webview-ui/src/apps/qml-trace/QmlTraceApp.svelte
@@ -42,7 +42,6 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
     busy={ui.task.busy}
     error={ui.task.error}
     forceHidden={ui.task.isDebouncing}
-    backgroundOpacity={15}
     busyText={texts.loading.busy}
     closeText={texts.loading.close}
   />

--- a/qt-core/webview-ui/src/apps/qml-trace/QmlTraceHeader.svelte
+++ b/qt-core/webview-ui/src/apps/qml-trace/QmlTraceHeader.svelte
@@ -29,13 +29,13 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   ]
 
   const roleButtons = [
-    { role: 'in', icon: ZoomIn, tooltip: t.tooltips.zoomIn, roundnone: '-r' },
-    { role: 'out', icon: ZoomOut, tooltip: t.tooltips.zoomOut, roundnone: ''  },
-    { role: 'full', icon: Fullscreen, tooltip: t.tooltips.zoomOutFull, roundnone: '-l' },
-    { role: '_grow', icon: ZoomIn, tooltip: '', roundnone: ''  },
-    { role: 'config', icon: Settings, tooltip: t.tooltips.config, roundnone: '-r' },
-    { role: 'json', icon: Braces, tooltip: t.tooltips.jsonc, roundnone: '' },
-    { role: 'text', icon: Type, tooltip: t.tooltips.openAsText, roundnone: '-l'  },
+    { role: 'in', icon: ZoomIn, tooltip: t.tooltips.zoomIn, round: 'l' },
+    { role: 'out', icon: ZoomOut, tooltip: t.tooltips.zoomOut, round: 'x'  },
+    { role: 'full', icon: Fullscreen, tooltip: t.tooltips.zoomOutFull, round: 'r' },
+    { role: '_grow', icon: ZoomIn, tooltip: '', round: ''  },
+    { role: 'config', icon: Settings, tooltip: t.tooltips.config, round: 'l' },
+    { role: 'json', icon: Braces, tooltip: t.tooltips.jsonc, round: 'x' },
+    { role: 'text', icon: Type, tooltip: t.tooltips.openAsText, round: 'r'  },
   ]
 
   const underlineClass =
@@ -106,7 +106,12 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
         icon={b.icon}
         tooltip={b.tooltip}
         tooltipPlacement='bottom'
-        class={`w-1 -ml-px rounded${b.roundnone}-none!`}
+        class={`
+          w-1 -ml-px
+          ${b.round === 'l' ? 'rounded-r-none!' : ''}
+          ${b.round === 'r' ? 'rounded-l-none!' : ''}
+          ${b.round === 'x' ? 'rounded-none!' : ''}
+        `}
         onClicked={() => onRoleButtonClicked(b.role)}
         visible={b.role !== 'text' || data.configs.filePath.endsWith('.qtd')}
         disabled={['in', 'out', 'full'].includes(b.role) && (

--- a/qt-core/webview-ui/src/comps/IconButton.svelte
+++ b/qt-core/webview-ui/src/comps/IconButton.svelte
@@ -39,7 +39,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   >
     {@const IconComp = icon}
     <div class={`
-      flex flex-${align} items-center
+      flex ${align === 'row' ? 'flex-row' : 'flex-col'} items-center
       ${align === 'col' ? 'gap-1' : ''}
     `}>
       {#if IconComp}

--- a/qt-core/webview-ui/src/comps/LoadingMask.svelte
+++ b/qt-core/webview-ui/src/comps/LoadingMask.svelte
@@ -12,7 +12,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
     forceHidden = false,
     busyText = 'Loading...',
     closeText = 'Close',
-    backgroundOpacity = 10
+    backgroundOpacity = 2.5
   } = $props();
 </script>
 
@@ -20,8 +20,16 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   class:hidden={forceHidden || (!busy && error === undefined)}
   class={`
     flex w-full h-full absolute inset-0
-    bg-white/${backgroundOpacity} justify-center items-center qt-border-radius`}
+    justify-center items-center qt-border-radius`}
 >
+  <!-- background with opacity -->
+  <div
+    class="w-full h-full absolute inset-0"
+    style={`background-color: rgba(255,255,255,${backgroundOpacity / 100})`}
+  >
+  </div>
+
+  <!-- contents -->
   {#if busy}
     <div class="flex w-full justify-center items-center gap-6">
       <Spinner class="qt-spinner" size="20" color="custom" />


### PR DESCRIPTION
Tailwind CSS class names must be known at build time. Dynamically generated class names may not work if they are not statically referenced elsewhere.

- Use static classes for button roundness in QmlTraceHeader
- Use static classes in IconButton instead of dynamic composition
- Use inline styles for dynamic background opacity in LoadingMask

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
