### PR TITLE
qt-qml: qt-python: Disable QML preview launch for PySide projects

### DIFF
--- a/qt-qml/package.json
+++ b/qt-qml/package.json
@@ -98,11 +98,11 @@
         },
         {
           "command": "qt-qml.startQmlPreview",
-          "when": "!qt-qml.qmlPreviewRunning"
+          "when": "!qt-qml.qmlPreviewRunning && qt-qml.qmlPreviewLaunchEnabled"
         },
         {
           "command": "qt-qml.startQmlPreviewForCurrentFile",
-          "when": "resourceLangId == qml && !qt-qml.qmlPreviewRunning"
+          "when": "resourceLangId == qml && !qt-qml.qmlPreviewRunning && qt-qml.qmlPreviewLaunchEnabled"
         },
         {
           "command": "qt-qml.attachQmlPreview",
@@ -112,12 +112,12 @@
       "editor/title": [
         {
           "command": "qt-qml.startQmlPreview",
-          "when": "resourceLangId == qml && !qt-qml.qmlPreviewRunning",
+          "when": "resourceLangId == qml && !qt-qml.qmlPreviewRunning && qt-qml.qmlPreviewLaunchEnabled",
           "group": "navigation@1"
         },
         {
           "command": "qt-qml.startQmlPreviewForCurrentFile",
-          "when": "resourceLangId == qml && !qt-qml.qmlPreviewRunning",
+          "when": "resourceLangId == qml && !qt-qml.qmlPreviewRunning && qt-qml.qmlPreviewLaunchEnabled",
           "group": "navigation@2"
         },
         {

--- a/qt-qml/src/extension.mts
+++ b/qt-qml/src/extension.mts
@@ -10,6 +10,7 @@ import {
   initLogger,
   telemetry,
   QtWorkspaceConfigMessage,
+  QtWorkspaceFeatures,
   createColorProvider,
   CoreKey
 } from 'qt-lib';
@@ -74,6 +75,9 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(() => {
+      updatePreviewLaunchContext();
+    }),
     registerDebugPort(),
     registerRestartQmllsCommand(),
     registerCheckQmllsUpdateCommand(),
@@ -121,6 +125,30 @@ export function deactivate() {
   }
 }
 
+function updatePreviewLaunchContext() {
+  const activeUri = vscode.window.activeTextEditor?.document.uri;
+  const folder = activeUri
+    ? vscode.workspace.getWorkspaceFolder(activeUri)
+    : undefined;
+
+  let launchEnabled = false;
+  if (folder) {
+    const features = coreAPI?.getValue<QtWorkspaceFeatures>(
+      folder,
+      CoreKey.WORKSPACE_FEATURES
+    );
+    // Enable preview launch only for CMake projects.
+    // PySide projects can only use attach.
+    launchEnabled = features?.projectTypes.cmake === true;
+  }
+
+  void vscode.commands.executeCommand(
+    'setContext',
+    'qt-qml.qmlPreviewLaunchEnabled',
+    launchEnabled
+  );
+}
+
 function processMessage(message: QtWorkspaceConfigMessage) {
   try {
     // check if workspace folder is a string. If it is, it means the global
@@ -155,6 +183,9 @@ function processMessage(message: QtWorkspaceConfigMessage) {
           updateQmlls = true;
           project.buildDir = buildDir;
         }
+      }
+      if (key === CoreKey.WORKSPACE_FEATURES) {
+        updatePreviewLaunchContext();
       }
     }
     if (updateQmlls) {


### PR DESCRIPTION
Add a `qt-qml.qmlPreviewLaunchEnabled` context key that is set to true
only when a CMake project is detected via QtWorkspaceFeatures. The key
defaults to false (unset), so preview launch buttons and commands are
hidden until the project type is confirmed.

The start/startForCurrentFile commands and their editor title buttons
are gated behind this key. The attach command remains available for all
project types, as PySide users can still run their application from
the command line and attach to it.
