### PR TITLE
qt-qml: Fix race condition and ETXTBSY error in qmlls installation

### DIFF
--- a/qt-qml/src/installer.mts
+++ b/qt-qml/src/installer.mts
@@ -16,7 +16,8 @@ import {
   IsWindows,
   IsMacOS,
   IsLinux,
-  IsArm64
+  IsArm64,
+  IsUnix
 } from 'qt-lib';
 import * as unzipper from '@/unzipper.js';
 import * as downloader from '@/downloader.js';
@@ -177,6 +178,20 @@ export async function install(asset: AssetWithTag) {
 
       logger.info(`Downloading from: ${asset.browser_download_url}`);
       await downloadWithProgress(asset.browser_download_url, tmpPath);
+
+      // Remove existing files before extraction to avoid ETXTBSY error on Linux.
+      // On Linux, even after the language server process has stopped, the kernel
+      // may still hold a reference to the executable file briefly. Deleting the
+      // file first works because Linux allows deletion of open files - the inode
+      // persists until all handles are closed, but the directory entry is removed,
+      // allowing us to create a new file with the same name.
+      if (IsUnix) {
+        if (fs.existsSync(ExtractDir)) {
+          logger.info(`Removing existing installation: ${ExtractDir}`);
+          fs.rmSync(ExtractDir, { recursive: true, force: true });
+        }
+      }
+
       logger.info(`Unzipping to: ${ExtractDir}`);
       await unzipWithProgress(tmpPath);
 

--- a/qt-qml/src/installer.mts
+++ b/qt-qml/src/installer.mts
@@ -21,6 +21,8 @@ import {
 import * as unzipper from '@/unzipper.js';
 import * as downloader from '@/downloader.js';
 import { setDoNotAskForDownloadingQmlls } from '@/qmlls.mjs';
+import { projectManager } from './extension.mts';
+import { QmllsOperationType } from './qmlls-queue.mts';
 
 const ReleaseInfoUrl = 'https://qtccache.qt.io/QMLLS/LatestRelease';
 const ReleaseInfoTimeout = 10 * 1000;
@@ -168,21 +170,25 @@ export async function getUserConsent(isNewInstall: boolean): Promise<boolean> {
 }
 
 export async function install(asset: AssetWithTag) {
-  const tmpPath = path.join(DownloadDir, asset.name);
+  return projectManager.qmllsQueue.enqueue(
+    QmllsOperationType.Install,
+    async () => {
+      const tmpPath = path.join(DownloadDir, asset.name);
 
-  // download, unzip
-  logger.info(`Downloading from: ${asset.browser_download_url}`);
-  await downloadWithProgress(asset.browser_download_url, tmpPath);
-  logger.info(`Unzipping to: ${ExtractDir}`);
-  await unzipWithProgress(tmpPath);
+      logger.info(`Downloading from: ${asset.browser_download_url}`);
+      await downloadWithProgress(asset.browser_download_url, tmpPath);
+      logger.info(`Unzipping to: ${ExtractDir}`);
+      await unzipWithProgress(tmpPath);
 
-  // follow up
-  logger.info(`QML language server installed to: ${QmllsExePath}`);
-  fs.chmodSync(QmllsExePath, 0o755);
-  fs.unlinkSync(tmpPath);
-  fs.writeFileSync(
-    ReleaseJsonPath,
-    JSON.stringify({ tag_name: asset.tag_name }, null, 2)
+      // follow up
+      logger.info(`QML language server installed to: ${QmllsExePath}`);
+      fs.chmodSync(QmllsExePath, 0o755);
+      fs.unlinkSync(tmpPath);
+      fs.writeFileSync(
+        ReleaseJsonPath,
+        JSON.stringify({ tag_name: asset.tag_name }, null, 2)
+      );
+    }
   );
 }
 

--- a/qt-qml/src/qmlls.mts
+++ b/qt-qml/src/qmlls.mts
@@ -182,23 +182,21 @@ export class Qmlls {
   }
 
   public static async install(asset: installer.AssetWithTag) {
-    return projectManager.qmllsQueue.enqueue(QmllsOperationType.Install, () => {
-      try {
-        logger.info('Stopping QML language server to install new version');
-        void projectManager.stopQmlls();
+    try {
+      logger.info('Stopping QML language server to install new version');
+      await projectManager.stopQmlls();
 
-        logger.info(`Installing: ${asset.name}, ${asset.tag_name}`);
-        void installer.install(asset);
-        logger.info('Installation done');
+      logger.info(`Installing: ${asset.name}, ${asset.tag_name}`);
+      await installer.install(asset);
+      logger.info('Installation done');
 
-        projectManager.updateQmllsParams();
-        void projectManager.startQmlls();
-      } catch (error) {
-        logger.warn(isError(error) ? error.message : String(error));
-      }
+      projectManager.updateQmllsParams();
+      await projectManager.startQmlls();
+    } catch (error) {
+      logger.warn(isError(error) ? error.message : String(error));
+    }
 
-      return QmllsStatus.running;
-    });
+    return QmllsStatus.running;
   }
   public static checkAssetAndDecide() {
     // Do not show the progress bar during the startup


### PR DESCRIPTION
Fix two related issues in the QML language server installation flow.

The install operation was not enqueued in the qmlls operation queue,
which could cause race conditions with concurrent start/stop operations.
Additionally, the installation steps (stop, download, unzip, restart) were
not properly awaited, meaning the language server could be restarted
before installation completed.

On Unix systems, a secondary issue caused an ETXTBSY error when the
extraction tried to overwrite the existing qmlls executable. Even after
the process is stopped, the kernel may briefly hold a reference to the
file. Fix this by removing the existing installation directory before
extraction. Since Unix allows deletion of open files, this creates a
new inode instead of overwriting the busy executable.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
