### PR TITLE
qt-python: Add timeout to prevent hanging on nested shells

### DIFF
--- a/qt-python/src/runner.ts
+++ b/qt-python/src/runner.ts
@@ -45,8 +45,17 @@ export class PySideCommandRunner {
     const errPromise = streamToLines(proc.stderr, this._onStderr);
 
     await new Promise<void>((resolve, reject) => {
-      proc.on('error', reject);
+      const timeout = setTimeout(() => {
+        proc.kill();
+        reject(new Error('Process timed out after 5 seconds'));
+      }, 3_000);
+
+      proc.on('error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
       proc.on('close', (code) => {
+        clearTimeout(timeout);
         if (code === 0) {
           resolve();
           return;


### PR DESCRIPTION
When nested shells are used on macOS (e.g., bash invoking fish),
PySideCommandRunner could hang indefinitely during venv activation.
Add a 5-second timeout that kills the process and rejects with an error.

Fixes: [VSCODEEXT-291](https://qt-project.atlassian.net/browse/VSCODEEXT-291)
