### PR TITLE
Introduce PySideAPI & Add QML Preview support for PySide projects

### DIFF
--- a/qt-lib/src/index.ts
+++ b/qt-lib/src/index.ts
@@ -7,6 +7,7 @@ export * from './state';
 export * from './telemetry';
 export * from './color-provider';
 export * from './configuration-resolver';
+export * from './pyside-api';
 export * from './vcpkg';
 export * from './test-helper';
 export * from './test-constants';

--- a/qt-lib/src/pyside-api.ts
+++ b/qt-lib/src/pyside-api.ts
@@ -1,0 +1,105 @@
+// Copyright (C) 2026 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+import { type ChildProcess } from 'child_process';
+
+const PYTHON_EXTENSION_ID = 'qt-python';
+
+/**
+ * Minimum PySide version that supports passing additional arguments
+ * to `pyside6-project run` via `-- <args>`.
+ */
+export const PYSIDE_MIN_VERSION_RUN_ARGS = '6.10.3';
+
+/**
+ * The interface provided by the qt-python extension during activation.
+ * Allows other VS Code extensions to interact with PySide projects.
+ */
+export interface PySideAPI {
+  /**
+   * Gets the PySide project associated with the given workspace folder,
+   * if it exists.
+   * @param folder The workspace folder to get the project for.
+   * @returns The PySide project for the folder, or undefined if no project
+   *          exists in that folder.
+   */
+  getProject(folder: vscode.WorkspaceFolder): PySideProject | undefined;
+}
+
+/**
+ * Represents a PySide project within a workspace folder.
+ * Provides operations for running, querying, and inspecting the project.
+ */
+export interface PySideProject {
+  /**
+   * Run the PySide project using `pyside6-project run`.
+   * For PySide >= 6.10.3, additional arguments are passed via `-- <args>`.
+   * @param args Additional arguments to pass to the running application.
+   * @returns The spawned child process, or undefined if the project is invalid.
+   */
+  runProject(args?: string[]): ChildProcess | undefined;
+
+  /**
+   * Build the PySide project using `pyside6-project build`.
+   * @returns A promise that resolves to true on success, false on failure.
+   */
+  build(): Promise<number>;
+
+  /**
+   * Run a specific Python file with optional arguments.
+   * Used as a fallback when `pyside6-project run` does not support extra args
+   * (PySide < 6.10.3).
+   * @param filePath Absolute path to the Python file to run.
+   * @param args Additional arguments to pass to the Python script.
+   * @returns The spawned child process, or undefined on failure.
+   */
+  runFile(filePath: string, args?: string[]): ChildProcess | undefined;
+
+  /**
+   * Find all Python files within the project's workspace folder.
+   * Used as a fallback entry-point picker when PySide < 6.10.3.
+   * @returns Relative paths of all `.py` files found.
+   */
+  findPythonFiles(): Promise<string[]>;
+
+  /**
+   * Get the installed PySide6 version for this project.
+   * @returns Version string (e.g., "6.10.3") or undefined if not available.
+   */
+  getPySideVersion(): string | undefined;
+
+  /**
+   * Check if the PySide version for this project supports passing
+   * additional arguments to `pyside6-project run` (>= 6.10.3).
+   * @returns true if `pyside6-project run -- <args>` is supported.
+   */
+  supportsProjectRunArgs(): boolean;
+}
+
+/**
+ * Get the PySideAPI from the qt-python extension.
+ * Activates the extension if it is not already active.
+ * @returns The PySideAPI or undefined if the extension is not installed.
+ */
+export async function getPySideApi(): Promise<PySideAPI | undefined> {
+  const extension = vscode.extensions.getExtension(
+    `theqtcompany.${PYTHON_EXTENSION_ID}`
+  );
+  if (!extension) {
+    return undefined;
+  }
+
+  let exports: PySideAPI | undefined;
+  if (!extension.isActive) {
+    try {
+      exports = (await extension.activate()) as PySideAPI;
+    } catch {
+      return undefined;
+    }
+  } else {
+    exports = extension.exports as PySideAPI;
+  }
+
+  return exports;
+}

--- a/qt-lib/src/util.ts
+++ b/qt-lib/src/util.ts
@@ -92,31 +92,19 @@ export function compareVersions(version1: string, version2: string) {
   if (version1 == version2) {
     return 0;
   }
-  const v1parts = version1.split('.');
-  const v2parts = version2.split('.');
+  const v1parts = version1.split('.').map(Number);
+  const v2parts = version2.split('.').map(Number);
+  const length = Math.max(v1parts.length, v2parts.length);
 
-  for (let i = 0; i < v1parts.length; ++i) {
-    if (v2parts.length === i) {
-      return 1;
-    }
-    const v1Part = v1parts[i];
-    const v2Part = v2parts[i];
-    if (v1Part === undefined) {
-      throw new Error('v1Part is undefined');
-    }
-    if (v2Part === undefined) {
-      throw new Error('v2Part is undefined');
-    }
+  for (let i = 0; i < length; ++i) {
+    const v1Part = v1parts[i] ?? 0;
+    const v2Part = v2parts[i] ?? 0;
     if (v1Part === v2Part) {
       continue;
     }
     if (v1Part > v2Part) {
       return 1;
     }
-    return -1;
-  }
-
-  if (v1parts.length !== v2parts.length) {
     return -1;
   }
 

--- a/qt-python/src/api.ts
+++ b/qt-python/src/api.ts
@@ -1,0 +1,120 @@
+import * as vscode from 'vscode';
+import * as childProcess from 'child_process';
+import { glob } from 'glob';
+
+import * as consts from '@/constants';
+import { projectManager } from './extension';
+import {
+  PYSIDE_MIN_VERSION_RUN_ARGS,
+  compareVersions,
+  PySideAPI,
+  PySideProject as PySideProjectAPI,
+  createLogger
+} from 'qt-lib';
+import { PySideCommandBuilder } from './builder';
+import { PySideProject } from './project';
+
+const logger = createLogger('api');
+
+export class PySideAPIImpl implements PySideAPI {
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  getProject(folder: vscode.WorkspaceFolder): PySideProjectAPI | undefined {
+    const project = projectManager.getProject(folder);
+    if (!project) {
+      logger.error(`No PySide project in: ${folder.uri.fsPath}`);
+      return undefined;
+    }
+    return new PySideProjectWrapper(project, folder);
+  }
+}
+
+class PySideProjectWrapper implements PySideProjectAPI {
+  constructor(
+    private readonly project: PySideProject,
+    private readonly folder: vscode.WorkspaceFolder
+  ) {}
+
+  runProject(args?: string[]): childProcess.ChildProcess | undefined {
+    if (!this.project.isValid()) {
+      logger.error(`No valid PySide project in: ${this.folder.uri.fsPath}`);
+      return undefined;
+    }
+
+    let command = `${consts.PYSIDE_PROJECT_TOOL} run`;
+    if (args?.length) {
+      command += ` ${args.join(' ')}`;
+    }
+
+    const cmd = new PySideCommandBuilder()
+      .useVenv(true)
+      .venvBinPath(this.project.env.venvBinPath)
+      .build(command);
+
+    logger.info(`runProject: ${cmd.commandLine}`);
+    return childProcess.spawn(cmd.commandLine, {
+      shell: cmd.shellPath,
+      cwd: this.folder.uri.fsPath
+    });
+  }
+
+  async build(): Promise<number> {
+    return new Promise((resolve) => {
+      const cmd = new PySideCommandBuilder()
+        .useVenv(true)
+        .venvBinPath(this.project.env.venvBinPath)
+        .build(`${consts.PYSIDE_PROJECT_TOOL} build`);
+
+      logger.info(`build: ${cmd.commandLine}`);
+      const proc = childProcess.spawn(cmd.commandLine, {
+        shell: cmd.shellPath,
+        cwd: this.folder.uri.fsPath
+      });
+      proc.on('exit', (code) => {
+        resolve(code ?? -1);
+      });
+      proc.on('error', () => {
+        resolve(-1);
+      });
+    });
+  }
+
+  runFile(
+    filePath: string,
+    args?: string[]
+  ): childProcess.ChildProcess | undefined {
+    let command = `python "${filePath}"`;
+    if (args?.length) {
+      command += ` ${args.join(' ')}`;
+    }
+
+    const cmd = new PySideCommandBuilder()
+      .useVenv(true)
+      .venvBinPath(this.project.env.venvBinPath)
+      .build(command);
+
+    logger.info(`runFile: ${cmd.commandLine}`);
+    return childProcess.spawn(cmd.commandLine, {
+      shell: cmd.shellPath,
+      cwd: this.folder.uri.fsPath
+    });
+  }
+
+  async findPythonFiles(): Promise<string[]> {
+    return glob('**/*.py', {
+      cwd: this.folder.uri.fsPath,
+      ignore: ['**/.*/**', '**/__pycache__/**', '**/node_modules/**']
+    });
+  }
+
+  getPySideVersion(): string | undefined {
+    return this.project.pySideVersion;
+  }
+
+  supportsProjectRunArgs(): boolean {
+    const version = this.getPySideVersion();
+    if (!version) {
+      return false;
+    }
+    return compareVersions(version, PYSIDE_MIN_VERSION_RUN_ARGS) >= 0;
+  }
+}

--- a/qt-python/src/extension.ts
+++ b/qt-python/src/extension.ts
@@ -20,6 +20,7 @@ import { PySideDebugConfigProvider } from './debug';
 import { PySideProjectManager } from './project-manager';
 import * as consts from '@/constants';
 import { onInstallPySide6Command } from './installer';
+import { PySideAPIImpl } from './api';
 
 const logger = createLogger('extension');
 
@@ -40,8 +41,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
     logger.info(`Activated: ${consts.EXTENSION_ID}`);
     telemetry.sendEvent('activated');
+
+    return new PySideAPIImpl();
   } catch (e) {
     logger.error(`Cannot activate: ${consts.EXTENSION_ID}: ${String(e)}`);
+    return undefined;
   }
 }
 

--- a/qt-python/src/project.ts
+++ b/qt-python/src/project.ts
@@ -30,6 +30,7 @@ const logger = createLogger('project');
 export class PySideProject implements Project {
   private readonly _env: PySideEnv;
   private _info: PySideProjectInfo | undefined;
+  private _pySideVersion: string | undefined;
 
   private constructor(private readonly _folder: Folder) {
     logger.info(`Create: "${_folder.uri.fsPath}"`);
@@ -53,6 +54,14 @@ export class PySideProject implements Project {
     return this._info !== undefined;
   }
 
+  get pySideVersion() {
+    return this._pySideVersion;
+  }
+
+  get projectFiles() {
+    return this._info?.files ?? [];
+  }
+
   public async refreshEnv() {
     if (!pyApi) {
       return;
@@ -61,6 +70,7 @@ export class PySideProject implements Project {
     await this._env.refresh(pyApi);
 
     const pyside = await this._env.readPySide6PackageInfo();
+    this._pySideVersion = pyside?.version;
     const qmlImportPath = pyside?.location
       ? path.normalize(path.join(pyside.location, consts.QML_IMPORT_SUBDIR))
       : '';

--- a/qt-qml/src/extension.mts
+++ b/qt-qml/src/extension.mts
@@ -137,11 +137,14 @@ function updatePreviewLaunchContext() {
       folder,
       CoreKey.WORKSPACE_FEATURES
     );
-    // Enable preview launch only for CMake projects.
-    // PySide projects can only use attach.
-    launchEnabled = features?.projectTypes.cmake === true;
+    // Enable preview launch for CMake and PySide projects.
+    launchEnabled =
+      features?.projectTypes.cmake === true ||
+      features?.projectTypes.pyside === true;
   }
-
+  logger.info(
+    `Setting qmlPreviewLaunchEnabled to ${launchEnabled} for folder ${folder?.name}`
+  );
   void vscode.commands.executeCommand(
     'setContext',
     'qt-qml.qmlPreviewLaunchEnabled',
@@ -185,6 +188,17 @@ function processMessage(message: QtWorkspaceConfigMessage) {
         }
       }
       if (key === CoreKey.WORKSPACE_FEATURES) {
+        logger.info(
+          'Updating workspace features for project',
+          project.folder.name
+        );
+        const features = coreAPI?.getValue<QtWorkspaceFeatures>(
+          message.workspaceFolder,
+          CoreKey.WORKSPACE_FEATURES
+        );
+        if (features?.projectTypes.pyside === true) {
+          void project.initPySideProject();
+        }
         updatePreviewLaunchContext();
       }
     }

--- a/qt-qml/src/preview/preview.mts
+++ b/qt-qml/src/preview/preview.mts
@@ -1,17 +1,26 @@
 // Copyright (C) 2026 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
+import * as path from 'path';
 import * as vscode from 'vscode';
+import { type ChildProcess } from 'child_process';
 import getPort from 'get-port';
 
-import { createLogger, telemetry } from 'qt-lib';
+import {
+  createLogger,
+  telemetry,
+  PySideProject,
+  QtWorkspaceFeatures,
+  CoreKey
+} from 'qt-lib';
 import { EXTENSION_ID } from '@/constants.js';
-import { projectManager } from '@/extension.mjs';
+import { projectManager, coreAPI } from '@/extension.mjs';
 import { QmlPreviewConnectionManager } from '@/preview/preview-connection-manager.mjs';
 import { FpsInfo } from '@/preview/preview-client.mjs';
 import { ServerScheme } from '@debug/debug-connection.mjs';
 import { QtProcess, spawnProcessForTool } from '@/utils.mts';
 import { QmlPreviewUI } from '@preview/ui.js';
+import { QMLProject } from '@/project.mjs';
 
 const logger = createLogger('qml-preview');
 const ui = new QmlPreviewUI();
@@ -46,7 +55,7 @@ function createPreviewManager() {
   return manager;
 }
 
-async function resolveProgram() {
+async function resolveCMakeProgram() {
   const ret = await vscode.commands.executeCommand('cmake.launchTargetPath');
   return ret as string | undefined;
 }
@@ -59,8 +68,69 @@ function getPreviewConfig() {
   return vscode.workspace.getConfiguration('qt-qml.preview');
 }
 
-async function launchPreview(qmlFile?: string) {
-  const program = await resolveProgram();
+/**
+ * Resolve which workspace folder to use for preview.
+ * For "preview current file": use the active file's workspace folder.
+ * For "preview whole application": use active file's folder, or if ambiguous
+ * in multi-workspace, show a picker.
+ */
+async function resolveWorkspaceFolder(
+  requirePick: boolean
+): Promise<vscode.WorkspaceFolder | undefined> {
+  const activeUri = vscode.window.activeTextEditor?.document.uri;
+  if (activeUri) {
+    const folder = vscode.workspace.getWorkspaceFolder(activeUri);
+    if (folder) {
+      return folder;
+    }
+  }
+
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders || folders.length === 0) {
+    return undefined;
+  }
+
+  if (folders.length === 1) {
+    return folders[0];
+  }
+
+  if (requirePick) {
+    const picked = await vscode.window.showWorkspaceFolderPick({
+      placeHolder: 'Select the workspace folder for QML Preview'
+    });
+    return picked;
+  }
+
+  return folders[0];
+}
+
+/**
+ * Determine the project type for the given workspace folder.
+ */
+function getProjectType(
+  folder: vscode.WorkspaceFolder
+): 'cmake' | 'pyside' | undefined {
+  const project = projectManager.getProject(folder);
+  if (project?.pySideProject) {
+    return 'pyside';
+  }
+
+  const features = coreAPI?.getValue<QtWorkspaceFeatures>(
+    folder,
+    CoreKey.WORKSPACE_FEATURES
+  );
+  if (features?.projectTypes.cmake) {
+    return 'cmake';
+  }
+  if (features?.projectTypes.pyside) {
+    return 'pyside';
+  }
+
+  return undefined;
+}
+
+async function launchCMakePreview(qmlFile?: string) {
+  const program = await resolveCMakeProgram();
   if (!program) {
     logger.error('Failed to get launch target executable');
     ui.showFailedToStart(new Error('No launch target configured'));
@@ -103,28 +173,178 @@ async function launchPreview(qmlFile?: string) {
     }
     logger.info(`QML Preview process started with PID: ${process.pid}`);
 
-    // Set up output channel
-    if (!qmlPreviewOutputChannel) {
-      qmlPreviewOutputChannel =
-        vscode.window.createOutputChannel('QML Preview Output');
+    setupProcessForPreview(process, manager, qmlFile, host, port);
+    return true;
+  } catch (err) {
+    logger.error(`Failed to start QML Preview: ${String(err)}`);
+    manager.dispose();
+    ui.showFailedToStart(err instanceof Error ? err : new Error(String(err)));
+    return false;
+  }
+}
+
+/**
+ * Pick a Python file entry point for PySide preview.
+ *
+ * The workspace folder is already resolved from the active QML file, so only
+ * Python files belonging to that folder's project are shown.
+ *
+ * @param currentProject The PySide project for the target folder.
+ * @returns The relative path of the selected file, or undefined on cancel.
+ */
+async function pickPythonFile(
+  project: QMLProject,
+  currentProject: PySideProject
+): Promise<string | undefined> {
+  const pyFiles = await currentProject.findPythonFiles();
+  if (pyFiles.length === 0) {
+    ui.showFailedToStart(new Error('No Python files found in the project'));
+    return undefined;
+  }
+  if (pyFiles.length === 1) {
+    return pyFiles[0];
+  }
+
+  const items = pyFiles.map((file) => ({
+    label: path.basename(file),
+    description: path.join(project.folder.name, path.dirname(file)),
+    file: file,
+    folder: project.folder
+  }));
+  const selected = await vscode.window.showQuickPick(items, {
+    placeHolder: 'Select the Python file that has the main function',
+    title: 'QML preview - select entry point'
+  });
+  if (!selected) {
+    logger.info('User cancelled file selection');
+  }
+  return selected?.file;
+}
+
+async function launchPySidePreview(
+  folder: vscode.WorkspaceFolder,
+  qmlFile?: string
+) {
+  const host = '127.0.0.1';
+  const port = await getPort();
+  if (!port) {
+    logger.error('Failed to obtain a free port');
+    ui.showFailedToStart(new Error('Failed to obtain a free port'));
+    return false;
+  }
+  logger.info(`Host: ${host}, Port: ${port}`);
+
+  const manager = createPreviewManager();
+  manager.onConnectionClosed(() => {
+    logger.info('QML Preview connection closed');
+    cleanupSession();
+  });
+  manager.setFpsHandler((fps: FpsInfo) => {
+    ui.updateFps(fps);
+  });
+
+  const previewArgs = buildPreviewArgs(host, port);
+  const additionalArgs = getPreviewConfig().get<string[]>('args', []);
+  const allArgs = [previewArgs, ...additionalArgs];
+
+  try {
+    let proc: ChildProcess | undefined;
+    const project = projectManager.getProject(folder);
+    const pySideProject = project?.pySideProject;
+    if (!pySideProject) {
+      throw new Error('No PySide project found for the workspace folder');
+    }
+    if (pySideProject.supportsProjectRunArgs()) {
+      // PySide >= 6.10.3: pass args via pyside6-project run <args>
+      logger.info('Using pyside6-project run with args');
+      proc = pySideProject.runProject(allArgs);
+    } else {
+      // PySide < 6.10.3: let user pick the main Python file
+      logger.info(
+        'PySide version does not support run args, using file picker'
+      );
+
+      const selectedFile = await pickPythonFile(project, pySideProject);
+      if (!selectedFile) {
+        manager.dispose();
+        return false;
+      }
+
+      const absFilePath = path.isAbsolute(selectedFile)
+        ? selectedFile
+        : path.join(folder.uri.fsPath, selectedFile);
+      logger.info(`Selected main file: ${absFilePath}`);
+
+      logger.info('Building PySide project before running file...');
+      const buildOk = await pySideProject.build();
+      if (buildOk !== 0) {
+        logger.error('PySide project build failed');
+        manager.dispose();
+        ui.showFailedToStart(new Error('pyside6-project build failed'));
+        return false;
+      }
+
+      proc = pySideProject.runFile(absFilePath, allArgs);
     }
 
-    process.stdout?.on('data', (data: Buffer) => {
-      qmlPreviewOutputChannel?.append(data.toString());
-    });
+    if (!proc || proc.killed || proc.pid === undefined) {
+      logger.error('Failed to start PySide preview process');
+      manager.dispose();
+      ui.showFailedToStart(new Error('Process failed to start'));
+      return false;
+    }
+    logger.info(`PySide preview process started with PID: ${proc.pid}`);
 
-    process.stderr?.on('data', (data: Buffer) => {
-      qmlPreviewOutputChannel?.append(data.toString());
-    });
+    setupProcessForPreview(proc, manager, qmlFile, host, port);
+    return true;
+  } catch (err) {
+    logger.error(`Failed to start PySide preview: ${String(err)}`);
+    manager.dispose();
+    ui.showFailedToStart(err instanceof Error ? err : new Error(String(err)));
+    return false;
+  }
+}
 
-    process.on('exit', (code, signal) => {
-      logger.info(
-        `QML Preview process exited with code ${code}, signal ${signal}`
-      );
-      cleanupSession();
-    });
+/**
+ * Common process setup for both CMake and PySide preview.
+ */
+function setupProcessForPreview(
+  proc: ChildProcess | QtProcess,
+  manager: QmlPreviewConnectionManager,
+  qmlFile: string | undefined,
+  host: string,
+  port: number
+) {
+  // Set up output channel
+  if (!qmlPreviewOutputChannel) {
+    qmlPreviewOutputChannel =
+      vscode.window.createOutputChannel('QML Preview Output');
+  }
 
-    // Helper promises for connection establishment
+  proc.stdout?.on('data', (data: Buffer) => {
+    qmlPreviewOutputChannel?.append(data.toString());
+  });
+
+  proc.stderr?.on('data', (data: Buffer) => {
+    qmlPreviewOutputChannel?.append(data.toString());
+  });
+
+  proc.on('exit', (code, signal) => {
+    logger.info(
+      `QML Preview process exited with code ${code}, signal ${signal}`
+    );
+    cleanupSession();
+  });
+
+  previewManager = manager;
+  previewProcess = proc as QtProcess;
+
+  manager.connectToServer({ host, port, scheme: ServerScheme.Tcp });
+  logger.info('QML Preview connected successfully');
+
+  // If a QML file was specified, wait for connection and load it
+  if (qmlFile) {
+    logger.info('Waiting for QML Preview connection to be ready...');
     const waitForConnection = async () => {
       const connectionReady = new Promise<void>((resolve) => {
         const disposable = manager.onConnectionOpened(() => {
@@ -141,32 +361,17 @@ async function launchPreview(qmlFile?: string) {
       return Promise.race([connectionReady, timeout]);
     };
 
-    previewManager = manager;
-    previewProcess = process;
-
-    manager.connectToServer({ host, port, scheme: ServerScheme.Tcp });
-    logger.info('QML Preview connected successfully');
-
-    // If a QML file was specified, wait for connection and load it
-    if (qmlFile) {
-      logger.info('Waiting for QML Preview connection to be ready...');
-      try {
-        await waitForConnection();
+    void waitForConnection()
+      .then(() => {
         logger.info(`Loading QML file: ${qmlFile}`);
         manager.loadUrl(qmlFile);
-      } catch (err) {
+      })
+      .catch((err) => {
         logger.error(`Timeout waiting for connection: ${String(err)}`);
-      }
-    }
-
-    ui.setPreviewRunning();
-    return true;
-  } catch (err) {
-    logger.error(`Failed to start QML Preview: ${String(err)}`);
-    manager.dispose();
-    ui.showFailedToStart(err instanceof Error ? err : new Error(String(err)));
-    return false;
+      });
   }
+
+  ui.setPreviewRunning();
 }
 
 function attachPreview(host: string, port: number) {
@@ -212,6 +417,18 @@ async function startQmlPreviewImpl(loadCurrentFile: boolean) {
     return;
   }
 
+  // Resolve the workspace folder.
+  // For "preview current file": get folder from active file.
+  // For "preview whole application" in multi-workspace: show picker.
+  const requirePick = !loadCurrentFile;
+  const folder = await resolveWorkspaceFolder(requirePick);
+  if (!folder) {
+    void vscode.window.showWarningMessage(
+      'No workspace folder available for QML Preview.'
+    );
+    return;
+  }
+
   let qmlFile: string | undefined;
 
   if (loadCurrentFile) {
@@ -231,7 +448,24 @@ async function startQmlPreviewImpl(loadCurrentFile: boolean) {
     }
   }
 
-  await launchPreview(qmlFile);
+  const projectType = getProjectType(folder);
+  logger.info(`Project type for ${folder.name}: ${projectType ?? 'unknown'}`);
+
+  if (projectType === 'pyside') {
+    const project = projectManager.getProject(folder);
+    const pySideProject = project?.pySideProject;
+    if (!pySideProject) {
+      logger.error(`No PySide project found for folder: ${folder.uri.fsPath}`);
+      void vscode.window.showErrorMessage(
+        'No PySide project found in the workspace folder.'
+      );
+      return;
+    }
+    await launchPySidePreview(folder, qmlFile);
+  } else {
+    // Default to CMake preview (existing behavior)
+    await launchCMakePreview(qmlFile);
+  }
 }
 
 export function registerStartQmlPreviewCommand() {

--- a/qt-qml/src/project.mts
+++ b/qt-qml/src/project.mts
@@ -3,7 +3,15 @@
 
 import * as vscode from 'vscode';
 
-import { CoreKey, Project, ProjectManager, createLogger } from 'qt-lib';
+import {
+  CoreKey,
+  Project,
+  ProjectManager,
+  createLogger,
+  QtWorkspaceFeatures,
+  getPySideApi,
+  PySideProject
+} from 'qt-lib';
 import { Qmlls } from '@/qmlls.mjs';
 import { coreAPI } from '@/extension.mjs';
 import { QmllsOperationQueue, QmllsOperationType } from '@/qmlls-queue.mjs';
@@ -111,6 +119,7 @@ export class QMLProject implements Project {
   _qtpathsExe: string | undefined;
   _kitPath: string | undefined;
   _buildDir: string | undefined;
+  _pySideProject?: PySideProject | undefined;
   public constructor(
     readonly _folder: vscode.WorkspaceFolder,
     readonly _context: vscode.ExtensionContext
@@ -135,12 +144,34 @@ export class QMLProject implements Project {
     this._qtpathsExe = qtpathsExe;
   }
 
+  get pySideProject() {
+    return this._pySideProject;
+  }
+
+  public async initPySideProject() {
+    const api = await getPySideApi();
+    this._pySideProject = api?.getProject(this._folder);
+    if (!this._pySideProject) {
+      logger.info(
+        `No PySide project available for: ${this._folder.uri.fsPath}`
+      );
+    }
+  }
+
   getConfigValues() {
     this.qtpathsExe = coreAPI?.getValue<string>(
       this.folder,
       CoreKey.SELECTED_QT_PATHS
     );
     this.buildDir = coreAPI?.getValue<string>(this.folder, CoreKey.BUILD_DIR);
+
+    const features = coreAPI?.getValue<QtWorkspaceFeatures>(
+      this.folder,
+      CoreKey.WORKSPACE_FEATURES
+    );
+    if (features?.projectTypes.pyside === true && !this._pySideProject) {
+      void this.initPySideProject();
+    }
   }
 
   updateQmllsParams() {


### PR DESCRIPTION
**qt-lib: Fix compareVersions to use numeric comparison**
String comparison of version parts produces wrong results for
multi-digit components (e.g. "10" < "9" lexicographically).
Switch to numeric comparison via .map(Number) so that versions
like 6.10.3 are correctly ordered relative to 6.9.0.

**qt-python: qt-lib: Introduce PySide API**
Add a PySideAPI interface and PySideProject interface to qt-lib so other
extensions can interact with PySide projects without a direct dependency
on qt-python.
* PySideAPI.getProject(folder) returns a PySideProject for the folder
* PySideProject exposes runProject(), runFile(), findPythonFiles(),
  getPySideVersion(), and supportsProjectRunArgs()
* PYSIDE_MIN_VERSION_RUN_ARGS constant marks 6.10.3 as the minimum
  version for pyside6-project run -- <args> support
* qt-python activate() now returns a PySideAPIImpl implementing the
  interface
* PySideProject stores and exposes the installed PySide6 version

**qt-qml: Add QML live preview support for PySide projects (part 2/x)**
Extend the QML preview to launch PySide projects in addition to CMake
projects.

- Enable the preview launch context for PySide projects (previously
  only CMake was allowed)
- resolveWorkspaceFolder() picks the folder from the active editor or
  prompts a picker in multi-root workspaces when no file is open
- launchPySidePreview() runs the project via PySideAPI:
  - PySide >= 6.10.3: passes debug args via pyside6-project run <args>
  - PySide < 6.10.3: shows a QuickPick of all .py files for the user to
    select the entry point
- QMLProject tracks WORKSPACE_FEATURES changes
- initPySideProject() called on the QML project when pyside feature is set

Task-number: [VSCODEEXT-16](https://qt-project.atlassian.net/browse/VSCODEEXT-16)
<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
