### PR TITLE
qt-qml: qt-python: qt-lib: Port pyside6-project run logic for older PySide versions

### DIFF
--- a/qt-lib/src/pyside-api.ts
+++ b/qt-lib/src/pyside-api.ts
@@ -75,6 +75,15 @@ export interface PySideProject {
    * @returns true if `pyside6-project run -- <args>` is supported.
    */
   supportsProjectRunArgs(): boolean;
+
+  /**
+   * Find the main entry-point file for the project, replicating the logic
+   * used by `pyside6-project run`:
+   * 1. A Python file whose stem is `main` (i.e. `main.py`).
+   * 2. The first Python file in the project that contains `__main__`.
+   * @returns Absolute path to the main file, or undefined if not found.
+   */
+  getMainFile(): Promise<string | undefined>;
 }
 
 /**

--- a/qt-python/src/api.ts
+++ b/qt-python/src/api.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import * as childProcess from 'child_process';
 import { glob } from 'glob';
@@ -104,6 +106,35 @@ class PySideProjectWrapper implements PySideProjectAPI {
       cwd: this.folder.uri.fsPath,
       ignore: ['**/.*/**', '**/__pycache__/**', '**/node_modules/**']
     });
+  }
+
+  async getMainFile(): Promise<string | undefined> {
+    const folderPath = this.folder.uri.fsPath;
+    const pyFiles = this.project.projectFiles
+      .filter((f) => f.endsWith('.py') || f.endsWith('.pyw'))
+      .map((f) => (path.isAbsolute(f) ? f : path.join(folderPath, f)));
+
+    // First priority: file whose stem is 'main' (i.e. main.py)
+    const mainPy = pyFiles.find(
+      (f) => path.basename(f, path.extname(f)) === 'main'
+    );
+    if (mainPy) {
+      return mainPy;
+    }
+
+    // Second priority: first file whose content contains '__main__'
+    for (const f of pyFiles) {
+      try {
+        const content = await fs.promises.readFile(f, 'utf-8');
+        if (content.includes('__main__')) {
+          return f;
+        }
+      } catch {
+        // ignore unreadable files
+      }
+    }
+
+    return undefined;
   }
 
   getPySideVersion(): string | undefined {

--- a/qt-qml/src/preview/preview.mts
+++ b/qt-qml/src/preview/preview.mts
@@ -259,21 +259,29 @@ async function launchPySidePreview(
       logger.info('Using pyside6-project run with args');
       proc = pySideProject.runProject(allArgs);
     } else {
-      // PySide < 6.10.3: let user pick the main Python file
+      // PySide < 6.10.3: replicate pyside6-project run manually:
+      // build the project, then run the main file with args.
       logger.info(
-        'PySide version does not support run args, using file picker'
+        'PySide version does not support run args, replicating pyside6-project run'
       );
 
-      const selectedFile = await pickPythonFile(project, pySideProject);
-      if (!selectedFile) {
-        manager.dispose();
-        return false;
+      // Determine the main file using the same logic as pyside6-project run:
+      // 1. file named main.py, 2. file containing __main__, 3. user picker.
+      let absFilePath: string | undefined = await pySideProject.getMainFile();
+      if (absFilePath) {
+        logger.info(`Auto-detected main file: ${absFilePath}`);
+      } else {
+        logger.info('Main file not auto-detected, falling back to file picker');
+        const selectedFile = await pickPythonFile(project, pySideProject);
+        if (!selectedFile) {
+          manager.dispose();
+          return false;
+        }
+        absFilePath = path.isAbsolute(selectedFile)
+          ? selectedFile
+          : path.join(folder.uri.fsPath, selectedFile);
+        logger.info(`Selected main file: ${absFilePath}`);
       }
-
-      const absFilePath = path.isAbsolute(selectedFile)
-        ? selectedFile
-        : path.join(folder.uri.fsPath, selectedFile);
-      logger.info(`Selected main file: ${absFilePath}`);
 
       logger.info('Building PySide project before running file...');
       const buildOk = await pySideProject.build();


### PR DESCRIPTION
When PySide < 6.10.3, replicate the main-file detection logic from
pyside6-project run instead of immediately showing a file picker:
1. Use a file named main.py from the project's declared files.
2. Fall back to the first file whose content contains __main__.
3. Only show the file picker if neither heuristic finds a match.

Add PySideProject.getMainFile() to the qt-lib interface and implement
it in qt-python's PySideProjectWrapper.