### PR TITLE
tsconfig: qt-lib: Remove baseUrl

### DIFF
--- a/qt-lib/tsconfig.json
+++ b/qt-lib/tsconfig.json
@@ -19,11 +19,7 @@
     "noImplicitReturns": true,
     "exactOptionalPropertyTypes": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "baseUrl": "./",
-    "paths": {
-      "@/*": ["src/*"]
-    }
+    "noUnusedParameters": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
`baseUrl` is not used in qt-lib/tsconfig.json, we can remove it.
