### PR TITLE
qt-cpp:natvis-test: ignore ##NAMESPACE## prefix in NatVis type names

### DIFF
--- a/qt-cpp/test/debug-golden.mts
+++ b/qt-cpp/test/debug-golden.mts
@@ -438,7 +438,9 @@ function decodeXmlEntities(input: string): string {
     '&quot;': '"',
     '&apos;': "'"
   };
-  return input.replace(/&(lt|gt|amp|quot|apos);/g, (m) => map[m] ?? m);
+  const decoded = input.replace(/&(lt|gt|amp|quot|apos);/g, (m) => map[m] ?? m);
+  // NatVis placeholder normalization
+  return decoded.replace(/##NAMESPACE##::/g, '');
 }
 
 /**


### PR DESCRIPTION
Strip the "##NAMESPACE##::" placeholder when parsing NatVis <Type Name="..."> entries. This restores matching between NatVis types and debugger-reported types and fixes coverage reporting after NatVis format changes.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
