### PR TITLE
qt-python: Migrate to node16 module resolution

### DIFF
--- a/qt-python/esbuild.mjs
+++ b/qt-python/esbuild.mjs
@@ -19,7 +19,7 @@ const extensionConfig = {
   mainFields: ['module', 'main'],
   tsconfig: './tsconfig.json',
   format: 'cjs',
-  entryPoints: ['./src/extension.ts'],
+  entryPoints: ['./src/extension.mts'],
   outfile: './out/extension.js',
   external: ['vscode']
 };

--- a/qt-python/src/api.mts
+++ b/qt-python/src/api.mts
@@ -4,8 +4,8 @@ import * as vscode from 'vscode';
 import * as childProcess from 'child_process';
 import { glob } from 'glob';
 
-import * as consts from '@/constants';
-import { projectManager } from './extension';
+import * as consts from '@/constants.js';
+import { projectManager } from './extension.mjs';
 import {
   PYSIDE_MIN_VERSION_RUN_ARGS,
   compareVersions,
@@ -13,8 +13,8 @@ import {
   PySideProject as PySideProjectAPI,
   createLogger
 } from 'qt-lib';
-import { PySideCommandBuilder } from './builder';
-import { PySideProject } from './project';
+import { PySideCommandBuilder } from './builder.js';
+import { PySideProject } from './project.mjs';
 
 const logger = createLogger('api');
 

--- a/qt-python/src/debug.mts
+++ b/qt-python/src/debug.mts
@@ -4,9 +4,9 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import { TaskId } from './types';
-import { findTaskFullName } from './task';
-import * as consts from './constants';
+import { TaskId } from './types.js';
+import { findTaskFullName } from './task.mjs';
+import * as consts from './constants.js';
 
 export class PySideDebugConfigProvider
   implements vscode.DebugConfigurationProvider

--- a/qt-python/src/env.mts
+++ b/qt-python/src/env.mts
@@ -9,10 +9,10 @@ import {
 } from '@vscode/python-extension';
 
 import { isError, OSExeSuffix, createLogger } from 'qt-lib';
-import { PipPackageInfo } from './types';
-import { PySideCommandRunner } from './runner';
-import * as utils from './utils';
-import * as consts from './constants';
+import { PipPackageInfo } from './types.js';
+import { PySideCommandRunner } from './runner.mjs';
+import * as utils from './utils.js';
+import * as consts from './constants.js';
 
 const logger = createLogger('env');
 

--- a/qt-python/src/extension.mts
+++ b/qt-python/src/extension.mts
@@ -15,12 +15,12 @@ import {
   getLogOutputChannel,
   telemetry
 } from 'qt-lib';
-import { PySideTaskProvider } from './task';
-import { PySideDebugConfigProvider } from './debug';
-import { PySideProjectManager } from './project-manager';
-import * as consts from '@/constants';
-import { onInstallPySide6Command } from './installer';
-import { PySideAPIImpl } from './api';
+import { PySideTaskProvider } from './task.mjs';
+import { PySideDebugConfigProvider } from './debug.mjs';
+import { PySideProjectManager } from './project-manager.mjs';
+import * as consts from '@/constants.js';
+import { onInstallPySide6Command } from './installer.mjs';
+import { PySideAPIImpl } from './api.mjs';
 
 const logger = createLogger('extension');
 

--- a/qt-python/src/installer.mts
+++ b/qt-python/src/installer.mts
@@ -11,16 +11,16 @@ import {
   QtInsRootConfigName,
   compareVersions
 } from 'qt-lib';
-import { PySideEnv } from './env';
-import { PySideProject } from './project';
+import { PySideEnv } from './env.mjs';
+import { PySideProject } from './project.mjs';
 import {
   PySideCommandRunner,
   PySideCommandRunOptions as RunOptions
-} from './runner';
-import { coreApi, projectManager } from './extension';
-import { normalizeDriveLetter } from './utils';
-import * as texts from './texts';
-import * as consts from './constants';
+} from './runner.mjs';
+import { coreApi, projectManager } from './extension.mjs';
+import { normalizeDriveLetter } from './utils.js';
+import * as texts from './texts.js';
+import * as consts from './constants.js';
 
 const logger = createLogger('installer');
 

--- a/qt-python/src/project-manager.mts
+++ b/qt-python/src/project-manager.mts
@@ -4,7 +4,7 @@
 import * as vscode from 'vscode';
 
 import { ProjectManager } from 'qt-lib';
-import { PySideProject } from './project';
+import { PySideProject } from './project.mjs';
 
 export class PySideProjectManager extends ProjectManager<PySideProject> {
   constructor(override readonly context: vscode.ExtensionContext) {

--- a/qt-python/src/project.mts
+++ b/qt-python/src/project.mts
@@ -16,11 +16,11 @@ import {
   CoreKey,
   QtWorkspaceFeatures
 } from 'qt-lib';
-import { PySideEnv } from './env';
-import { PySideProjectInfo } from './types';
-import { pyApi, coreApi } from './extension';
-import * as texts from '@/texts';
-import * as consts from '@/constants';
+import { PySideEnv } from './env.mjs';
+import { PySideProjectInfo } from './types.js';
+import { pyApi, coreApi } from './extension.mjs';
+import * as texts from '@/texts.js';
+import * as consts from '@/constants.js';
 
 type Folder = vscode.WorkspaceFolder;
 type Context = vscode.ExtensionContext;

--- a/qt-python/src/runner.mts
+++ b/qt-python/src/runner.mts
@@ -4,8 +4,8 @@
 import * as childProcess from 'child_process';
 
 import { createLogger } from 'qt-lib';
-import { PySideEnv } from './env';
-import { PySideCommandBuilder } from './builder';
+import { PySideEnv } from './env.mjs';
+import { PySideCommandBuilder } from './builder.js';
 
 const logger = createLogger('runner');
 

--- a/qt-python/src/task.mts
+++ b/qt-python/src/task.mts
@@ -4,11 +4,11 @@
 import * as vscode from 'vscode';
 
 import { createLogger } from 'qt-lib';
-import { TaskId, type ProjectToolAction } from './types';
-import { PySideProject } from './project';
-import { projectManager } from './extension';
-import { PySideCommandBuilder } from './builder';
-import * as consts from './constants';
+import { TaskId, type ProjectToolAction } from './types.js';
+import { PySideProject } from './project.mjs';
+import { projectManager } from './extension.mjs';
+import { PySideCommandBuilder } from './builder.js';
+import * as consts from './constants.js';
 
 const logger = createLogger('task');
 

--- a/qt-python/tsconfig.json
+++ b/qt-python/tsconfig.json
@@ -1,8 +1,11 @@
 {
   "compilerOptions": {
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "target": "ES2022",
     "types": ["node"],
     "outDir": "out",


### PR DESCRIPTION
- Convert source files to ESM (.mts) to support ESM-only packages
- ESM packages get-port and promise-socket cannot be imported in CommonJS
- Add explicit .mjs/.js extensions to all imports per node16 requirements
- Update esbuild entry points and test configuration
