### PR TITLE
qt-cpp:natvis-test: revert ignore ##NAMESPACE## prefix in NatVis type…

### DIFF
--- a/qt-cpp/test/debug-golden.mts
+++ b/qt-cpp/test/debug-golden.mts
@@ -438,9 +438,7 @@ function decodeXmlEntities(input: string): string {
     '&quot;': '"',
     '&apos;': "'"
   };
-  const decoded = input.replace(/&(lt|gt|amp|quot|apos);/g, (m) => map[m] ?? m);
-  // NatVis placeholder normalization
-  return decoded.replace(/##NAMESPACE##::/g, '');
+  return input.replace(/&(lt|gt|amp|quot|apos);/g, (m) => map[m] ?? m);
 }
 
 /**


### PR DESCRIPTION
reverts https://github.com/qt-labs/vscodeext/pull/443

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
