### PR TITLE
qt-python:  Make runner timeout optional

### DIFF
--- a/qt-python/src/env.mts
+++ b/qt-python/src/env.mts
@@ -134,7 +134,7 @@ async function runPipShowAndParseInfo(env: PySideEnv, name: string) {
     runner.onStdout(logIndented);
     runner.onStderr(logIndented);
 
-    const lines = await runner.run(`pip show ${name}`, { useVenv: true });
+    const lines = await runner.run(`pip show ${name}`, { useVenv: true, timeoutMs: 5000 });
     lines.forEach((line) => {
       const [key, value] = line.split(': ');
       if (key && value) {

--- a/qt-python/src/runner.mts
+++ b/qt-python/src/runner.mts
@@ -12,6 +12,7 @@ const logger = createLogger('runner');
 export interface PySideCommandRunOptions {
   useVenv?: boolean;
   cwd?: string;
+  timeoutMs?: number;
 }
 
 export class PySideCommandRunner {
@@ -45,10 +46,15 @@ export class PySideCommandRunner {
     const errPromise = streamToLines(proc.stderr, this._onStderr);
 
     await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        proc.kill();
-        reject(new Error('Process timed out after 5 seconds'));
-      }, 3_000);
+      let timeout: NodeJS.Timeout | undefined;
+
+      const timeoutMs = options?.timeoutMs;
+      if (timeoutMs) {
+        timeout = setTimeout(() => {
+          proc.kill();
+          reject(new Error(`Process timed out after ${String(timeoutMs)} milliseconds`));
+        }, timeoutMs);
+      }
 
       proc.on('error', (err) => {
         clearTimeout(timeout);


### PR DESCRIPTION
* When https://github.com/qt-labs/vscodeext/commit/76085795080c2855b0b01d91b072a69d00d7e8a9 was merged, it introduced
a bug where the runner would timeout after 5 seconds when installing
PySide. We should not set a timeout for the runner when running
installation commands, as they can take a long time to complete.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
