### PR TITLE
qt-qml: Use needsStop() instead of isRunning()

### DIFF
--- a/qt-python/src/env.mts
+++ b/qt-python/src/env.mts
@@ -41,10 +41,6 @@ export class PySideEnv {
       : '';
   }
 
-  get interpreterPath(): string | undefined {
-    return this._pyEnv?.executable.uri?.fsPath;
-  }
-
   public async refresh(pyApi: PyApi) {
     const allEnvs = pyApi.environments;
     const activeEnvPath = allEnvs.getActiveEnvironmentPath(this._folder);

--- a/qt-qml/src/qmlls.mts
+++ b/qt-qml/src/qmlls.mts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import { spawnSync } from 'child_process';
 import {
   Trace,
+  State,
   ServerOptions,
   LanguageClient,
   LanguageClientOptions
@@ -222,8 +223,8 @@ export class Qmlls {
       QMLLS_CONFIG,
       this._folder
     );
-    if (this._client?.isRunning()) {
-      logger.info('QML Language Server is already running');
+    if (this._client?.needsStop()) {
+      logger.info('QML Language Server is already running or starting');
       return;
     }
     if (!configs.get<boolean>('enabled', false)) {
@@ -416,18 +417,37 @@ export class Qmlls {
 
   public async stop() {
     if (this._client) {
-      if (this._client.isRunning()) {
+      if (this._client.needsStop()) {
         logger.info(`Stopping QML Language Server: "${this._folder.name}"`);
-        await this._client
-          .stop()
-          .then(() => {
-            logger.info(`QML Language Server stopped: "${this._folder.name}"`);
-          })
-          .catch((e: unknown) => {
-            logger.error(
-              `QML Language Server stop failed: "${this._folder.name}", ${String(e)}`
-            );
-          });
+        // LanguageClient.stop() throws when called in the "starting" state.
+        // Calling start() on an already-starting client is idempotent — it
+        // returns the existing in-progress promise, letting us wait for the
+        // startup to complete before we can safely call stop().
+        if (this._client.state === State.Starting) {
+          logger.info(
+            `Waiting for QML Language Server to finish starting before stopping: "${this._folder.name}"`
+          );
+          try {
+            await this._client.start();
+          } catch {
+            // If start fails, the client transitions to StartFailed state
+            // and no longer needs to be stopped.
+          }
+        }
+        if (this._client.isRunning()) {
+          await this._client
+            .stop()
+            .then(() => {
+              logger.info(
+                `QML Language Server stopped: "${this._folder.name}"`
+              );
+            })
+            .catch((e: unknown) => {
+              logger.error(
+                `QML Language Server stop failed: "${this._folder.name}", ${String(e)}`
+              );
+            });
+        }
       }
 
       this._client = undefined;


### PR DESCRIPTION
When `isRunning()` is used and qmlls is tried to be restarted while
qmlls in the `Starting` state, `isRunning()` returns `false` and qmlls
is restarted, which causes qmlls to be started twice. We should use
`needsStop()` instead, which returns `true` when qmlls is in both
`Starting` and `Running` states.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
