### PR TITLE
qt-qml: warn, instead of abort, if source in stack frame is not found

### DIFF
--- a/qt-qml/src/debug/qml-engine.mts
+++ b/qt-qml/src/debug/qml-engine.mts
@@ -233,6 +233,7 @@ export class QmlEngine extends QmlDebugClient implements IQmlDebugClient {
   private readonly _session: QmlDebugSession;
   private _onShutdownEngine: (() => void) | undefined;
   private readonly _connectionTimer: Timer = new Timer();
+  private readonly _fileNotFoundWarned = new Set<string>();
   constructor(session: QmlDebugSession) {
     super('V8Debugger', new QmlDebugConnection());
     this._ui = new QmlEngineUI();
@@ -463,13 +464,19 @@ export class QmlEngine extends QmlDebugClient implements IQmlDebugClient {
         })
         .map(async (frame) => {
           const physicalPath = await fileFinder.findFile(frame.script);
-          if (!physicalPath) {
-            const err =
+
+          if (!physicalPath && !this._fileNotFoundWarned.has(frame.script)) {
+            const warning =
               `Cannot find physical path for: "${frame.script}".` +
               ' Use "buildDirs" to set the build directories in "launch.json".';
-            throw new Error(err);
+
+            this.ui.showWarning(warning);
+            this._fileNotFoundWarned.add(frame.script);
           }
-          const parsedPath = path.parse(physicalPath);
+
+          const parsedPath = physicalPath
+            ? path.parse(physicalPath)
+            : path.parse(frame.script);
           return new StackFrame(
             frame.index,
             frame.func,

--- a/qt-qml/src/debug/ui.ts
+++ b/qt-qml/src/debug/ui.ts
@@ -53,6 +53,10 @@ export class QmlEngineUI {
     this.removeWaitingForDebugger();
     void vscode.window.showErrorMessage(message);
   }
+  showWarning(message: string) {
+    void this;
+    void vscode.window.showWarningMessage(message);
+  }
   dispose() {
     this.removeWaitingForDebugger();
   }


### PR DESCRIPTION
There's absolutely no need to throw a tantrum when QmlEngine can't find the source file associated with a particular stack frame; only a warning is enough. VSCode debugging UI handle this just fine.

To avoid spamming VSCode window with repetitive warnings, only warn about a particular file once per lifetime of QmlEngine.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
