### PR TITLE
Fix QML Preview issues for pyside projects

### DIFF
--- a/qt-python/src/api.mts
+++ b/qt-python/src/api.mts
@@ -44,6 +44,8 @@ class PySideProjectWrapper implements PySideProjectAPI {
 
     let command = `${consts.PYSIDE_PROJECT_TOOL} run`;
     if (args?.length) {
+      command += ` "${this.folder.uri.fsPath}"`;
+      command += ` -- `;
       command += ` ${args.join(' ')}`;
     }
 

--- a/qt-qml/src/preview/preview.mts
+++ b/qt-qml/src/preview/preview.mts
@@ -250,7 +250,6 @@ async function launchPySidePreview(
   const allArgs = [previewArgs, ...additionalArgs];
 
   try {
-    let proc: ChildProcess | undefined;
     const project = projectManager.getProject(folder);
     const pySideProject = project?.pySideProject;
     if (!pySideProject) {
@@ -259,7 +258,7 @@ async function launchPySidePreview(
     if (pySideProject.supportsProjectRunArgs()) {
       // PySide >= 6.10.3: pass args via pyside6-project run <args>
       logger.info('Using pyside6-project run with args');
-      proc = pySideProject.runProject(allArgs);
+      previewProcess = pySideProject.runProject(allArgs);
     } else {
       // PySide < 6.10.3: replicate pyside6-project run manually:
       // build the project, then run the main file with args.
@@ -294,18 +293,24 @@ async function launchPySidePreview(
         return false;
       }
 
-      proc = pySideProject.runFile(absFilePath, allArgs);
+      previewProcess = pySideProject.runFile(absFilePath, allArgs);
     }
 
-    if (!proc || proc.killed || proc.pid === undefined) {
+    if (
+      !previewProcess ||
+      previewProcess.killed ||
+      previewProcess.pid === undefined
+    ) {
       logger.error('Failed to start PySide preview process');
       manager.dispose();
       ui.showFailedToStart(new Error('Process failed to start'));
       return false;
     }
-    logger.info(`PySide preview process started with PID: ${String(proc.pid)}`);
+    logger.info(
+      `PySide preview process started with PID: ${String(previewProcess.pid)}`
+    );
 
-    setupProcessForPreview(proc, manager, qmlFile, host, port);
+    setupProcessForPreview(previewProcess, manager, qmlFile, host, port);
     return true;
   } catch (err) {
     logger.error(`Failed to start PySide preview: ${String(err)}`);


### PR DESCRIPTION
* Since `--` was missing, we were not able to pass any arguments to the
command. This commit adds the missing `--` to fix the issue.

* When QML preview was tried to be stopped for pyside projects, it was
not working because the process was not being tracked correctly.
To fix that, we should use the same implementation as in C++ projects.
<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
