### PR TITLE
qt-core: Assign tab icons for web views

### DIFF
--- a/qt-core/src/webview/ex-browser/controller.ts
+++ b/qt-core/src/webview/ex-browser/controller.ts
@@ -11,7 +11,8 @@ import {
   WebviewAppConfig,
   createWebviewHtml,
   createWebviewOptions,
-  basicWebviewAppConfig
+  basicWebviewAppConfig,
+  createWebviewPanelIcons
 } from '@/webview/utils';
 import * as texts from '@/texts';
 import { ExDataManager } from './data-manager';
@@ -61,6 +62,7 @@ export class ExBrowserController {
       ]
     };
 
+    panel.iconPath = createWebviewPanelIcons(context);
     panel.webview.html = createWebviewHtml(panel.webview, config);
     panel.webview.options = createWebviewOptions(config);
 

--- a/qt-core/src/webview/new-item/panel.ts
+++ b/qt-core/src/webview/new-item/panel.ts
@@ -11,7 +11,8 @@ import * as texts from '@/texts';
 import {
   createWebviewHtml,
   createWebviewOptions,
-  basicWebviewAppConfig
+  basicWebviewAppConfig,
+  createWebviewPanelIcons
 } from '@/webview/utils';
 import { EXTENSION_ID } from '@/constants';
 import { QtcliRestServer, generateSocketId } from '@/qtcli/rest';
@@ -51,6 +52,7 @@ export class NewItemPanel {
       ...basicWebviewAppConfig
     };
 
+    panel.iconPath = createWebviewPanelIcons(context);
     panel.webview.html = createWebviewHtml(panel.webview, config);
     panel.webview.options = createWebviewOptions(config);
 

--- a/qt-core/src/webview/qml-trace/editor-provider.ts
+++ b/qt-core/src/webview/qml-trace/editor-provider.ts
@@ -16,7 +16,8 @@ import { EXTENSION_ID } from '@/constants';
 import {
   createWebviewHtml,
   createWebviewOptions,
-  basicWebviewAppConfig
+  basicWebviewAppConfig,
+  createWebviewPanelIcons
 } from '@/webview/utils';
 import { QtcliRestServer, generateSocketId } from '@/qtcli/rest';
 import { QmlTraceDoc } from './doc';
@@ -66,9 +67,9 @@ class QmlTraceProvider implements CustomReadonlyEditorProvider<QmlTraceDoc> {
       ...basicWebviewAppConfig
     };
 
-    const view = panel.webview;
-    view.html = createWebviewHtml(view, config);
-    view.options = createWebviewOptions(config);
+    panel.iconPath = createWebviewPanelIcons(this._context);
+    panel.webview.html = createWebviewHtml(panel.webview, config);
+    panel.webview.options = createWebviewOptions(config);
 
     // controller
     const socketId = generateSocketId('qml-trace');
@@ -77,7 +78,7 @@ class QmlTraceProvider implements CustomReadonlyEditorProvider<QmlTraceDoc> {
 
     const controller = new QmlTraceController(
       doc,
-      view,
+      panel.webview,
       qtcliServer.socketName,
       this._context
     );

--- a/qt-core/src/webview/qrc-editor/editor-provider.ts
+++ b/qt-core/src/webview/qrc-editor/editor-provider.ts
@@ -17,7 +17,8 @@ import { EXTENSION_ID } from '@/constants';
 import {
   createWebviewHtml,
   createWebviewOptions,
-  basicWebviewAppConfig
+  basicWebviewAppConfig,
+  createWebviewPanelIcons
 } from '@/webview/utils';
 import { QrcDocsManager } from './docs-manager';
 import { QrcEditorController } from './controller';
@@ -97,16 +98,16 @@ class QrcEditorProvider implements CustomTextEditorProvider {
       ...basicWebviewAppConfig
     };
 
-    const view = panel.webview;
-    view.html = createWebviewHtml(view, config);
-    view.options = createWebviewOptions(config);
+    panel.iconPath = createWebviewPanelIcons(this._context);
+    panel.webview.html = createWebviewHtml(panel.webview, config);
+    panel.webview.options = createWebviewOptions(config);
 
     // doc
     this._docsManager.add(doc);
 
     // controller
     const controller = new QrcEditorController(
-      view,
+      panel.webview,
       this._docsManager,
       doc.uri.fsPath
     );


### PR DESCRIPTION
Set icons for the panel options of several web views:
- QRC Editor
- Example Browser
- New Item Wizard
- QML Trace Viewer

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
