### PR TITLE
qt-python: add uv support 

### DIFF
--- a/qt-python/ThirdPartyNotices.txt
+++ b/qt-python/ThirdPartyNotices.txt
@@ -911,6 +911,36 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------------------------
 
+command-exists 1.2.9 - MIT
+https://github.com/mathisonian/command-exists#readme
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Matthew Conlen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 cross-spawn 7.0.6 - MIT
 https://github.com/moxystudio/node-cross-spawn#readme
 

--- a/qt-python/package-lock.json
+++ b/qt-python/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.15.0",
       "dependencies": {
         "@vscode/python-extension": "^1.0.5",
+        "command-exists": "^1.2.9",
         "glob": "^12.0.0",
         "lodash": "^4.17.21",
         "module-alias": "^2.2.3",
@@ -20,6 +21,7 @@
         "@eslint/eslintrc": "^3.3.0",
         "@eslint/js": "^9.21.0",
         "@types/chai": "^5.2.3",
+        "@types/command-exists": "^1.2.3",
         "@types/lodash": "^4.17.16",
         "@types/mocha": "^10.0.10",
         "@types/node": "^20.17.0",
@@ -3621,6 +3623,13 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/command-exists": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-exists/-/command-exists-1.2.3.tgz",
+      "integrity": "sha512-PpbaE2XWLaWYboXD6k70TcXO/OdOyyRFq5TVpmlUELNxdkkmXU9fkImNosmXU1DtsNrqdUgWd/nJQYXgwmtdXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4732,6 +4741,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/command-exists": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "12.1.0",

--- a/qt-python/package.json
+++ b/qt-python/package.json
@@ -46,6 +46,12 @@
           "default": false,
           "description": "Do not warn about old-style projects",
           "scope": "machine-overridable"
+        },
+        "qt-python.preferUv": {
+          "type": "boolean",
+          "default": false,
+          "description": "Prefer uv for creating virtual environments when uv is available on PATH",
+          "scope": "machine-overridable"
         }
       }
     },
@@ -54,12 +60,21 @@
         "command": "qt-python.installPySide6",
         "title": "%qt-python.command.installPySide6.title%",
         "category": "Qt-Python"
+      },
+      {
+        "command": "qt-python.createUvEnv",
+        "title": "%qt-python.command.createUvEnv.title%",
+        "category": "Qt-Python"
       }
     ],
     "menus": {
       "commandPalette": [
         {
           "command": "qt-python.installPySide6",
+          "when": "workspaceFolderCount > 0"
+        },
+        {
+          "command": "qt-python.createUvEnv",
           "when": "workspaceFolderCount > 0"
         }
       ]
@@ -174,6 +189,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^20.17.0",
     "@types/vscode": "^1.94.0",
+    "@types/command-exists": "^1.2.3",
     "@typescript-eslint/eslint-plugin": "^7.6.0",
     "@typescript-eslint/parser": "^7.6.0",
     "@vscode/test-electron": "^2.5.2",
@@ -189,6 +205,7 @@
   },
   "dependencies": {
     "@vscode/python-extension": "^1.0.5",
+    "command-exists": "^1.2.9",
     "glob": "^12.0.0",
     "lodash": "^4.17.21",
     "module-alias": "^2.2.3",

--- a/qt-python/package.nls.json
+++ b/qt-python/package.nls.json
@@ -1,5 +1,6 @@
 {
   "qt-python.command.installPySide6.title": "Install PySide6",
+  "qt-python.command.createUvEnv.title": "Create virtual environment with uv",
   "qt-python.debug.launch.label": "Qt: PySide: Launch",
   "qt-python.debug.launch.description": "Launch a PySide application"
 }

--- a/qt-python/src/constants.ts
+++ b/qt-python/src/constants.ts
@@ -10,6 +10,7 @@ export const LOG_NAME = 'qt-python';
 export const COMMAND_PREFIX = 'qt-python';
 export const COMMAND_SHOW_LOG = 'showLogOutputChannel';
 export const COMMAND_INSTALL_PYSIDE = 'installPySide6'; // contributes > commands
+export const COMMAND_CREATE_UV_ENV = 'createUvEnv'; // contributes > commands
 export const COMMAND_PYTHON_CREATE_ENV = 'python.createEnvironment';
 export const COMMAND_PYTHON_SELECT_PYTHON = 'python.setInterpreter';
 export const COMMAND_RESTART_QMLLS = 'qt-qml.restartQmlls';
@@ -31,5 +32,8 @@ export const TOML_KEY_PROJECT_FILES = 'tool.pyside6-project.files';
 export const PYSIDE_PROJECT_TOOL = 'pyside6-project';
 export const MAINT_WHEEL_DIR_NAME = 'QtForPython';
 
+export const UV_DEFAULT_VENV_DIR = '.venv';
+
 // contributes > configruation
+export const CONFIG_PREFER_UV = 'preferUv';
 export const CONFIG_DO_NOT_WARN_OLD_PROJECTS = 'doNotWarnAboutOldStyleProjects';

--- a/qt-python/src/extension.mts
+++ b/qt-python/src/extension.mts
@@ -19,7 +19,7 @@ import { PySideTaskProvider } from './task.mjs';
 import { PySideDebugConfigProvider } from './debug.mjs';
 import { PySideProjectManager } from './project-manager.mjs';
 import * as consts from '@/constants.js';
-import { onInstallPySide6Command } from './installer.mjs';
+import { onInstallPySide6Command, onCreateUvEnvCommand } from './installer.mjs';
 import { PySideAPIImpl } from './api.mjs';
 
 const logger = createLogger('extension');
@@ -100,7 +100,8 @@ function initCommands(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     register(consts.COMMAND_SHOW_LOG, onShowLog, false),
-    register(consts.COMMAND_INSTALL_PYSIDE, onInstallPySide6Command)
+    register(consts.COMMAND_INSTALL_PYSIDE, onInstallPySide6Command),
+    register(consts.COMMAND_CREATE_UV_ENV, onCreateUvEnvCommand)
   );
 }
 

--- a/qt-python/src/installer.mts
+++ b/qt-python/src/installer.mts
@@ -3,11 +3,14 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import * as childProcess from 'child_process';
+import * as commandExists from 'command-exists';
 import * as vscode from 'vscode';
 
 import {
   CoreKey,
   createLogger,
+  OSExeSuffix,
   QtInsRootConfigName,
   compareVersions
 } from 'qt-lib';
@@ -17,7 +20,7 @@ import {
   PySideCommandRunner,
   PySideCommandRunOptions as RunOptions
 } from './runner.mjs';
-import { coreApi, projectManager } from './extension.mjs';
+import { coreApi, projectManager, pyApi } from './extension.mjs';
 import { normalizeDriveLetter } from './utils.js';
 import * as texts from './texts.js';
 import * as consts from './constants.js';
@@ -121,14 +124,28 @@ async function showMessageOrInstall(result: CheckResult) {
   if (result.status === 'noVenv') {
     const msg = texts.install.popup.noVenv(result.folder.name);
     const btnCreate = texts.install.popup.buttonCreateEnv;
+    const btnCreateUv = texts.install.popup.buttonCreateUvEnv;
     const btnSelect = texts.install.popup.buttonSelectEnv;
 
+    const preferUv = vscode.workspace
+      .getConfiguration(consts.COMMAND_PREFIX)
+      .get<boolean>(consts.CONFIG_PREFER_UV, false);
+
+    const uvAvailable = isUvAvailable();
+    const buttons = uvAvailable
+      ? preferUv
+        ? [btnCreateUv, btnCreate, btnSelect]
+        : [btnCreate, btnCreateUv, btnSelect]
+      : [btnCreate, btnSelect];
+
     void vscode.window
-      .showWarningMessage(msg, btnCreate, btnSelect)
+      .showWarningMessage(msg, ...buttons)
       .then((value) => {
         const exec = vscode.commands.executeCommand;
         if (value === btnCreate) {
           void exec(consts.COMMAND_PYTHON_CREATE_ENV);
+        } else if (value === btnCreateUv) {
+          void createUvVenv(result.folder);
         } else if (value === btnSelect) {
           void exec(consts.COMMAND_PYTHON_SELECT_PYTHON);
         }
@@ -325,3 +342,98 @@ async function getLocalPackageInfo(insRoot: string, env: PySideEnv) {
 const info = (folder: vscode.WorkspaceFolder, ...message: string[]) => {
   logger.info(`(${folder.name}) `, ...message);
 };
+
+function isUvAvailable(): boolean {
+  return commandExists.sync('uv');
+}
+
+async function createUvVenv(folder: vscode.WorkspaceFolder) {
+  if (!isUvAvailable()) {
+    void vscode.window.showWarningMessage(texts.install.popup.uvNotFound);
+    return;
+  }
+
+  const venvDir = consts.UV_DEFAULT_VENV_DIR;
+  const cwd = folder.uri.fsPath;
+
+  const venvPath = path.join(cwd, venvDir);
+  if (fs.existsSync(venvPath)) {
+    const overwrite = await vscode.window.showWarningMessage(
+      texts.install.popup.uvVenvExists(folder.name, venvDir),
+      texts.install.popup.buttonOverwrite,
+      texts.install.popup.buttonCancel
+    );
+    if (overwrite !== texts.install.popup.buttonOverwrite) {
+      return;
+    }
+  }
+
+  const linkText = texts.install.popup.linkShowLog;
+  const linkCommand = `${consts.COMMAND_PREFIX}.${consts.COMMAND_SHOW_LOG}`;
+  const linkShowLogs = `[${linkText}](command:${linkCommand})`;
+
+  const options = {
+    location: vscode.ProgressLocation.Notification,
+    cancellable: false
+  };
+
+  await vscode.window.withProgress(options, async (progress) => {
+    try {
+      progress.report({
+        message: `${texts.install.popup.creatingUvVenv} (${linkShowLogs})`
+      });
+
+      info(folder, `Creating uv venv in ${venvDir}`);
+      await runSimpleCommand(`uv venv --seed ${venvDir}`, cwd);
+      info(folder, 'uv venv created');
+
+      if (pyApi) {
+        const pythonPath = path.join(
+          cwd,
+          venvDir,
+          consts.VENV_BIN_DIR,
+          'python' + OSExeSuffix
+        );
+        await pyApi.environments.updateActiveEnvironmentPath(
+          pythonPath,
+          folder
+        );
+        info(folder, `Active environment set to ${pythonPath}`);
+        await projectManager.refreshProjectEnv(folder);
+      }
+
+      void vscode.window.showInformationMessage(
+        texts.install.popup.uvVenvCreated(folder.name, venvDir)
+      );
+    } catch (e) {
+      logger.error(`Failed to create uv venv: ${String(e)}`);
+      void vscode.window.showWarningMessage(
+        texts.install.popup.uvVenvFailed(folder.name) +
+          ` (${linkShowLogs})`
+      );
+    }
+  });
+}
+
+export async function onCreateUvEnvCommand() {
+  const selected = await selectTargetProject();
+  if (!selected) {
+    return;
+  }
+
+  await createUvVenv(selected.folder);
+}
+
+// run a command and get the output as a promise. basically a wrapper around child_process.exec
+async function runSimpleCommand(command: string, cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    childProcess.exec(command, { cwd }, (error, stdout, stderr) => {
+      if (error) {
+        logger.error(`Command failed: ${command}\n${stderr}`);
+        reject(error);
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}

--- a/qt-python/src/texts.ts
+++ b/qt-python/src/texts.ts
@@ -18,8 +18,21 @@ export const install = {
       `Cannot find a virtual environment for '${folder}'. ` +
       'Create or select a virtual environment first',
     buttonCreateEnv: 'Create environment',
+    buttonCreateUvEnv: 'Create with uv',
     buttonSelectEnv: 'Select interpreter',
-    linkShowLog: 'Show logs'
+    linkShowLog: 'Show logs',
+    creatingUvVenv: 'Creating virtual environment with uv...',
+    uvVenvCreated: (folder: string, venv: string) =>
+      `Virtual environment '${venv}' created for '${folder}' using uv`,
+    uvVenvFailed: (folder: string) =>
+      `Cannot create virtual environment for '${folder}' using uv`,
+    uvNotFound:
+      'uv is not installed or not on PATH. ' +
+      'Install it from https://docs.astral.sh/uv/ or use the standard environment creator instead',
+    uvVenvExists: (folder: string, venv: string) =>
+      `Virtual environment '${venv}' already exists in '${folder}'. Overwrite it?`,
+    buttonOverwrite: 'Overwrite',
+    buttonCancel: 'Cancel'
   },
   placeHolder: {
     selectFolder: 'Select a folder',


### PR DESCRIPTION
This PR adds support for uv (https://docs.astral.sh/uv/). It is currently the most popular Python package and environment manager, known for being extremely fast and a drop-in replacement for pip/venv.

Summary of chhanges:
- New setting qt-python.preferUv. When enabled, the uv option is shown as the primary action in the "no venv" prompt
- New command qt-python: Create uv Virtual Environment 
- when no venv is detected, the "Install PySide6" prompt now offers a "Create uv venv" button alongside the existing venv/interpreter options in the warning message in the bottom