### PR TITLE
qt-core: No need to check return value of commandExists.sync

### DIFF
--- a/qt-core/src/vcpkg.ts
+++ b/qt-core/src/vcpkg.ts
@@ -69,10 +69,7 @@ function containsQtPath(qtPath: string, additionalQtPaths: QtAdditionalPath[]) {
 }
 
 function isVCPKGInstalled(): boolean {
-  if (commandExists.sync('vcpkg')) {
-    return true;
-  }
-  return false;
+  return commandExists.sync('vcpkg');
 }
 
 function getDoNotAskForVCPKG(): boolean {


### PR DESCRIPTION
It already returns a boolean, so we can directly return.
