### PR TITLE
qt-core/qt-cpp/qt-ui: Propagate qtpaths execution errors from getQtInfo

### DIFF
--- a/qt-core/src/api.ts
+++ b/qt-core/src/api.ts
@@ -12,6 +12,7 @@ import {
   QtWorkspaceConfig,
   QtWorkspaceConfigMessage,
   QtInfo,
+  QtInfoResult,
   QtAdditionalPath,
   ConfigType
 } from 'qt-lib';
@@ -152,15 +153,15 @@ export class CoreAPIImpl implements CoreAPI {
   // kit configuration. So, we should be able to obtain the QtInfo from the path
   // directly. `getQtInfoFromPath` might lose some information like the name of
   // the kit, and whether it is a VCPKG kit or not.
-  getQtInfoFromPath(qtPathsExe: string): QtInfo | undefined {
+  getQtInfoFromPath(qtPathsExe: string): QtInfoResult {
     return this.getQtInfo({ path: qtPathsExe });
   }
-  getQtInfo(qtAdditionalPath: QtAdditionalPath): QtInfo | undefined {
+  getQtInfo(qtAdditionalPath: QtAdditionalPath): QtInfoResult {
     let result = this._qtInfoCache.get(qtAdditionalPath.path);
     if (result) {
       result.name = qtAdditionalPath.name;
       result.isVCPKG = qtAdditionalPath.isVCPKG;
-      return result;
+      return { info: result };
     }
 
     result = new QtInfo(
@@ -182,8 +183,15 @@ export class CoreAPIImpl implements CoreAPI {
           timeout: 1000
         }
       );
-      if (retOldQtPaths.error ?? retOldQtPaths.status !== 0) {
-        return undefined;
+      if (retOldQtPaths.error) {
+        return { err: retOldQtPaths.error };
+      }
+      if (retOldQtPaths.status !== 0) {
+        return {
+          err: new Error(
+            `"${qtAdditionalPath.path} --binaries-dir" exited with code ${String(retOldQtPaths.status)}`
+          )
+        };
       }
       const outputOldQtPaths = retOldQtPaths.stdout;
       const qmakePath = path.join(outputOldQtPaths.trim(), 'qmake');
@@ -191,12 +199,25 @@ export class CoreAPIImpl implements CoreAPI {
         encoding: 'utf8',
         timeout: 1000
       });
-      if (retQmake.error ?? retQmake.status !== 0) {
-        return undefined;
+      if (retQmake.error) {
+        return { err: retQmake.error };
+      }
+      if (retQmake.status !== 0) {
+        return {
+          err: new Error(
+            `"${qmakePath} -query" exited with code ${String(retQmake.status)}`
+          )
+        };
       }
       output = retQmake.stdout;
-    } else if (retFristTry.error ?? retFristTry.status !== 0) {
-      return undefined;
+    } else if (retFristTry.error) {
+      return { err: retFristTry.error };
+    } else if (retFristTry.status !== 0) {
+      return {
+        err: new Error(
+          `"${qtAdditionalPath.path} -query" exited with code ${String(retFristTry.status)}`
+        )
+      };
     } else {
       output = retFristTry.stdout;
     }
@@ -250,6 +271,6 @@ export class CoreAPIImpl implements CoreAPI {
       result.set('MSVC_PATCH_VERSION', msvcVersion.patch.toString());
     }
     this._qtInfoCache.set(qtAdditionalPath.path, result);
-    return result;
+    return { info: result };
   }
 }

--- a/qt-core/src/qtpaths.ts
+++ b/qt-core/src/qtpaths.ts
@@ -67,12 +67,13 @@ export function checkQtpathsInEnvPath(): void {
     logger.info('No qtpaths or qmake found in PATH');
     return;
   }
-  const info = coreAPI?.getQtInfo({ path: exePath });
-  if (!info) {
+  const ret = coreAPI?.getQtInfo({ path: exePath });
+  if (!ret?.info) {
     logger.error(`Failed to get Qt info for ${exePath}`);
+    logger.error(String(ret?.err));
     return;
   }
-  const name = generateDefaultQtPathsName(info) + '_from_PATH';
+  const name = generateDefaultQtPathsName(ret.info) + '_from_PATH';
   const qtPath: QtAdditionalPath = { path: exePath, name: name };
   const currentQtPaths = getCurrentGlobalAdditionalQtPaths();
   if (currentQtPaths.some((p) => p.path === qtPath.path)) {
@@ -92,7 +93,7 @@ export function addQtPathToSettings(qtPath: QtAdditionalPath) {
     AdditionalQtPathsName
   );
   let valueToSet: (string | object)[] = [];
-  const info = coreAPI?.getQtInfo(qtPath);
+  const info = coreAPI?.getQtInfo(qtPath).info;
   if (!info) {
     throw new Error(`Failed to get Qt info for ${qtPath.path}`);
   }

--- a/qt-core/src/translation.ts
+++ b/qt-core/src/translation.ts
@@ -115,7 +115,7 @@ function getLinguistExePath(selectedQtBinPath: string) {
 }
 
 async function locateLinguistFromQtPaths(selectedQtPaths: string) {
-  const qtInfo = coreAPI?.getQtInfoFromPath(selectedQtPaths);
+  const qtInfo = coreAPI?.getQtInfoFromPath(selectedQtPaths).info;
   if (!qtInfo) {
     return undefined;
   }

--- a/qt-core/src/webview/ex-browser/helpers.ts
+++ b/qt-core/src/webview/ex-browser/helpers.ts
@@ -42,8 +42,8 @@ export function findAllPackagePools(): ExPackagePoolDir[] {
 
   getCurrentGlobalAdditionalQtPaths().forEach((p) => {
     const info = coreAPI?.getQtInfoFromPath(p.path);
-    if (info) {
-      const docs = info.get('QT_INSTALL_DOCS'); // .../Qt/Docs/Qt-x.y.z
+    if (info?.info) {
+      const docs = info.info.get('QT_INSTALL_DOCS'); // .../Qt/Docs/Qt-x.y.z
       const parent = docs ? path.dirname(path.dirname(docs)) : '';
 
       found.push({

--- a/qt-core/test/helper.mts
+++ b/qt-core/test/helper.mts
@@ -593,7 +593,7 @@ export function setupGetQtInfoStub(
   coreAPI: CoreAPI,
   qtInfo: QtInfo
 ): sinon.SinonStub {
-  return sb.stub(coreAPI, 'getQtInfo').returns(qtInfo);
+  return sb.stub(coreAPI, 'getQtInfo').returns({ info: qtInfo });
 }
 
 // Cache the in-flight or resolved CoreAPIImpl so repeated calls are fast

--- a/qt-cpp/src/commands/launch-variables.ts
+++ b/qt-cpp/src/commands/launch-variables.ts
@@ -93,7 +93,7 @@ function getQtDirFromQtPaths(pathsExe: string, toolchainFile?: string) {
     }
     return false;
   };
-  const info = coreAPI?.getQtInfoFromPath(pathsExe);
+  const info = coreAPI?.getQtInfoFromPath(pathsExe).info;
   const paths: string[] = [];
   if (info) {
     const keys = info.data;
@@ -205,7 +205,7 @@ export function registerKitDirectoryCommand() {
 }
 
 async function findQtPluginPath(qtpaths: string) {
-  const info = coreAPI?.getQtInfoFromPath(qtpaths);
+  const info = coreAPI?.getQtInfoFromPath(qtpaths).info;
   if (info) {
     const buildType = await vscode.commands.executeCommand('cmake.buildType');
     let pluginPath = info.get('QT_INSTALL_PLUGINS');
@@ -280,7 +280,7 @@ function isVCPKGToolchainFile(toolchainFile: string) {
 }
 
 async function getQmlImportPathFromQtPaths(qtpaths: string) {
-  const info = coreAPI?.getQtInfoFromPath(qtpaths);
+  const info = coreAPI?.getQtInfoFromPath(qtpaths).info;
   if (!info) {
     return undefined;
   }

--- a/qt-cpp/src/commands/natvis.ts
+++ b/qt-cpp/src/commands/natvis.ts
@@ -61,7 +61,7 @@ export function registerNatvisCommand() {
           throw new Error(error);
         }
         const qtInfo = coreAPI?.getQtInfoFromPath(qtpaths);
-        const majorVersion = qtInfo?.get('QT_VERSION')?.split('.')[0];
+        const majorVersion = qtInfo?.info?.get('QT_VERSION')?.split('.')[0];
         if (!majorVersion) {
           throw new Error('Cannot determine the major version');
         }

--- a/qt-cpp/src/kit-manager.ts
+++ b/qt-cpp/src/kit-manager.ts
@@ -336,13 +336,19 @@ export class KitManager {
       : undefined;
     for (const p of qtPaths) {
       const qtInfo = coreAPI?.getQtInfo(p);
-      if (!qtInfo) {
-        const warningMessage = `qtPaths info not found for "${p.path}".`;
+      if (!qtInfo?.info) {
+        let warningMessage = `qtPaths info not found for "${p.path}".`;
+        if (qtInfo?.err) {
+          warningMessage += ` Error: "${qtInfo.err.message}"`;
+        }
         void vscode.window.showWarningMessage(warningMessage);
         logger.info(warningMessage);
         continue;
       }
-      const kit = KitManager.generateKitFromQtInfo(qtInfo, await cmakeKits);
+      const kit = KitManager.generateKitFromQtInfo(
+        qtInfo.info,
+        await cmakeKits
+      );
       for await (const k of kit) {
         logger.info('newKit: ' + JSON.stringify(k));
         if (k) {
@@ -981,7 +987,7 @@ function analyzeToolchain(kit: Kit) {
     // TODO: parse qconfig.pri to get more detailed info
     if (!toolchainType) {
       const qtInfo = coreAPI?.getQtInfoFromPath(qtpaths);
-      toolchainType = qtInfo?.get('QMAKE_XSPEC');
+      toolchainType = qtInfo?.info?.get('QMAKE_XSPEC');
     }
   }
 

--- a/qt-cpp/src/util/get-qt-paths.ts
+++ b/qt-cpp/src/util/get-qt-paths.ts
@@ -41,8 +41,8 @@ export function mangleQtInstallation(qtInsRoot: string, installation: string) {
   const qtPaths = findQtPathsInInstallationPath(installation);
   if (qtPaths) {
     const qtInfo = coreAPI?.getQtInfoFromPath(qtPaths);
-    if (qtInfo) {
-      const archInfo = getArchInfoFromQtInfo(qtInfo);
+    if (qtInfo?.info) {
+      const archInfo = getArchInfoFromQtInfo(qtInfo.info);
       if (archInfo) {
         return kitName + '-' + archInfo;
       }

--- a/qt-cpp/src/util/util.ts
+++ b/qt-cpp/src/util/util.ts
@@ -38,7 +38,7 @@ export function QtVersionFromKit(kit: Kit) {
   const qtPathsExe = getQtPathsExe(kit);
   if (qtPathsExe) {
     const qtInfo = coreAPI?.getQtInfoFromPath(qtPathsExe);
-    return qtInfo?.get('QT_VERSION');
+    return qtInfo?.info?.get('QT_VERSION');
   }
   return undefined;
 }

--- a/qt-lib/src/core-api.ts
+++ b/qt-lib/src/core-api.ts
@@ -88,6 +88,11 @@ export class QtInfo {
   }
 }
 
+export interface QtInfoResult {
+  info?: QtInfo;
+  err?: Error;
+}
+
 export interface CoreAPI {
   notify(config: QtWorkspaceConfigMessage): void;
   getValue<T>(
@@ -100,8 +105,8 @@ export interface CoreAPI {
     value: ConfigType
   ): void;
   onValueChanged: vscode.Event<QtWorkspaceConfigMessage>;
-  getQtInfo(qtPathsExecutable: QtAdditionalPath): QtInfo | undefined;
-  getQtInfoFromPath(qtPathsExe: string): QtInfo | undefined;
+  getQtInfo(qtPathsExecutable: QtAdditionalPath): QtInfoResult;
+  getQtInfoFromPath(qtPathsExe: string): QtInfoResult;
   reset(): void;
 }
 

--- a/qt-qml/src/project.mts
+++ b/qt-qml/src/project.mts
@@ -178,7 +178,7 @@ export class QMLProject implements Project {
     this.qmlls.clearImportPaths();
     this.qmlls.docsPath = undefined;
     if (this.qtpathsExe) {
-      const info = coreAPI?.getQtInfoFromPath(this.qtpathsExe);
+      const info = coreAPI?.getQtInfoFromPath(this.qtpathsExe).info;
       if (!info) {
         throw new Error('Cannot find Qt info');
       }

--- a/qt-ui/src/util.ts
+++ b/qt-ui/src/util.ts
@@ -46,7 +46,7 @@ export async function locateDesignerFromKit(
 }
 
 export async function locateDesignerFromQtPaths(qtPaths: string) {
-  const info = coreAPI?.getQtInfoFromPath(qtPaths);
+  const info = coreAPI?.getQtInfoFromPath(qtPaths).info;
   if (!info) {
     return undefined;
   }


### PR DESCRIPTION
Previously, getQtInfo/getQtInfoFromPath returned undefined both when the
qtpaths executable could not be launched (e.g. ENOENT, EACCES) and when
it exited with a non-zero status, losing the underlying error.

Add a QtInfoResult interface in qt-lib with optional info and err fields.

Update getQtInfo and getQtInfoFromPath so they always return a
QtInfoResult. If something goes wrong (like a process error or non-zero
exit code), return an Error in the err field. If it works, put the
result in the info field.

Then update all the code that uses these functions in qt-core, qt-cpp,
and qt-ui to follow this new format.
