### PR TITLE
qt-cli: Add ARM64 builds

### DIFF
--- a/qt-cli/.goreleaser.yaml
+++ b/qt-cli/.goreleaser.yaml
@@ -29,11 +29,6 @@ builds:
       {{- .Arch }}-
       {{- .Version }}/qtcli
     no_unique_dist_dir: true
-    ignore:
-      - goos: linux
-        goarch: arm64
-      - goos: windows
-        goarch: arm64
 
 universal_binaries:
   - name_template: qtcli

--- a/qt-core/src/qtcli/commands.ts
+++ b/qt-core/src/qtcli/commands.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import { exists } from 'qt-lib';
+import { exists, IsArm64 } from 'qt-lib';
 import { EXTENSION_ID } from '@/constants';
 import {
   qtcliExeName,
@@ -56,9 +56,11 @@ function findQtcliOsPrefix(): string {
   const platform = process.platform;
 
   if (platform === 'win32') {
-    return 'qtcli-windows-';
-  } else if (platform === 'darwin' || platform === 'linux') {
-    return `qtcli-${platform}-`;
+    return `qtcli-windows-${IsArm64 ? 'arm64-' : 'amd64-'}`;
+  } else if (platform === 'linux') {
+    return `qtcli-linux-${IsArm64 ? 'arm64-' : 'amd64-'}`;
+  } else if (platform === 'darwin') {
+    return 'qtcli-darwin-all-';
   } else {
     throw new Error(`Platform '${platform}' is not supported`);
   }


### PR DESCRIPTION
Update qt-cli build settings to produce two additional binaries:
- Linux ARM64
- Windows ARM64

Update the code for locating qt-cli binaries accordingly.

Task-Number: [VSCODEEXT-211](https://qt-project.atlassian.net/browse/VSCODEEXT-211)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
