### PR TITLE
qt-cli: Add and reorganize documentation

### DIFF
--- a/qt-cli/README.md
+++ b/qt-cli/README.md
@@ -55,7 +55,7 @@ $ ./qtcli new myapp
   → [Default] @projects/cpp/console
     [Default] @projects/cpp/qtquick
     [Default] @projects/cpp/qwidget
-    [Manually select features]     
+    [Manually select features]
 
   Use the arrow keys to move, Enter to select.
 ```
@@ -72,10 +72,10 @@ For example, to create a `myasset.qrc`, run `qtcli` with `new-file myasset` (wit
 $ ./qtcli new-file myasset
 ? Pick a preset
 
-    [Default] @types/qml      
-  → [Default] @types/qrc      
-    [Default] @types/ts       
-    [Default] @types/ui       
+    [Default] @types/qml
+  → [Default] @types/qrc
+    [Default] @types/ts
+    [Default] @types/ui
     [Manually select features]
 
   Use the arrow keys to move, Enter to select.
@@ -108,7 +108,7 @@ $ ./qtcli new myapp
 ✔ Use translation: Yes
 ✔ Target language (e.g. de, ko_KR): de
 ✔ Save for later use? Yes
-? Enter the preset name: my_console_app 
+? Enter the preset name: my_console_app
 ```
 
 The `my_console_app` preset will be at the top of the list next time you run `qtcli`.
@@ -118,10 +118,10 @@ $ ./qtcli new myapp2
 ? Pick a preset
 
   → my_console_app (projects/cpp/console)
-    [Default] @projects/cpp/console      
-    [Default] @projects/cpp/qtquick      
-    [Default] @projects/cpp/qwidget      
-    [Manually select features]           
+    [Default] @projects/cpp/console
+    [Default] @projects/cpp/qtquick
+    [Default] @projects/cpp/qwidget
+    [Manually select features]
 
   Use the arrow keys to move, Enter to select.
 ```
@@ -164,7 +164,7 @@ Select `qtcli preset --help` for more details.
 
 ## Development
 
-For more information about developing the Qt CLI tool, see [Development.md](Development.md).
+For more information about developing the Qt CLI tool, see [Development.md](./docs/Development.md).
 
 ## Issues
 

--- a/qt-cli/docs/Development.md
+++ b/qt-cli/docs/Development.md
@@ -80,3 +80,58 @@ Then run the tests in the `tests/e2e` directory.
 $ go build -C ./src -o ../tests
 $ go test -C ./tests/e2e -v
 ```
+
+## run.sh
+
+Use `run.sh` bash script to make frequent tasks easier.
+For example, use the `build` command to build qtcli for multiple platforms at once.
+
+```bash
+$ ./run.sh build
+```
+
+On your first build, you can install go packages/tools using `install-tools` command.
+```bash
+$ ./run.sh install-tools
+$ ./run.sh build
+```
+
+The `qtcli` command is useful when you want to quickly rebuild and run it with
+some arguments in one go,
+
+```bash
+$ ./run.sh qtcli preset ls
+>>> Building binaries...
+[Default] @projects/cpp/console
+[Default] @projects/cpp/qtquick
+[Default] @projects/cpp/qwidget
+[Default] @projects/python/qtquick
+[Default] @projects/python/qwidget
+[Default] @cpp/class
+[Default] @types/qml
+[Default] @types/qrc
+[Default] @types/ui
+```
+
+More commands are available and running `run.sh` without arguments will show the list.
+
+```bash
+$ chmod a+x run.sh
+$ ./run.sh
+
+Usage: ./run.sh <command>
+Commands:
+  build               build binaries, copy to qt-core/res/qtcli
+  test <unit|e2e|all> run test (default: all)
+  qtcli [args...]     run qtcli with given arguments after rebuilding the binary
+  gen-all             generate items from all presets for manual check
+  print-version       print current version
+  install-tools       install tools for build, license update, etc.
+  update-license      update license files
+  help                print help
+```
+
+## Further Reading
+
+- [REST API](RestApi.md) - Server management and REST API endpoints
+- [Templates](Templates.md) - Template syntax, configuration, and examples

--- a/qt-cli/docs/RestApi.md
+++ b/qt-cli/docs/RestApi.md
@@ -1,0 +1,269 @@
+# REST API Server Management
+
+Qt CLI provides `server` with three sub-commands to manage REST server.
+- [start](#starting-the-server)
+- [stop](#stopping-the-server)
+- [ls](#listing-running-servers)
+
+```bash
+qtcli server <start|stop|ls> [OPTIONS]
+```
+
+
+## Starting the server
+
+```bash
+qtcli server start [OPTIONS]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--socket <name>` | - | Specify UDS(Unix Domain Socket) socket name. |
+| `--tcp` | false | Use TCP instead of UDS |
+| `--port <port>` | 8080 | Specify TCP port (only used with `--tcp`) |
+| `--exit-on-idle` | false | Exit the server automatically after inactivity |
+| `--heartbeat <duration>` | 10s | Heartbeat interval for idle detection (e.g., `5s`, `1m`) |
+
+#### Examples
+
+```bash
+# start server with Unix Domain Socket (default):
+$ qtcli server start
+
+# start server with custom socket name
+$ qtcli server start --socket my-custom-socket
+
+
+# start server with TCP on port 8080
+$ qtcli server start --tcp --port 8080
+
+# start server with auto-exit on idle
+$ qtcli server start --exit-on-idle --heartbeat 5s
+```
+
+## Stopping the server
+
+```bash
+qtcli server stop [OPTIONS]
+```
+
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--socket <name>` | - | Socket name of UDS server to stop (default: default) |
+| `--tcp` | false |Stop the TCP server (same as start) |
+| `--port <port>` | 8080 | Port of TCP server to stop (default: 8080) |
+
+**Examples:**
+
+```bash
+# stop UDS server
+qtcli server stop --socket my-custom-socket
+
+# stop TCP server on port 8080
+qtcli server stop --tcp --port 8080
+
+# stop all server instances
+qtcli server stop all
+```
+
+## Listing running servers
+
+```bash
+qtcli server ls
+```
+
+---
+
+# REST API Endpoints - V1
+
+There are three types of endpoints:
+- [Presets management](#preset-management)
+- [Item (project or file) creation](#item-creation)
+- [Server management](#server-management)
+
+
+## Preset management
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/v1/presets` | Retrieve all presets or filter by type/name |
+|  | `/v1/presets/:id` | Get details of a specific preset by ID |
+| POST | `/v1/presets` | Create a new custom preset |
+| PATCH | `/v1/presets/:id` | Update an existing custom preset |
+| DELETE | `/v1/presets/:id` | Delete a custom preset |
+
+### GET /presets
+Retrieve all presets (filter: `?type=project|file`, `?name=<name>`)
+```bash
+GET /v1/presets
+GET /v1/presets?type=project
+GET /v1/presets?name=@projects/cpp/console
+```
+
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+Date: Mon, 18 May 2026 14:05:46 GMT
+Connection: close
+Transfer-Encoding: chunked
+
+[
+  {
+    "id": "3972419898",
+    "name": "@projects/cpp/console",
+    "meta": {
+      "type": "project",
+      "title": "Qt console application",
+      "description": "Creates a project containing a single main.cpp file with a stub implementation and no graphical UI."
+    }
+  },
+  ...
+]
+```
+
+### GET /presets/:id
+
+Get preset details by ID
+
+```bash
+GET /v1/presets/2239089261
+```
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+Date: Mon, 18 May 2026 14:08:39 GMT
+Content-Length: 225
+Connection: close
+
+{
+  "id": "3972419898",
+  "name": "@projects/cpp/console",
+  "meta": {
+    "type": "project",
+    "title": "Qt console application",
+    "description": "Creates a project containing a single main.cpp file with a stub implementation and no graphical UI."
+  }
+}
+```
+
+### POST /presets
+
+Create a new custom preset
+
+```bash
+POST /v1/presets
+Content-Type: application/json
+
+{
+  "name": "mypreset",
+  "presetId": "3399596650",
+  "options": {
+      "qqcStyle": "Material",
+      "qqcTheme": "Dark"
+  }
+}
+
+```
+
+### PATCH /presets/:id
+
+Update a custom preset
+
+```bash
+PATCH /v1/presets/1234567890
+Content-Type: application/json
+
+{
+  "options": {
+    "minimumQtVersion": "6.4",
+    "qqcStyle": "Universal"
+  }
+}
+
+```
+
+### DELETE /presets/:id
+Delete a custom preset
+```bash
+DELETE /v1/presets/1234567890
+```
+
+
+
+## Item creation
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| POST | `/v1/items` | Create a new project or file based on a preset |
+| | `/v1/items/validate` | Validate item creation parameters |
+
+### POST /items
+
+Create a new project or file based on a preset
+
+```bash
+POST /v1/items
+Content-Type: application/json
+
+{
+    "name": "myapp",
+    "workingDir": "/home/my_all_projects",
+    "presetId": "3399596650"
+}
+```
+
+Set `dry_run` to true to run this endpoint without actually creating files.
+```bash
+POST /v1/items?dry_run=true
+Content-Type: application/json
+
+{
+    "name": "myapp",
+    "workingDir": "/home/my_all_projects",
+    "presetId": "3399596650"
+}
+```
+
+### POST /items/validate
+Validate item creation parameters without actually creating
+```bash
+POST /v1/items/validate
+Content-Type: application/json
+
+{
+    "name": "myapp",
+    "workingDir": "/home/my_all_projects",
+    "presetId": "3399596650"
+}
+```
+
+When validation fails, endpoint returns error with details:
+
+```json
+HTTP/1.1 400 Bad Request
+Content-Type: application/json; charset=utf-8
+Date: Mon, 18 May 2026 14:17:02 GMT
+Content-Length: 122
+Connection: close
+
+{
+  "error": "Cannot validate input",
+  "details": [
+    {
+      "level": "error",
+      "field": "workingdir",
+      "message": "The path must be absolute"
+    }
+  ]
+}
+```
+
+## Server management
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/v1/ready` | Health check endpoint |
+| POST | `/v1/heartbeat` | Keep server alive and track activity |
+| DELETE | `/v1/server` | Gracefully shutdown the server |
+

--- a/qt-cli/docs/Templates.md
+++ b/qt-cli/docs/Templates.md
@@ -1,0 +1,267 @@
+# Qt CLI Templates Documentation
+
+Qt CLI uses a template system to generate projects and files. This document describes the template structure, syntax, and configuration files.
+
+# Overview
+
+Templates are located in `src/assets/templates/` and are organized by category:
+
+- **`projects/`** - Project templates (console, widgets, QML)
+- **`types/`** - Individual file type templates (QML, UI, QRC)
+- **`common/`** - Common template files shared across all templates
+- **`cpp/`** - C++ class templates
+
+Each template directory name becomes the preset name (e.g., `cpp/class` → `@cpp/class`).
+
+## Template Structure
+
+Each template contains:
+
+```
+template-name/
+├── templates.yml    # Configuration and file definitions
+├── prompt.yml       # User input prompts (optional)
+└── <template-files> # Files to be generated (e.g., file.cpp, file.h)
+```
+
+
+# templates.yml
+
+The main configuration file that defines template metadata, file inputs/outputs, and computed fields.
+
+## Basic Structure
+
+```yaml
+version: "1"
+
+meta:
+  type: project
+  title: "Display Title"
+  description: "Description"
+
+files:
+  - in: input_file.txt
+    out: output_file.txt
+    when: condition
+    bypass: false
+
+fields:
+  - fieldNme: fieldValue
+```
+
+## Version
+
+| Property | Value | Description |
+|----------|-------|-------------|
+| `version` | `"1"` | Current template version. Always set to `"1"`. This field exists for future version compatibility. |
+
+### Meta
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `type` | `project` or `file` | Specifies whether the template creates a project or individual file |
+| `title` | string | Display name shown in the UI |
+| `description` | string | Detailed description of what the template creates |
+
+## Files
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `in` | string | Yes | Input template file path |
+| `out` | string | - | Output file path (defaults to input name). Supports template expressions |
+| `when` | string | - | Conditional expression. File is created only if true |
+| `bypass` | boolean | - | If `true`, file content is not processed with template syntax (default: false) |
+
+Note:
+- all the properties are treated as the Go template string
+- use `@` prefix to reference root directories. e.g. `@/common/git.ignore` is resolved as `src/assets/templates/common/`
+
+## Fields
+
+Variables that become available in template expressions, for example:
+
+```yaml
+fields:
+  - fieldName: template_expression
+  - anotherField: |
+      {{ if condition }}
+      value_if_true
+      {{ else }}
+      value_if_false
+      {{ end }}
+```
+
+## Options
+
+Configuration options for controlling template processing behavior.
+
+```yaml
+options:
+  polish:
+    trimStart: true
+    compressEmptyLines: true
+```
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `polish.trimStart` | boolean | true | Removes leading whitespace from template files - prevents unnecessary blank lines caused by something like template directives |
+| `polish.compressEmptyLines` | boolean | true | Compresses multiple empty lines into single lines - simplifies template authoring. Otherwise, set to `false` for example, a Python files or projects to preserve two empty lines considering PEP8. |
+
+# prompt.yml
+
+Defines user input prompts that appear in the terminal or GUI.
+
+## Basic Structure
+
+```yaml
+version: "1"
+
+steps:
+  - id: fieldId
+    type: picker | confirm | text
+    question: "Display question?"
+    default: default_value
+    items: [list of options]  # For picker type
+```
+
+
+## Version
+
+| Property | Value | Description |
+|----------|-------|-------------|
+| `version` | `"1"` | Current template version. Always set to `"1"`. This field exists for future version compatibility. |
+
+
+## Step Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `id` | string | Yes | Unique identifier for the input (becomes available as `.fieldId` in templates) |
+| `type` | string | Yes | Input type: `picker`, `confirm`, or `text` |
+| `question` | string | Yes | Question displayed to user |
+| `default` | any | No | Default value if user skips the step |
+| `items` | array | No | List of options (required for `picker` type) |
+
+## Input Types
+
+### Picker
+
+```yaml
+- id: baseClass
+  type: picker
+  question: "Select base class:"
+  default: QObject
+  items:
+    - text: QObject
+    - text: QWidget
+    - text: QMainWindow
+    - text: QQuickItem
+```
+
+#### Confirm
+
+```yaml
+- id: useForm
+  type: confirm
+  question: "Use form?"
+  default: true
+```
+
+#### Text
+
+```yaml
+- id: projectName
+  type: text
+  question: "Project name:"
+  default: "MyProject"
+```
+
+## Template syntax
+
+Template files use Go's `text/template` syntax with some custom functions.
+For standard Go template syntax, refer to the [Go text/template documentation](https://pkg.go.dev/text/template).
+
+### Variables
+
+All the variables are defined from `prompt.yml` or `fields` in `templates.yml` file.
+One exception to this is `name`, which is automatically available in all templates and represents the project or file name provided by the user via terminal command or GUI. It can be access like:
+
+```go
+{{ .name }}  // Project or file name (passed from terminal or GUI)
+```
+
+### Varaibles from `prompt.yml`
+
+```yaml
+steps:
+  - id: framework
+    type: picker
+    question: "Select framework:"
+    items:
+      - text: "Qt Widgets"
+      - text: "Qt Quick"
+
+  - id: style
+    type: picker
+    question: "Select style:"
+    items:
+      - text: "Modern"
+      - text: "Classic"
+```
+
+Then use both values: `{{ .framework }}` and `{{ .style }}` in any template strings.
+
+### Custom Functions
+
+Qt CLI provides custom template functions that are exposed during template generation. These functions are designed to simplify template composition and reduce boilerplate code.
+
+| Function | Parameters | Return | Description |
+|----------|-----------|--------|-------------|
+| `Qt.NewArray` | - | `[]any` | Creates an empty array |
+| `Qt.Append` | `array`, `value` | `[]any` | Appends a value to an array |
+| `Qt.AppendIf` | `array`, `value`, `condition` | `[]any` | Conditionally appends a value to an array (only if condition is true) |
+| `Qt.ParseFloat` | `value` | `float64` | Parses a value as a floating-point number |
+| `Qt.Reverse` | `slice` | `[]string` | Reverses a string array |
+
+## Simple Example
+
+**Directory Structure:**
+```
+types/qml/
+├── file.qml
+└── templates.qml
+```
+
+**templates.yml:**
+```yaml
+version: "1"
+
+meta:
+  type: file
+  title: QML file
+  description: >-
+    Creates a QML file with boilerplate code,
+    starting with "import QtQuick".
+
+files:
+  - in: file.qml
+    out: '{{ .name }}.qml'
+```
+
+No `prompt.yml` needed here because no user input is required.
+
+**file.qml:**
+```qml
+import QtQuick
+
+Rectangle {
+    width: 640
+    height: 480
+    color: "#ffffff"
+
+    Text {
+        anchors.centerIn: parent
+        text: "Hello, {{ .name }}!"
+    }
+}
+```


### PR DESCRIPTION
Add RestApi.md and Templates.md, and move existing documentation to docs/ for better organization.

Task-Number: [VSCODEEXT-210](https://qt-project.atlassian.net/browse/VSCODEEXT-210)
Task-Number: [VSCODEEXT-212](https://qt-project.atlassian.net/browse/VSCODEEXT-212)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
