### PR TITLE
qt-core: Fix examples browser for non-standard Qt layouts

### DIFF
--- a/qt-core/src/webview/ex-browser/controller.ts
+++ b/qt-core/src/webview/ex-browser/controller.ts
@@ -55,8 +55,12 @@ export class ExBrowserController {
         helpers.fallbackImageDir(context),
         ...sources.flatMap((s) => {
           return [
-            vscode.Uri.file(path.join(s.fsPath, consts.EX_DIR_NAME)),
-            vscode.Uri.file(path.join(s.fsPath, consts.DOCS_DIR_NAME))
+            vscode.Uri.file(
+              s.examplesPath ?? path.join(s.fsPath, consts.EX_DIR_NAME)
+            ),
+            vscode.Uri.file(
+              s.docsPath ?? path.join(s.fsPath, consts.DOCS_DIR_NAME)
+            )
           ];
         })
       ]

--- a/qt-core/src/webview/ex-browser/data-manager.ts
+++ b/qt-core/src/webview/ex-browser/data-manager.ts
@@ -61,11 +61,17 @@ export class ExDataManager {
     this._resolvedPaths = {};
 
     const categoriesCollector = new catHelpers.CategoriesCollector();
-    const manifests = discoverManifestFiles(
-      path.join(p.poolDir.fsPath, consts.DOCS_DIR_NAME, p.subDir)
-    );
+    const docsDir =
+      p.poolDir.docsPath ??
+      path.join(p.poolDir.fsPath, consts.DOCS_DIR_NAME, p.subDir);
+    const manifests = discoverManifestFiles(docsDir);
 
-    const resolver = new ExPathsResolver(p.poolDir.fsPath, p.subDir);
+    const resolver = new ExPathsResolver(
+      p.poolDir.fsPath,
+      p.subDir,
+      p.poolDir.docsPath,
+      p.poolDir.examplesPath
+    );
 
     manifests.forEach((m) => {
       const files = parseManifestFile(m.absPath, m.type);
@@ -152,6 +158,23 @@ export function discoverManifestFiles(absPath: string) {
 
 export function readPackagesInfo(poolDir: ExPackagePoolDir): ExPackage[] {
   try {
+    if (poolDir.docsPath) {
+      const dir = fsDir(poolDir.docsPath);
+      if (!dir.exists()) {
+        return [];
+      }
+      const name = poolDir.qtVersion
+        ? `Qt-${poolDir.qtVersion}`
+        : path.basename(poolDir.docsPath);
+      return [
+        {
+          name,
+          subDir: name,
+          poolDir
+        }
+      ];
+    }
+
     const all = fsDir(poolDir.fsPath, consts.DOCS_DIR_NAME).subDirNames();
     const prefixLength = 'Qt-'.length;
     const regexQt6 = new RegExp(`^Qt-6\\.\\d+\\.\\d+$`);

--- a/qt-core/src/webview/ex-browser/helpers.ts
+++ b/qt-core/src/webview/ex-browser/helpers.ts
@@ -17,7 +17,6 @@ import {
   ExBrowserViewConfig
 } from '@/webview/shared/ex-browser';
 import { fsDir } from '@/fs-utils';
-import * as consts from './constants';
 
 type Context = vscode.ExtensionContext;
 
@@ -44,21 +43,21 @@ export function findAllPackagePools(): ExPackagePoolDir[] {
     const info = coreAPI?.getQtInfoFromPath(p.path);
     if (info?.info) {
       const docs = info.info.get('QT_INSTALL_DOCS'); // .../Qt/Docs/Qt-x.y.z
+      const examples = info.info.get('QT_INSTALL_EXAMPLES');
+      const version = info.info.get('QT_VERSION');
       const parent = docs ? path.dirname(path.dirname(docs)) : '';
 
       found.push({
         sourceType: 'qtpaths',
-        fsPath: parent
+        fsPath: parent,
+        ...(docs ? { docsPath: docs } : {}),
+        ...(examples ? { examplesPath: examples } : {}),
+        ...(version ? { qtVersion: version } : {})
       });
     }
   });
 
-  return found.filter((loc) => {
-    return (
-      fsDir(loc.fsPath, consts.DOCS_DIR_NAME).exists() &&
-      fsDir(loc.fsPath, consts.EX_DIR_NAME).exists()
-    );
-  });
+  return found;
 }
 
 export function createNewProject(

--- a/qt-core/src/webview/ex-browser/resolvers.ts
+++ b/qt-core/src/webview/ex-browser/resolvers.ts
@@ -12,7 +12,9 @@ import * as consts from './constants';
 export class ExPathsResolver {
   public constructor(
     private readonly _insRoot: string,
-    private readonly _qtVersionDir: string
+    private readonly _qtVersionDir: string,
+    private readonly _docsPath?: string,
+    private readonly _examplesPath?: string
   ) {}
 
   public resolve(e: ExEntry): ExResolvedPaths {
@@ -66,6 +68,13 @@ export class ExPathsResolver {
   }
 
   private _toAbsPath(type: 'docs' | 'examples', relPath: string): string {
+    if (type === 'docs' && this._docsPath) {
+      return path.join(this._docsPath, relPath);
+    }
+    if (type === 'examples' && this._examplesPath) {
+      return path.join(this._examplesPath, relPath);
+    }
+
     // input: qtscxml/images/calculator.png"
     // output: <insRoot>/Docs/<version>/<input>
     // output: <insRoot>/Examples/<version>/<input>

--- a/qt-core/src/webview/shared/ex-browser.ts
+++ b/qt-core/src/webview/shared/ex-browser.ts
@@ -79,6 +79,9 @@ export type ExPackageSourceType = 'insRoot' | 'qtpaths';
 export interface ExPackagePoolDir {
   fsPath: string;
   sourceType: ExPackageSourceType;
+  docsPath?: string;
+  examplesPath?: string;
+  qtVersion?: string;
 }
 
 export function isExPackagePoolDir(x: unknown): x is ExPackagePoolDir {
@@ -90,7 +93,10 @@ export function isExPackagePoolDir(x: unknown): x is ExPackagePoolDir {
   return (
     typeof o.fsPath === 'string' &&
     typeof o.sourceType === 'string' &&
-    (o.sourceType === 'insRoot' || o.sourceType === 'qtpaths')
+    (o.sourceType === 'insRoot' || o.sourceType === 'qtpaths') &&
+    (o.docsPath === undefined || typeof o.docsPath === 'string') &&
+    (o.examplesPath === undefined || typeof o.examplesPath === 'string') &&
+    (o.qtVersion === undefined || typeof o.qtVersion === 'string')
   );
 }
 


### PR DESCRIPTION
Read QT_INSTALL_DOCS, QT_INSTALL_EXAMPLES, and QT_VERSION from qtpaths
--query instead of assuming a fixed directory layout. This allows
packages from additionalQtPaths to display in the examples browser
regardless of where Qt installation stores its docs/examples.
