### PR TITLE
qt-cpp:test: fix "No usable generator found" in build test

### DIFF
--- a/qt-cpp/test/helper.mts
+++ b/qt-cpp/test/helper.mts
@@ -15,7 +15,6 @@ export {
   getWorkspaceFolderOrThrow,
   cleanBuildDir,
   cmakeConfigForWorkspace,
-  getPlatformCMakeGenerator,
   readCMakeCacheVar,
   prepareStandardCMakeArgs,
   selectAndApplyKit

--- a/qt-cpp/test/runTest.build.mts
+++ b/qt-cpp/test/runTest.build.mts
@@ -10,7 +10,8 @@ import { downloadAndUnzipVSCode, runTests } from '@vscode/test-electron';
 import {
   setupTestInfrastructure,
   setupVSCodeSettings,
-  installRequiredExtensions
+  installRequiredExtensions,
+  getPlatformCMakeGenerator
 } from './runTestHelper.mjs';
 
 async function main() {
@@ -46,6 +47,18 @@ async function main() {
     // Node 16+: recursive copy
     await fsp.cp(projectDir, tmpProject, { recursive: true });
     console.log('[runTest] Copied project to temp dir:', tmpProject);
+
+    // Set the generator in workspace settings before VS Code starts so that
+    // a runtime cmake.generator change doesn't trigger a driver reload
+    // before a kit is selected (which causes "No usable generator found").
+    const wsSettingsPath = path.join(tmpProject, '.vscode', 'settings.json');
+    const wsSettings = JSON.parse(await fsp.readFile(wsSettingsPath, 'utf-8'));
+    wsSettings['cmake.generator'] = getPlatformCMakeGenerator();
+    await fsp.writeFile(
+      wsSettingsPath,
+      JSON.stringify(wsSettings, null, 2),
+      'utf-8'
+    );
 
     // Run the integration tests (no need to pass launchArgs; we reused the same dirs)
     try {

--- a/qt-cpp/test/runTestHelper.mts
+++ b/qt-cpp/test/runTestHelper.mts
@@ -19,6 +19,10 @@ import {
 
 const QT_INS_ROOT_CONFIG_NAME = 'qtInstallationRoot';
 
+export function getPlatformCMakeGenerator(): string {
+  return process.platform === 'win32' ? 'Ninja' : 'Unix Makefiles';
+}
+
 /**
  * Parse a CLI argument by name (e.g., --qt-root or --qt-root=/path)
  */

--- a/qt-cpp/test/suite/build.test.mts
+++ b/qt-cpp/test/suite/build.test.mts
@@ -16,7 +16,6 @@ import {
   getWorkspaceFolderOrThrow,
   cleanBuildDir,
   cmakeConfigForWorkspace,
-  getPlatformCMakeGenerator,
   prepareStandardCMakeArgs,
   readCMakeCacheVar,
   selectAndApplyKit
@@ -38,8 +37,6 @@ describe('build: minimal Qt project (index-build)', function () {
     const projectDir = wsFolder.uri.fsPath;
     console.log('Using projectDir:', projectDir);
     const buildDir = await cleanBuildDir(projectDir);
-
-    await cmakeConfigurator.set('generator', getPlatformCMakeGenerator());
 
     await selectAndApplyKit();
 

--- a/qt-lib/test/helper.mts
+++ b/qt-lib/test/helper.mts
@@ -293,10 +293,6 @@ export function cmakeConfigForWorkspace(ws: vscode.WorkspaceFolder) {
   return new CMakeConfigurator(ws);
 }
 
-export function getPlatformCMakeGenerator(): string {
-  return process.platform === 'win32' ? 'Ninja' : 'Unix Makefiles';
-}
-
 /**
  * Reads a specific variable value from a CMake build directory's `CMakeCache.txt` file.
  *

--- a/qt-qml/test/helper.mts
+++ b/qt-qml/test/helper.mts
@@ -15,7 +15,6 @@ export {
   getWorkspaceFolderOrThrow,
   cleanBuildDir,
   cmakeConfigForWorkspace,
-  getPlatformCMakeGenerator,
   readCMakeCacheVar,
   prepareStandardCMakeArgs,
   selectAndApplyKit,


### PR DESCRIPTION
The build test was crashing with "No usable generator found" before it
could even configure or build.

The test called cmakeConfigurator.set('generator', 'Unix Makefiles') at
runtime to tell CMake Tools which build system to use. CMake Tools
noticed the setting change and immediately tried to restart its internal
driver. But no compiler kit (e.g. GCC) had been selected yet, so the
driver restart failed and stored a broken promise. When the test then
called selectAndApplyKit() to pick a GCC kit, it tried to talk to the
already-failed driver and got the same "No usable generator found" error.

The fix is to write cmake.generator into the workspace settings.json
before VS Code starts, rather than changing it at runtime. This way
CMake Tools already knows the generator on first load, so there is no
mid-flight restart and no race with kit selection. The runtime
cmakeConfigurator.set('generator') call and its unused import are
removed since they are no longer needed.

(cherry picked from commit 4a3af52d013f7752dbeb6dc0c1b2d52aba9e592d)
