### PR TITLE
qt-cli: Add auto-added subdirectory for QtQuick project with Figma ex…

### DIFF
--- a/qt-cli/src/assets/templates/projects/cpp/qtquick/CMakeLists.txt
+++ b/qt-cli/src/assets/templates/projects/cpp/qtquick/CMakeLists.txt
@@ -12,6 +12,12 @@ find_package(Qt6 {{ .minimumQtVersion }} REQUIRED COMPONENTS Quick)
 {{ if ge $mininumQtVersionFloat 6.5 }}
 qt_standard_project_setup(REQUIRES {{ .minimumQtVersion }})
 {{ end }}
+
+# Content of downloaded design from Figma to Qt or similar
+if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/{{ .importdir }}/CMakeLists.txt")
+    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/{{ .importdir }})
+endif()
+
 qt_add_executable({{ $target }}
     main.cpp
 )

--- a/qt-cli/src/assets/templates/projects/cpp/qtquick/importedcontent/README.md
+++ b/qt-cli/src/assets/templates/projects/cpp/qtquick/importedcontent/README.md
@@ -1,0 +1,4 @@
+# Downloaded Design from Figma to Qt
+
+Save the downloaded design from Figma to Qt here, including the CMakeLists.txt.
+The main project CMakeLists.txt picks this up automatically.

--- a/qt-cli/src/assets/templates/projects/cpp/qtquick/templates.yml
+++ b/qt-cli/src/assets/templates/projects/cpp/qtquick/templates.yml
@@ -13,6 +13,12 @@ files:
   - in: Main.qml
   - in: main.cpp
 
+  - in: '{{ .importdir }}/README.md'
+    out: '{{ .importdir }}/README.md'
+
   - in: '@/common/git.ignore'
     out: .gitignore
     bypass: true
+
+fields:
+  - importdir: importedcontent

--- a/qt-cli/src/newitem/generator/generator.go
+++ b/qt-cli/src/newitem/generator/generator.go
@@ -189,9 +189,9 @@ func (g *Generator) runNames() (ResultData, error) {
 			continue
 		}
 
-		inputRel := g.createInputFileRel(file)
-		outputRel, err := g.createOutputFileRel(file)
-		if err != nil {
+		inputRel, errIn := g.createInputFileRel(file)
+		outputRel, errOut := g.createOutputFileRel(file)
+		if errIn != nil || errOut != nil {
 			return ResultData{}, err
 		}
 
@@ -267,12 +267,26 @@ func (g *Generator) runContents(result ResultItem) error {
 	return nil
 }
 
-func (g *Generator) createInputFileRel(file preset.TemplateItem) string {
+func (g *Generator) createInputFileRel(file preset.TemplateItem) (string, error) {
+	var in string
+
 	if strings.HasPrefix(file.In, "@/") {
-		return file.In[2:]
+		in = file.In[2:]
+	} else {
+		in = path.Join(g.preset.GetTemplateDir(), file.In)
 	}
 
-	return path.Join(g.preset.GetTemplateDir(), file.In)
+	expanded, err := utils.NewTemplateExpander().
+		Name(file.In).
+		Data(g.context.data).
+		Funcs(g.context.funcs).
+		RunString(in)
+
+	if err != nil {
+		return expanded, err
+	}
+
+	return expanded, nil
 }
 
 func (g *Generator) createOutputFileRel(

--- a/qt-cli/tests/e2e/expected_outputs/projects_cpp_qtquick/CMakeLists.txt
+++ b/qt-cli/tests/e2e/expected_outputs/projects_cpp_qtquick/CMakeLists.txt
@@ -8,6 +8,11 @@ find_package(Qt6 6.8 REQUIRED COMPONENTS Quick)
 
 qt_standard_project_setup(REQUIRES 6.8)
 
+# Content of downloaded design from Figma to Qt or similar
+if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/importedcontent/CMakeLists.txt")
+    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/importedcontent)
+endif()
+
 qt_add_executable(appprojects_cpp_qtquick
     main.cpp
 )

--- a/qt-cli/tests/e2e/expected_outputs/projects_cpp_qtquick/importedcontent/README.md
+++ b/qt-cli/tests/e2e/expected_outputs/projects_cpp_qtquick/importedcontent/README.md
@@ -1,0 +1,4 @@
+# Downloaded Design from Figma to Qt
+
+Save the downloaded design from Figma to Qt here, including the CMakeLists.txt.
+The main project CMakeLists.txt picks this up automatically.


### PR DESCRIPTION
Add a `importedcontent` directory with a README.md that is searched for a CMakeLists.txt by the main project file.
Users can drop for example Figma exported content there and automatically make that available to their project.

qt-cli:
- make the qt-cli generator treat the `in` property of template files as a Go template string.
- update expected outputs of qtquick project to reflect change.

Task-number: [VSCODEEXT-302](https://qt-project.atlassian.net/browse/QTCREATORBUG-34321)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
