### PR TITLE
Publish: Handle new signed qtcli zip layout with extracted folder

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -23,6 +23,24 @@ function extractAndPlaceQtCli(qtcorePath: string, zipPath: string) {
     // https://github.com/ZJONSSON/node-unzipper/issues/216
     console.log(`Extracting "${zipPath}" to "${outputDir}"`);
     execSync(`unzip -o ${zipPath} -d ${outputDir}`, { stdio: 'inherit' });
+    // Move contents of 'extracted' folder up one level if it exists
+    const extractedDir = path.join(outputDir, 'extracted');
+    if (fs.existsSync(extractedDir)) {
+      console.log(`Moving contents of "${extractedDir}" to "${outputDir}"`);
+      const entries = fs.readdirSync(extractedDir, { withFileTypes: true });
+      for (const entry of entries) {
+        const src = path.join(extractedDir, entry.name);
+        const dest = path.join(outputDir, entry.name);
+        fs.renameSync(src, dest);
+      }
+      fs.rmSync(extractedDir, { recursive: true });
+    }
+    // print the contents of outputDir for verification
+    console.log(`Contents of "${outputDir}":`);
+    const finalEntries = fs.readdirSync(outputDir, { withFileTypes: true });
+    for (const entry of finalEntries) {
+      console.log(`- ${path.join(outputDir, entry.name)}`);
+    }
     // chmod 755 to all files in the outputDir
     console.log(`Setting permissions for files in "${outputDir}"`);
     const setPermissions = (dir: string) => {


### PR DESCRIPTION
The CI signing process now places darwin and windows binaries inside
an 'extracted' subdirectory. Flatten this directory after unzipping
by moving its contents up one level before setting permissions.

(cherry picked from commit a3ef83c86866ed7744f99994a52a179c3c958d3c)
