### PR TITLE
qt-core, qt-cli: Send telemetry event for new item wizard usage

### DIFF
--- a/qt-cli/src/newitem/handler_preset.go
+++ b/qt-cli/src/newitem/handler_preset.go
@@ -14,18 +14,20 @@ import (
 
 // presets
 type PresetsResponseItem struct {
-	Id   string              `json:"id"`
-	Name string              `json:"name"`
-	Meta preset.TemplateMeta `json:"meta"`
+	Id          string              `json:"id"`
+	Name        string              `json:"name"`
+	TemplateDir string              `json:"template"`
+	Meta        preset.TemplateMeta `json:"meta"`
 }
 
 type PresetsResponse []PresetsResponseItem
 
 type PresetDetailResponse struct {
-	Id     string                     `json:"id"`
-	Name   string                     `json:"name"`
-	Meta   preset.TemplateMeta        `json:"meta"`
-	Prompt *preset.PromptFileContents `json:"prompt,omitempty"`
+	Id          string                     `json:"id"`
+	Name        string                     `json:"name"`
+	TemplateDir string                     `json:"template"`
+	Meta        preset.TemplateMeta        `json:"meta"`
+	Prompt      *preset.PromptFileContents `json:"prompt,omitempty"`
 }
 
 func GetPresetsByNameOrType(c *gin.Context) {
@@ -61,9 +63,10 @@ func GetPresetsByNameOrType(c *gin.Context) {
 		}
 
 		res = append(res, PresetsResponseItem{
-			Id:   p.GetUniqueId(),
-			Name: p.GetName(),
-			Meta: template.GetMeta(),
+			Id:          p.GetUniqueId(),
+			Name:        p.GetName(),
+			TemplateDir: p.GetTemplateDir(),
+			Meta:        template.GetMeta(),
 		})
 	}
 
@@ -103,10 +106,11 @@ func getPresetBy(c *gin.Context, value, by string) {
 	}
 
 	rest.ReplyGet(c, PresetDetailResponse{
-		Id:     p.GetUniqueId(),
-		Name:   p.GetName(),
-		Meta:   template.GetMeta(),
-		Prompt: prompt,
+		Id:          p.GetUniqueId(),
+		Name:        p.GetName(),
+		TemplateDir: p.GetTemplateDir(),
+		Meta:        template.GetMeta(),
+		Prompt:      prompt,
 	})
 }
 

--- a/qt-core/src/webview/new-item/dispatcher.ts
+++ b/qt-core/src/webview/new-item/dispatcher.ts
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import { createLogger } from 'qt-lib';
+import { createLogger, telemetry } from 'qt-lib';
 import * as texts from '@/texts';
 import { QtcliRestClient, QtcliRestError } from '@/qtcli/rest';
 import { openFilesUnder, openUri } from '@/qtcli/common';
@@ -114,6 +114,11 @@ export class NewItemDispatcher {
         const globalState = new GlobalStateManager(this._context);
         await globalState.setNewProjectOpenIn(openIn);
       }
+
+      telemetry.sendEvent('Wizard:createItem', {
+        type,
+        template: String(_.get(cmd.payload, 'template', '')).trim()
+      });
 
       this._panel?.close();
     } catch (e) {

--- a/qt-core/webview-ui/src/apps/new-item/types.svelte.ts
+++ b/qt-core/webview-ui/src/apps/new-item/types.svelte.ts
@@ -4,6 +4,7 @@
 export interface Preset {
   id: string;
   name: string;
+  template: string;
   meta: PresetMeta;
   prompt?: PresetPrompt;
 }
@@ -49,6 +50,9 @@ export class PresetWrapper {
   }
   get name() {
     return this._raw?.name ?? '';
+  }
+  get template() {
+    return this._raw?.template ?? '';
   }
   get title() {
     return this._raw?.meta.title;
@@ -96,6 +100,7 @@ export function isPreset(x: unknown): x is Preset {
   if (
     typeof obj.id !== 'string' ||
     typeof obj.name !== 'string' ||
+    typeof obj.template !== 'string' ||
     typeof obj.meta !== 'object' ||
     obj.meta === null
   ) {

--- a/qt-core/webview-ui/src/apps/new-item/viewlogic.svelte.ts
+++ b/qt-core/webview-ui/src/apps/new-item/viewlogic.svelte.ts
@@ -294,10 +294,12 @@ export async function onInputFormEvent(type: NewItemForm.EventType, args?: unkno
           name: input.states.name,
           workingDir: input.states.workingDir,
           presetId: data.selected.preset?.id,
+          template: data.selected.preset?.template,
           options: $state.snapshot(ui.unsavedOptionChanges),
           saveProjectDir: input.states.saveProjectDir,
           openIn: input.states.openIn
         });
+
       } catch (e) {
         reportUiError('Cannot create item', e);
       }


### PR DESCRIPTION
Send a telementry event containing the template directory when the user successfully creates a project or file using the new item wizard.

Task-number: [VSCODEEXT-303](https://qt-project.atlassian.net/browse/VSCODEEXT-303)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
