### PR TITLE
qt-core: Add popup menu to QRC editor webview

### DIFF
--- a/qt-core/src/webview/qrc-editor/controller.ts
+++ b/qt-core/src/webview/qrc-editor/controller.ts
@@ -251,7 +251,18 @@ export class QrcEditorController {
         if (r) {
           await this._applyAndPostData(cmd, { action: 'paste', ...r });
         }
-        return;
+        break;
+      }
+
+      case 'copy-resource-url':
+      case 'copy-resource-path': {
+        const type = action.endsWith('-url') ? 'url' : 'path';
+        const text = node.formatResourceString(type).trim();
+        if (text.length !== 0) {
+          void vscode.env.clipboard.writeText(text);
+          this._comm.postDataReply(cmd, { status: 'done' });
+        }
+        break;
       }
     }
   };

--- a/qt-core/src/webview/qrc-editor/node.ts
+++ b/qt-core/src/webview/qrc-editor/node.ts
@@ -137,6 +137,17 @@ export class QrcNode {
     return this._insertClipData(data);
   }
 
+  public formatResourceString(type: 'path' | 'url') {
+    const prefix = this.group?.attributes.prefix;
+    const name = this.file?.attributes.alias ?? this.file?.text;
+    if (!prefix || !name) {
+      return '';
+    }
+
+    const p = path.join(prefix, name);
+    return `${type === 'url' ? 'qrc' : ''}:${p.replace(/\\/g, '/')}`;
+  }
+
   // private methods
   private _findGroupIndex(): number {
     if (this.pos.groupKey.length === 0) {

--- a/qt-core/webview-ui/src/apps/qrc-editor/QrcEditorHeader.svelte
+++ b/qt-core/webview-ui/src/apps/qrc-editor/QrcEditorHeader.svelte
@@ -16,7 +16,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
   import * as texts from '@/apps/texts';
   import IconButton from '@/comps/IconButton.svelte';
-  import { data, ui } from './states.svelte';
+  import { data } from './states.svelte';
   import * as viewlogic from './viewlogic.svelte';
 
   let empty = $derived(data.groups.length === 0);

--- a/qt-core/webview-ui/src/apps/qrc-editor/QrcFileItem.svelte
+++ b/qt-core/webview-ui/src/apps/qrc-editor/QrcFileItem.svelte
@@ -4,12 +4,13 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 -->
 
 <script lang="ts">
-  import { TriangleAlert } from '@lucide/svelte';
+  import { TriangleAlert, Ellipsis } from '@lucide/svelte';
 
   import * as texts from '@/apps/texts';
   import { data, ui } from './states.svelte';
   import * as viewlogic from './viewlogic.svelte';
   import { FileNodeWrapper } from './types.svelte';
+  import QrcFileItemMenu from './QrcFileItemMenu.svelte';
   import QrcFileItemThumbnail from './QrcFileItemThumbnail.svelte';
 
   let {
@@ -23,13 +24,18 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   let exists = $derived.by(() => loaded?.exists ?? false);
   let okay = $derived.by(() => (exists || (!exists && file.empty)));
   let current = $derived.by(() => ui.cursor.currentPos.equals(file.pos));
+
+  let menuOpened = $state(false);
 </script>
 
-<button
+<div
   {id}
-  class={`w-full qt-item${current ? '-selected' : ''} !p-0 relative`}
+  role='button'
+  tabindex={0}
+  class={`w-full qt-item${current ? '-selected' : ''} !p-0 relative group`}
   onclick={() => ui.cursor.moveToPos(file.pos)}
   ondblclick={() => viewlogic.runVscodeUiAction('openFile')}
+  onkeydown={() => {}}
 >
   {#if file.highlighted}
     <div class="absolute w-full h-full top-0 left-0
@@ -74,5 +80,23 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
         </div>
       {/if}
     {/if}
+
+    <div class='grow'></div>
+    <div class='mr-2 hidden group-hover:block'>
+      <Ellipsis
+        class='qt-button-contentOnly'
+        onclick={() => {
+          menuOpened = true;
+        }}
+      />
+      {#if menuOpened}
+        <QrcFileItemMenu
+          open={true}
+          onClosed={() => {
+            menuOpened = false;
+          }}
+        />
+      {/if}
+    </div>
   </div>
-</button>
+</div>

--- a/qt-core/webview-ui/src/apps/qrc-editor/QrcFileItemMenu.svelte
+++ b/qt-core/webview-ui/src/apps/qrc-editor/QrcFileItemMenu.svelte
@@ -1,0 +1,52 @@
+<!--
+Copyright (C) 2026 The Qt Company Ltd.
+SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+-->
+
+<script lang="ts">
+  import { Copy, Trash2 } from '@lucide/svelte';
+
+  import * as texts from '@/apps/texts';
+  import * as viewlogic from './viewlogic.svelte';
+  import PickerList from '@/comps/PickerList.svelte';
+
+  let {
+    open = false,
+    onClosed = () => {}
+  } = $props();
+
+  const items = [
+    {
+      icon: Copy,
+      text: texts.qrc.menu.copyUrl,
+      action: () => { viewlogic.runClipboardAction('copy-resource-url'); }
+    },
+    {
+      icon: Copy,
+      text: texts.qrc.menu.copyPath,
+      action: () => { viewlogic.runClipboardAction('copy-resource-path'); }
+    },
+    {
+      icon: Trash2,
+      text: texts.qrc.menu.delete,
+      action: () => { viewlogic.removeCurrent(); }
+    }
+  ];
+
+  function onItemClickedAt(index: number) {
+    items[index].action();
+    open = false;
+    onClosed();
+  }
+</script>
+
+{#if open}
+  <PickerList
+    active={true}
+    {items}
+    width={200}
+    currentIndex="-1"
+    onRejected={onClosed}
+    onAccepted={onItemClickedAt}
+  />
+{/if}

--- a/qt-core/webview-ui/src/apps/qrc-editor/types.svelte.ts
+++ b/qt-core/webview-ui/src/apps/qrc-editor/types.svelte.ts
@@ -12,7 +12,7 @@ import {
 import * as texts from '@/apps/texts';
 
 export type QrcPropName =  'alias' | 'prefix' | 'lang';
-export type QrcClipboardAction = 'copy' | 'cut' | 'paste';
+export type QrcClipboardAction = 'copy' | 'cut' | 'paste' | 'copy-resource-url' | 'copy-resource-path';
 export type QrcVscodeUiAction =
   | 'openFile'
   | 'openQrcInTextEditor'

--- a/qt-core/webview-ui/src/apps/texts.ts
+++ b/qt-core/webview-ui/src/apps/texts.ts
@@ -72,6 +72,12 @@ export const qrc = {
     openInTextEditor: 'Open in a text editor'
   },
 
+  menu: {
+    copyUrl: 'Copy resource URL',
+    copyPath: 'Copy resource path',
+    delete: 'Delete'
+  },
+
   stats: (groups: number, files: number) => {
     return [
       'Total',


### PR DESCRIPTION
For file items, a popup menu opens when the user hovers over the item and clicks the menu button at the right end.

The menu provides actions for:
- copying the Qt resource path starting with :
- copying the Qt resource URL starting with qrc:/
- deleting the selected item

Task-number: [VSCODEEXT-272](https://qt-project.atlassian.net/browse/VSCODEEXT-272)

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
