### PR TITLE
qt-lib: Fix incorrect project lookup when project names share a commo…

### DIFF
--- a/qt-lib/src/project.ts
+++ b/qt-lib/src/project.ts
@@ -89,12 +89,19 @@ export class ProjectManager<ProjectType extends Project> {
       }
     });
   }
+
   public findProjectContainingFile(uri: vscode.Uri) {
+    const folder = vscode.workspace.getWorkspaceFolder(uri);
+    const folderUri = folder?.uri.toString();
+    if (!folderUri) {
+      return undefined;
+    }
+
     return Array.from(this.projects).find((project) => {
-      const ret = uri.toString().startsWith(project.folder.uri.toString());
-      return ret;
+      return project.folder.uri.toString() === folderUri;
     });
   }
+
   dispose() {
     for (const project of this.projects) {
       project.dispose();


### PR DESCRIPTION
When multiple projects have URIs with a common prefix (e.g. /myproject and /myproject-ext),
looking up a file under /myproject-ext/myfile would incorrectly return /myproject due to the use of startsWith() for matching.

This patch fixes this by using vscode.workspace.getWorkspaceFolder() API.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
