### PR TITLE
Fix debugging fails silently when CMakePresets is used with qtpaths

### DIFF
--- a/qt-cpp/src/commands/source-directory.ts
+++ b/qt-cpp/src/commands/source-directory.ts
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 import * as vscode from 'vscode';
-import * as path from 'path';
 
 import { createLogger, telemetry } from 'qt-lib';
-import { getQtInsRoot, getSelectedKit } from '@cmd/register-qt-path';
 import { EXTENSION_ID } from '@/constants';
-import { CppProjectType, getActiveProject } from '@/project';
+import { getActiveProject } from '@/project';
 
 const logger = createLogger('source-directory');
 
@@ -18,49 +16,39 @@ export function registerSourceDirectoryCommand() {
       telemetry.sendAction('sourceDirectory');
       const project = await getActiveProject();
       if (!project) {
+        logger.warn(
+          'No active C++ project found. Cannot determine source directory.'
+        );
         return undefined;
       }
-      if (project.type === CppProjectType.Presets) {
+      const sourceDir = await project.getSourceDirectory();
+      if (!sourceDir) {
+        const config = vscode.workspace.getConfiguration(EXTENSION_ID);
+        const doNotWarn = config.get<boolean>(
+          'doNotWarnMissingSourceDir',
+          false
+        );
+        const message =
+          'Source directory cannot be determined for the active project.';
+        logger.error(message);
+        if (!doNotWarn) {
+          const doNotAskBtn = 'Do not show again';
+          void vscode.window
+            .showWarningMessage(message, doNotAskBtn)
+            .then((result) => {
+              if (result === doNotAskBtn) {
+                void config.update(
+                  'doNotWarnMissingSourceDir',
+                  true,
+                  vscode.ConfigurationTarget.Global
+                );
+              }
+            });
+        }
         return undefined;
-      } else {
-        // CppProjectType.Kit
-        const kit = await getSelectedKit();
-        if (!kit) {
-          return undefined;
-        }
-        const insRoot = getQtInsRoot(kit);
-        if (!insRoot) {
-          const config = vscode.workspace.getConfiguration(EXTENSION_ID);
-          const doNotWarn = config.get<boolean>(
-            'doNotWarnMissingSourceDir',
-            false
-          );
-          const message = `Cannot find VSCODE_QT_INSTALLATION in the selected kit: ${kit.name}. Source directory cannot be determined.`;
-          logger.error(message);
-          if (!doNotWarn) {
-            const doNotAskBtn = 'Do not show again';
-            void vscode.window
-              .showWarningMessage(message, doNotAskBtn)
-              .then((result) => {
-                if (result === doNotAskBtn) {
-                  void config.update(
-                    'doNotWarnMissingSourceDir',
-                    true,
-                    vscode.ConfigurationTarget.Global
-                  );
-                }
-              });
-          }
-          return undefined;
-        }
-        // Remove the last part of the path to get the source directory
-        // For example, if insRoot is '/path/to/Qt/6.5.0/gcc_64', we want to get '/path/to/Qt/6.5.0'
-        const versionDir = path.dirname(insRoot);
-        // Add the 'Src' directory to the path
-        const sourceDir = path.join(versionDir, 'Src');
-        logger.info(`Source directory for kit ${kit.name} is: ${sourceDir}`);
-        return sourceDir;
       }
+      logger.info(`Source directory: ${sourceDir}`);
+      return sourceDir;
     }
   );
 }

--- a/qt-cpp/src/commands/source-directory.ts
+++ b/qt-cpp/src/commands/source-directory.ts
@@ -19,7 +19,7 @@ export function registerSourceDirectoryCommand() {
         logger.warn(
           'No active C++ project found. Cannot determine source directory.'
         );
-        return undefined;
+        return 'undefined';
       }
       const sourceDir = await project.getSourceDirectory();
       if (!sourceDir) {
@@ -45,7 +45,7 @@ export function registerSourceDirectoryCommand() {
               }
             });
         }
-        return undefined;
+        return 'undefined';
       }
       logger.info(`Source directory: ${sourceDir}`);
       return sourceDir;

--- a/qt-cpp/src/project.ts
+++ b/qt-cpp/src/project.ts
@@ -569,6 +569,14 @@ export class CppProject implements Project {
     }
     return undefined;
   }
+  async getSourceDirectory(): Promise<string | undefined> {
+    const installationPath = await this.getInstallationPath();
+    if (!installationPath) {
+      return undefined;
+    }
+    const versionDir = path.dirname(installationPath);
+    return path.join(versionDir, 'Src');
+  }
   async getQtPathsExeFromKit() {
     const folder = this.folder;
     const kit = await getSelectedKit(folder, true);


### PR DESCRIPTION
* qt-cpp: Move source directory logic into CppProject
Add getSourceDirectory() to CppProject, which uses the existing
getInstallationPath() to work for both Kit and Preset project types.
Simplify the sourceDirectory command to delegate to the project
instead of handling project type details directly.
* qt-cpp: Fix debugging fails silently when CMakePresets is used with qtpaths
When using CMakePresets with qtpaths, the extension fails to determine
the source directory.Instead of returning undefined, we should return
the string 'undefined' to avoid block debugging silently and log the
warning message to the user.

Fixes: [VSCODEEXT-311](https://qt-project.atlassian.net/browse/VSCODEEXT-311)

