### PR TITLE
qt-core: Generate CMakePresets.json for example projects

### DIFF
--- a/qt-core/src/webview/ex-browser/data-manager.ts
+++ b/qt-core/src/webview/ex-browser/data-manager.ts
@@ -17,12 +17,15 @@ import * as catHelpers from './helpers-category';
 import * as searchHelpers from './helpers-search';
 import { ExPathsResolver } from './resolvers';
 import { parseManifestFile, ManifestType } from './manifest-parser';
+import { resolveQtInstallation, type QtInstallationInfo } from './helpers';
 
 const logger = createLogger('examples-data-manager');
 
 export class ExDataManager {
   private _packages: ExPackage[] = [];
   private _categories: ExCategory[] = [];
+  private _selectedPackage: ExPackage | undefined;
+  private _qtInstallation: QtInstallationInfo | undefined;
 
   private _examples: ExEntry[] = [];
   private _resolvedPaths: Record<string, ExResolvedPaths> = {};
@@ -34,6 +37,8 @@ export class ExDataManager {
   public dispose() {
     this._packages = [];
     this._categories = [];
+    this._selectedPackage = undefined;
+    this._qtInstallation = undefined;
     this._examples = [];
     this._resolvedPaths = {};
   }
@@ -54,9 +59,19 @@ export class ExDataManager {
     return this._resolvedPaths;
   }
 
-  public selectPackage(p: ExPackage) {
+  get selectedPackage() {
+    return this._selectedPackage;
+  }
+
+  get qtInstallation() {
+    return this._qtInstallation;
+  }
+
+  public async selectPackage(p: ExPackage) {
     logger.info(`Selecting examples: ${p.poolDir.fsPath}, ${p.subDir}`);
 
+    this._selectedPackage = p;
+    this._qtInstallation = await resolveQtInstallation(p.poolDir, p.subDir);
     this._examples = [];
     this._resolvedPaths = {};
 

--- a/qt-core/src/webview/ex-browser/dispatcher.ts
+++ b/qt-core/src/webview/ex-browser/dispatcher.ts
@@ -117,13 +117,13 @@ export class ExBrowserDispatcher {
     this._comm.postDataReply(cmd, r);
   };
 
-  private readonly _onSelectPackage = (cmd: Command) => {
+  private readonly _onSelectPackage = async (cmd: Command) => {
     const p = _.get(cmd.payload, 'package', {});
     if (!isExPackage(p)) {
       throw Error('Parameter is invalid');
     }
 
-    this._data.selectPackage(p);
+    await this._data.selectPackage(p);
     this._comm.postDataReply(cmd, {
       info: p,
       categories: this._data.categories,
@@ -183,7 +183,12 @@ export class ExBrowserDispatcher {
           const rel = example.projectPath;
           const originalName = path.basename(path.dirname(rel));
 
-          helpers.createNewProject(args, abs, originalName);
+          helpers.createNewProject(
+            args,
+            abs,
+            originalName,
+            this._data.qtInstallation
+          );
           await helpers.saveNewProjectArgs(args, this._context);
         }
       }

--- a/qt-core/src/webview/ex-browser/helpers.ts
+++ b/qt-core/src/webview/ex-browser/helpers.ts
@@ -11,6 +11,7 @@ import {
   findQtKits,
   findQtPathsInInstallationPath,
   generateDefaultQtPathsName,
+  getMsvcInfo,
   IsWindows,
   QtInfo
 } from 'qt-lib';
@@ -251,46 +252,6 @@ export async function resolveQtInstallation(
   }
 
   return undefined;
-}
-
-const MsvcArchRegexp = /msvc\d{4}_(.+)/;
-const MsvcYearRegexp = /msvc(\d{4})/;
-const MsvcArchMap: Record<string, string> = {
-  '64': 'x64',
-  '32': 'x86',
-  arm64: 'ARM64'
-};
-const MsvcYearToVsVersion: Record<string, string> = {
-  '2015': '14',
-  '2017': '15',
-  '2019': '16',
-  '2022': '17'
-};
-
-interface MsvcInfo {
-  arch: string;
-  vsGenerator: string;
-}
-
-function getMsvcInfo(prefixPath: string): MsvcInfo | undefined {
-  const toolchain = path.basename(prefixPath);
-  if (!toolchain.startsWith('msvc')) {
-    return undefined;
-  }
-  const archMatch = toolchain.match(MsvcArchRegexp);
-  const archStr = archMatch?.[1] ?? '64';
-  const arch = MsvcArchMap[archStr] ?? 'x64';
-
-  const yearMatch = toolchain.match(MsvcYearRegexp);
-  const year = yearMatch?.[1] ?? '2022';
-  const vsVersion = MsvcYearToVsVersion[year];
-  if (!vsVersion) {
-    return undefined;
-  }
-  return {
-    arch,
-    vsGenerator: `Visual Studio ${vsVersion} ${year}`
-  };
 }
 
 function generateCMakePresets(

--- a/qt-core/src/webview/ex-browser/helpers.ts
+++ b/qt-core/src/webview/ex-browser/helpers.ts
@@ -1,9 +1,19 @@
 // Copyright (C) 2026 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
+import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import * as commandExists from 'command-exists';
 
+import {
+  createLogger,
+  findQtKits,
+  findQtPathsInInstallationPath,
+  generateDefaultQtPathsName,
+  IsWindows,
+  QtInfo
+} from 'qt-lib';
 import { coreAPI } from '@/extension';
 import { GlobalStateManager } from '@/state';
 import { getNewProjectBaseDir, setDefaultProjectDir } from '@/qtcli/commands';
@@ -19,6 +29,8 @@ import {
 import { fsDir } from '@/fs-utils';
 
 type Context = vscode.ExtensionContext;
+
+const logger = createLogger('ex-browser-helpers');
 
 export function createViewConfig(context: Context): ExBrowserViewConfig {
   return {
@@ -52,7 +64,8 @@ export function findAllPackagePools(): ExPackagePoolDir[] {
         fsPath: parent,
         ...(docs ? { docsPath: docs } : {}),
         ...(examples ? { examplesPath: examples } : {}),
-        ...(version ? { qtVersion: version } : {})
+        ...(version ? { qtVersion: version } : {}),
+        qtPathsExe: p.path
       });
     }
   });
@@ -63,13 +76,16 @@ export function findAllPackagePools(): ExPackagePoolDir[] {
 export function createNewProject(
   args: ExNewProjectArgs,
   projectAbsDir: string,
-  projectName: string
+  projectName: string,
+  qtInstallation: QtInstallationInfo | undefined
 ) {
   const name = args.name || projectName;
   const sourceDir = fsDir(projectAbsDir);
   const targetDir = fsDir(args.workingDir, name);
 
   sourceDir.copyAll(targetDir.toString());
+
+  generateCMakePresets(targetDir.toString(), qtInstallation);
 
   void targetDir.openAsWorkspace({
     newWindow: args.openIn === 'newWindow'
@@ -94,4 +110,318 @@ export async function saveOpenInArg(
 
 export function fallbackImageDir(c: Context) {
   return vscode.Uri.joinPath(c.extensionUri, 'res', 'icons');
+}
+
+export interface QtInstallationInfo {
+  name: string;
+  prefixPath: string;
+  toolchainFile: string | undefined;
+  binDir: string;
+  vendor: Record<string, string>;
+}
+
+function extractVersionFromSubDir(subDir: string): string {
+  // subDir is like "Qt-6.8.0", extract "6.8.0"
+  const prefix = 'Qt-';
+  if (subDir.startsWith(prefix)) {
+    return subDir.substring(prefix.length);
+  }
+  return subDir;
+}
+
+function getToolchainFile(prefixPath: string): string | undefined {
+  const toolchainPath = path.join(
+    prefixPath,
+    'lib',
+    'cmake',
+    'Qt6',
+    'qt.toolchain.cmake'
+  );
+  return fs.existsSync(toolchainPath) ? toolchainPath : undefined;
+}
+
+function resolveHostInstallation(
+  qtInfo: QtInfo
+): QtInstallationInfo | undefined {
+  const prefixPath = qtInfo.get('QT_INSTALL_PREFIX');
+  const hostPrefix = qtInfo.get('QT_HOST_PREFIX');
+
+  // If QT_HOST_PREFIX differs from QT_INSTALL_PREFIX, this is a cross-compilation
+  // target. Follow QT_HOST_PREFIX once to get the host installation.
+  if (hostPrefix && prefixPath && hostPrefix !== prefixPath) {
+    const hostQtPaths = findQtPathsInInstallationPath(hostPrefix);
+    if (hostQtPaths) {
+      const hostInfo = coreAPI?.getQtInfoFromPath(hostQtPaths).info;
+      if (hostInfo) {
+        const hostBinDir =
+          hostInfo.get('QT_INSTALL_BINS') ?? path.join(hostPrefix, 'bin');
+        return {
+          name: generateDefaultQtPathsName(hostInfo),
+          prefixPath: hostPrefix,
+          toolchainFile: getToolchainFile(hostPrefix),
+          binDir: hostBinDir,
+          vendor: { VSCODE_QT_INSTALLATION: hostPrefix }
+        };
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export async function resolveQtInstallation(
+  poolDir: ExPackagePoolDir,
+  packageSubDir: string
+): Promise<QtInstallationInfo | undefined> {
+  if (poolDir.sourceType === 'qtpaths' && poolDir.qtPathsExe) {
+    const info = coreAPI?.getQtInfoFromPath(poolDir.qtPathsExe);
+    if (!info?.info) {
+      return undefined;
+    }
+
+    const hostInstallation = resolveHostInstallation(info.info);
+    if (hostInstallation) {
+      return hostInstallation;
+    }
+
+    const prefixPath = info.info.get('QT_INSTALL_PREFIX');
+    if (!prefixPath) {
+      return undefined;
+    }
+    const binDir =
+      info.info.get('QT_INSTALL_BINS') ?? path.join(prefixPath, 'bin');
+    return {
+      name: generateDefaultQtPathsName(info.info),
+      prefixPath,
+      toolchainFile: getToolchainFile(prefixPath),
+      binDir,
+      vendor: { VSCODE_QT_QTPATHS_EXE: info.info.qtPathsBin }
+    };
+  }
+
+  if (poolDir.sourceType === 'insRoot' && poolDir.fsPath) {
+    const targetVersion =
+      poolDir.qtVersion ?? extractVersionFromSubDir(packageSubDir);
+    const installations = await findQtKits(poolDir.fsPath);
+    const matchingInstallations = installations.filter((installation) => {
+      const relPath = path.relative(poolDir.fsPath, installation);
+      const versionPart = relPath.split(path.sep)[0];
+      return versionPart === targetVersion;
+    });
+
+    // On Windows, prefer MSVC installations over MinGW
+    if (IsWindows) {
+      matchingInstallations.sort((a, b) => {
+        const aIsMsvc = path.basename(a).startsWith('msvc');
+        const bIsMsvc = path.basename(b).startsWith('msvc');
+        if (aIsMsvc && !bIsMsvc) {
+          return -1;
+        }
+        if (!aIsMsvc && bIsMsvc) {
+          return 1;
+        }
+        return 0;
+      });
+    }
+
+    for (const installation of matchingInstallations) {
+      const qtPaths = findQtPathsInInstallationPath(installation);
+      const qtInfo = qtPaths
+        ? coreAPI?.getQtInfoFromPath(qtPaths).info
+        : undefined;
+
+      if (qtInfo) {
+        const hostInstallation = resolveHostInstallation(qtInfo);
+        if (hostInstallation) {
+          return hostInstallation;
+        }
+      }
+
+      const name = qtInfo
+        ? generateDefaultQtPathsName(qtInfo)
+        : path.basename(installation);
+      return {
+        name,
+        prefixPath: installation,
+        toolchainFile: getToolchainFile(installation),
+        binDir: path.join(installation, 'bin'),
+        vendor: { VSCODE_QT_INSTALLATION: installation }
+      };
+    }
+  }
+
+  return undefined;
+}
+
+const MsvcArchRegexp = /msvc\d{4}_(.+)/;
+const MsvcYearRegexp = /msvc(\d{4})/;
+const MsvcArchMap: Record<string, string> = {
+  '64': 'x64',
+  '32': 'x86',
+  arm64: 'ARM64'
+};
+const MsvcYearToVsVersion: Record<string, string> = {
+  '2015': '14',
+  '2017': '15',
+  '2019': '16',
+  '2022': '17'
+};
+
+interface MsvcInfo {
+  arch: string;
+  vsGenerator: string;
+}
+
+function getMsvcInfo(prefixPath: string): MsvcInfo | undefined {
+  const toolchain = path.basename(prefixPath);
+  if (!toolchain.startsWith('msvc')) {
+    return undefined;
+  }
+  const archMatch = toolchain.match(MsvcArchRegexp);
+  const archStr = archMatch?.[1] ?? '64';
+  const arch = MsvcArchMap[archStr] ?? 'x64';
+
+  const yearMatch = toolchain.match(MsvcYearRegexp);
+  const year = yearMatch?.[1] ?? '2022';
+  const vsVersion = MsvcYearToVsVersion[year];
+  if (!vsVersion) {
+    return undefined;
+  }
+  return {
+    arch,
+    vsGenerator: `Visual Studio ${vsVersion} ${year}`
+  };
+}
+
+function generateCMakePresets(
+  projectDir: string,
+  qtInfo: QtInstallationInfo | undefined
+) {
+  if (!qtInfo) {
+    logger.warn(
+      'No Qt installation info, skipping CMakePresets.json generation'
+    );
+    return;
+  }
+
+  const presetsPath = path.join(projectDir, 'CMakePresets.json');
+  if (fs.existsSync(presetsPath)) {
+    logger.info('CMakePresets.json already exists, skipping generation');
+    return;
+  }
+
+  const commonCacheVariables: Record<string, string> = {
+    CMAKE_EXPORT_COMPILE_COMMANDS: 'ON',
+    QT_QML_GENERATE_QMLLS_INI: 'ON',
+    CMAKE_CXX_FLAGS_DEBUG_INIT: '-DQT_QML_DEBUG -DQT_DECLARATIVE_DEBUG',
+    CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT: '-DQT_QML_DEBUG -DQT_DECLARATIVE_DEBUG'
+  };
+
+  if (qtInfo.toolchainFile) {
+    commonCacheVariables.CMAKE_TOOLCHAIN_FILE = qtInfo.toolchainFile;
+  } else {
+    commonCacheVariables.CMAKE_PREFIX_PATH = qtInfo.prefixPath;
+  }
+
+  const commonFields: Record<string, unknown> = {
+    environment: {
+      PATH: `${qtInfo.binDir};$penv{PATH}`
+    },
+    vendor: {
+      'qt-cpp': qtInfo.vendor
+    }
+  };
+
+  const msvcInfo = IsWindows ? getMsvcInfo(qtInfo.prefixPath) : undefined;
+
+  const insName = qtInfo.name;
+
+  if (msvcInfo) {
+    commonFields.generator = msvcInfo.vsGenerator;
+    commonFields.architecture = {
+      value: msvcInfo.arch,
+      strategy: 'set'
+    };
+
+    // VS generator is multi-config: one configure preset, build presets
+    // select the configuration
+    const presets = {
+      version: 3,
+      configurePresets: [
+        {
+          name: insName,
+          displayName: insName,
+          binaryDir: `\${sourceDir}/builds/${insName}`,
+          cacheVariables: {
+            ...commonCacheVariables
+          },
+          ...commonFields
+        }
+      ],
+      buildPresets: [
+        {
+          name: `${insName}-debug`,
+          displayName: `${insName} Debug`,
+          configurePreset: insName,
+          configuration: 'Debug'
+        },
+        {
+          name: `${insName}-relwithdebinfo`,
+          displayName: `${insName} RelWithDebInfo`,
+          configurePreset: insName,
+          configuration: 'RelWithDebInfo'
+        },
+        {
+          name: `${insName}-release`,
+          displayName: `${insName} Release`,
+          configurePreset: insName,
+          configuration: 'Release'
+        }
+      ]
+    };
+
+    fs.writeFileSync(presetsPath, JSON.stringify(presets, null, 2), 'utf-8');
+  } else {
+    if (commandExists.sync('ninja')) {
+      commonFields.generator = 'Ninja';
+    }
+
+    // Single-config generators: separate configure presets per build type
+    const configureTypes = [
+      {
+        name: `${insName}-debug`,
+        displayName: `${insName} Debug`,
+        buildType: 'Debug'
+      },
+      {
+        name: `${insName}-relwithdebinfo`,
+        displayName: `${insName} RelWithDebInfo`,
+        buildType: 'RelWithDebInfo'
+      },
+      {
+        name: `${insName}-release`,
+        displayName: `${insName} Release`,
+        buildType: 'Release'
+      }
+    ];
+
+    const presets = {
+      version: 3,
+      configurePresets: configureTypes.map((ct) => ({
+        name: ct.name,
+        displayName: ct.displayName,
+        binaryDir: `\${sourceDir}/builds/${insName}/${ct.buildType.toLowerCase()}`,
+        cacheVariables: {
+          CMAKE_BUILD_TYPE: ct.buildType,
+          ...commonCacheVariables
+        },
+        ...commonFields
+      }))
+    };
+
+    fs.writeFileSync(presetsPath, JSON.stringify(presets, null, 2), 'utf-8');
+  }
+  logger.info(
+    `Generated CMakePresets.json with toolchain: ${qtInfo.toolchainFile ?? 'none'}, prefix: ${qtInfo.prefixPath}`
+  );
 }

--- a/qt-core/src/webview/shared/ex-browser.ts
+++ b/qt-core/src/webview/shared/ex-browser.ts
@@ -82,6 +82,7 @@ export interface ExPackagePoolDir {
   docsPath?: string;
   examplesPath?: string;
   qtVersion?: string;
+  qtPathsExe?: string;
 }
 
 export function isExPackagePoolDir(x: unknown): x is ExPackagePoolDir {
@@ -96,7 +97,8 @@ export function isExPackagePoolDir(x: unknown): x is ExPackagePoolDir {
     (o.sourceType === 'insRoot' || o.sourceType === 'qtpaths') &&
     (o.docsPath === undefined || typeof o.docsPath === 'string') &&
     (o.examplesPath === undefined || typeof o.examplesPath === 'string') &&
-    (o.qtVersion === undefined || typeof o.qtVersion === 'string')
+    (o.qtVersion === undefined || typeof o.qtVersion === 'string') &&
+    (o.qtPathsExe === undefined || typeof o.qtPathsExe === 'string')
   );
 }
 

--- a/qt-cpp/src/kit-manager.ts
+++ b/qt-cpp/src/kit-manager.ts
@@ -22,7 +22,13 @@ import {
   getVCPKGRoot,
   telemetry,
   TelemetryEventProperties,
-  fileWriter
+  fileWriter,
+  MsvcPlatformToQtArch,
+  MsvcToolchainRegexp,
+  MsvcToolchainNoArchRegexp,
+  MsvcYearInNameRegexp,
+  VsMajorVersionRegexp,
+  VsMajorVersionToYear
 } from 'qt-lib';
 import * as qtPath from '@util/get-qt-paths';
 import { CppProject, CppProjectType } from '@/project';
@@ -131,30 +137,6 @@ export class KitManager {
   projects = new Set<CppProject>();
   workspaceFile: vscode.Uri | undefined;
   globalStateManager: GlobalStateManager;
-  static readonly MapMsvcPlatformToQt: Record<string, string> = {
-    x64: '64',
-    amd64_x86: '32',
-    x86_amd64: '64',
-    amd64: '64',
-    win32: '32',
-    x86: '32',
-    x86_64: '64',
-    i386: '32',
-    arm64: '64'
-  };
-  static readonly MsvcInfoRegexp = /msvc(\d\d\d\d)_(.+)/; // msvcYEAR_ARCH
-  static readonly MsvcInfoNoArchRegexp = /msvc(\d\d\d\d)/; // msvcYEAR
-  static readonly MsvcYearRegex = / (\d\d\d\d) /;
-  static readonly MsvcMajorVersionNumberRegex = /VisualStudio\.(\d\d)\.\d /;
-  static readonly MapMsvcMajorVersionToItsYear: Record<string, string> = {
-    11: '2008',
-    12: '2010',
-    13: '2012',
-    14: '2015',
-    15: '2017',
-    16: '2019',
-    17: '2022'
-  };
 
   constructor(readonly context: vscode.ExtensionContext) {
     this.globalStateManager = new GlobalStateManager(context);
@@ -437,7 +419,7 @@ export class KitManager {
         yield undefined;
         return;
       }
-      const arch = KitManager.MapMsvcPlatformToQt[qtInfo.get('ARCH') ?? ''];
+      const arch = MsvcPlatformToQtArch[qtInfo.get('ARCH') ?? ''];
       if (!arch) {
         logger.warn(`arch: ${arch ?? ''}`);
         yield undefined;
@@ -583,8 +565,8 @@ export class KitManager {
         ) as Kit[];
         logger.info(`MSVC kits clone: ${JSON.stringify(msvcKitsClone)}`);
         const msvcInfoMatch =
-          toolchain.match(KitManager.MsvcInfoRegexp) ??
-          toolchain.match(KitManager.MsvcInfoNoArchRegexp);
+          toolchain.match(MsvcToolchainRegexp) ??
+          toolchain.match(MsvcToolchainNoArchRegexp);
         const vsYear = msvcInfoMatch?.at(1) ?? '';
         const architecture = msvcInfoMatch?.at(2) ?? '32';
         yield* KitManager.generateMsvcKits(
@@ -803,9 +785,8 @@ export class KitManager {
       const msvcTargetArch = kit.visualStudioArchitecture?.toLowerCase() ?? '';
       const msvcTargetPlatformArch = kit.preferredGenerator?.platform ?? '';
       logger.info('msvcTargetArch: ' + msvcTargetArch);
-      const targetArchitecture = KitManager.MapMsvcPlatformToQt[msvcTargetArch];
-      const targetPlatformArch =
-        KitManager.MapMsvcPlatformToQt[msvcTargetPlatformArch];
+      const targetArchitecture = MsvcPlatformToQtArch[msvcTargetArch];
+      const targetPlatformArch = MsvcPlatformToQtArch[msvcTargetPlatformArch];
       const isArchMatch =
         targetArchitecture == architecture &&
         targetPlatformArch == architecture;
@@ -847,15 +828,13 @@ export class KitManager {
   }
 
   private static getMsvcYear(kit: Kit) {
-    const year = kit.name.match(KitManager.MsvcYearRegex)?.at(1) ?? '';
+    const year = kit.name.match(MsvcYearInNameRegexp)?.at(1) ?? '';
     if (year) {
       return year;
     }
-    const majorMsvcVersion = kit.name
-      .match(KitManager.MsvcMajorVersionNumberRegex)
-      ?.at(1);
+    const majorMsvcVersion = kit.name.match(VsMajorVersionRegexp)?.at(1);
     if (majorMsvcVersion) {
-      return KitManager.MapMsvcMajorVersionToItsYear[majorMsvcVersion] ?? '';
+      return VsMajorVersionToYear[majorMsvcVersion] ?? '';
     }
     return '';
   }

--- a/qt-lib/src/index.ts
+++ b/qt-lib/src/index.ts
@@ -14,3 +14,4 @@ export * from './test-constants';
 export * from './file-finder';
 export * from './qrc-parser';
 export * from './qml-api';
+export * from './msvc';

--- a/qt-lib/src/msvc.ts
+++ b/qt-lib/src/msvc.ts
@@ -1,0 +1,106 @@
+// Copyright (C) 2026 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as path from 'path';
+
+/**
+ * Maps MSVC platform identifiers (from CMake kits) to Qt's architecture
+ * suffix (e.g. '64', '32').
+ */
+export const MsvcPlatformToQtArch: Record<string, string> = {
+  x64: '64',
+  amd64_x86: '32',
+  x86_amd64: '64',
+  amd64: '64',
+  win32: '32',
+  x86: '32',
+  x86_64: '64',
+  i386: '32',
+  arm64: '64'
+};
+
+/**
+ * Maps Qt's architecture suffix to CMake architecture value.
+ */
+export const QtArchToCMakeArch: Record<string, string> = {
+  '64': 'x64',
+  '32': 'x86',
+  arm64: 'ARM64'
+};
+
+/**
+ * Bidirectional mapping between VS major version number and its marketing year.
+ */
+export const VsVersionToYear: Record<string, string> = {
+  '14': '2015',
+  '15': '2017',
+  '16': '2019',
+  '17': '2022'
+};
+
+export const VsYearToVersion: Record<string, string> = {
+  '2015': '14',
+  '2017': '15',
+  '2019': '16',
+  '2022': '17'
+};
+
+/**
+ * Maps VS major version (from kit name like "VisualStudio.17.0") to its year.
+ */
+export const VsMajorVersionToYear: Record<string, string> = {
+  '11': '2008',
+  '12': '2010',
+  '13': '2012',
+  ...VsVersionToYear
+};
+
+/** Matches `msvcYEAR_ARCH` (e.g. `msvc2022_64`). Group 1 = year, group 2 = arch. */
+export const MsvcToolchainRegexp = /msvc(\d{4})_(.+)/;
+
+/** Matches `msvcYEAR` without arch suffix (e.g. `msvc2022`). Group 1 = year. */
+export const MsvcToolchainNoArchRegexp = /msvc(\d{4})/;
+
+/** Matches a 4-digit year surrounded by spaces in a kit name. */
+export const MsvcYearInNameRegexp = / (\d{4}) /;
+
+/** Matches `VisualStudio.XX.Y` and captures the major version XX. */
+export const VsMajorVersionRegexp = /VisualStudio\.(\d{2})\.\d /;
+
+export interface MsvcInfo {
+  arch: string;
+  year: string;
+  vsGenerator: string;
+}
+
+/**
+ * Extracts MSVC info from a Qt installation path by parsing its basename
+ * (e.g. `msvc2022_64`).
+ *
+ * @returns `MsvcInfo` with architecture, year, and VS generator string,
+ *          or `undefined` if the path doesn't represent an MSVC installation.
+ */
+export function getMsvcInfo(installationPath: string): MsvcInfo | undefined {
+  const toolchain = path.basename(installationPath);
+  if (!toolchain.startsWith('msvc')) {
+    return undefined;
+  }
+  const match =
+    toolchain.match(MsvcToolchainRegexp) ??
+    toolchain.match(MsvcToolchainNoArchRegexp);
+  if (!match) {
+    return undefined;
+  }
+  const year = match[1] ?? '2022';
+  const archStr = match[2] ?? '64';
+  const arch = QtArchToCMakeArch[archStr] ?? 'x64';
+  const vsVersion = VsYearToVersion[year];
+  if (!vsVersion) {
+    return undefined;
+  }
+  return {
+    arch,
+    year,
+    vsGenerator: `Visual Studio ${vsVersion} ${year}`
+  };
+}


### PR DESCRIPTION
When users create a project from the Qt Examples browser,
generate a CMakePresets.json with the Qt toolchain file,
debug flags, and vendor metadata so CMake Tools can
configure without requiring manual kit selection.

The Qt installation is resolved when a package version is
selected and stored in ExDataManager. For qtpaths sources,
the stored qtPathsExe is used directly. For insRoot sources,
installations are matched by version via findQtKits.

Preset names include the installation name derived from
generateDefaultQtPathsName (e.g. Qt-6.9.3-macx-clang-arm64)
and three build types are generated: Debug, RelWithDebInfo,
and Release. Build directories follow the pattern
builds/<installation-name>/<build-type>.

Cross-compilation targets (where QT_HOST_PREFIX differs from
QT_INSTALL_PREFIX) are detected and resolved to the host
installation to ensure the generated presets are buildable
on the current machine.

Fixes: [VSCODEEXT-309](https://qt-project.atlassian.net/browse/VSCODEEXT-309)
