### PR TITLE
qt-core: qt-qml: Generate .vscode/settings.json and launch.json for new projects and examples & Activate extension for .qml and .qmlproject files

### DIFF
--- a/qt-core/src/project-config-generator.ts
+++ b/qt-core/src/project-config-generator.ts
@@ -1,0 +1,324 @@
+// Copyright (C) 2026 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { createLogger, IsWindows } from 'qt-lib';
+
+const logger = createLogger('project-config-generator');
+
+interface LaunchConfiguration {
+  name: string;
+  type: string;
+  request: string;
+  [key: string]: unknown;
+}
+
+interface CompoundConfiguration {
+  name: string;
+  configurations: string[];
+  preLaunchTask?: string;
+}
+
+function recommendedSettings(): Record<string, unknown> {
+  return {
+    'cmake.options.statusBarVisibility': 'visible',
+    'cmake.buildDirectory': '${workspaceFolder}/builds/${buildKit}/${buildType}'
+  };
+}
+
+function cppdbgLaunchConfig(): LaunchConfiguration {
+  const config: LaunchConfiguration = {
+    name: 'Debug Qt Application with cppdbg',
+    type: 'cppdbg',
+    request: 'launch',
+    program: '${command:cmake.launchTargetPath}',
+    stopAtEntry: false,
+    cwd: '${workspaceFolder}',
+    visualizerFile: '${command:qt-cpp.natvis}',
+    showDisplayString: true,
+    linux: {
+      MIMode: 'gdb',
+      miDebuggerPath: '/usr/bin/gdb',
+      sourceFileMap: {
+        '/home/qt/work/qt': '${command:qt-cpp.sourceDirectory}'
+      }
+    },
+    osx: {
+      MIMode: 'lldb',
+      sourceFileMap: {
+        '/Users/qt/work/qt': '${command:qt-cpp.sourceDirectory}'
+      }
+    },
+    windows: {
+      sourceFileMap: {
+        'Q:/qt5_workdir/w/s': '${command:qt-cpp.sourceDirectory}',
+        'C:/work/build/qt5_workdir/w/s': '${command:qt-cpp.sourceDirectory}',
+        'c:/users/qt/work/qt': '${command:qt-cpp.sourceDirectory}',
+        'c:/Users/qt/work/install': '${command:qt-cpp.sourceDirectory}',
+        '/Users/qt/work/qt': '${command:qt-cpp.sourceDirectory}'
+      },
+      environment: [
+        {
+          name: 'PATH',
+          value: '${env:PATH};${command:qt-cpp.qtDir}'
+        },
+        {
+          name: 'QT_QPA_PLATFORM_PLUGIN_PATH',
+          value: '${command:qt-cpp.QT_QPA_PLATFORM_PLUGIN_PATH}'
+        },
+        {
+          name: 'QML_IMPORT_PATH',
+          value: '${command:qt-cpp.QML_IMPORT_PATH}'
+        }
+      ],
+      MIMode: 'gdb',
+      miDebuggerPath: '${command:qt-cpp.minGWgdb}'
+    }
+  };
+
+  return config;
+}
+
+function cppvsdbgLaunchConfig(): LaunchConfiguration {
+  return {
+    name: 'Debug Qt Application with Visual Studio Debugger',
+    type: 'cppvsdbg',
+    request: 'launch',
+    program: '${command:cmake.launchTargetPath}',
+    stopAtEntry: false,
+    cwd: '${workspaceFolder}',
+    visualizerFile: '${command:qt-cpp.natvis}',
+    windows: {
+      sourceFileMap: {
+        'Q:/qt5_workdir/w/s': '${command:qt-cpp.sourceDirectory}',
+        'C:/work/build/qt5_workdir/w/s': '${command:qt-cpp.sourceDirectory}',
+        'c:/users/qt/work/qt': '${command:qt-cpp.sourceDirectory}',
+        'c:/Users/qt/work/install': '${command:qt-cpp.sourceDirectory}',
+        '/Users/qt/work/qt': '${command:qt-cpp.sourceDirectory}'
+      },
+      environment: [
+        {
+          name: 'PATH',
+          value: '${env:PATH};${command:qt-cpp.qtDir}'
+        },
+        {
+          name: 'QT_QPA_PLATFORM_PLUGIN_PATH',
+          value: '${command:qt-cpp.QT_QPA_PLATFORM_PLUGIN_PATH}'
+        },
+        {
+          name: 'QML_IMPORT_PATH',
+          value: '${command:qt-cpp.QML_IMPORT_PATH}'
+        }
+      ]
+    }
+  };
+}
+
+function qmlAttachLaunchConfig(): LaunchConfiguration {
+  return {
+    name: 'Attach to QML debugger',
+    type: 'qml',
+    request: 'attach',
+    host: 'localhost',
+    port: '${command:qt-qml.debugPort}'
+  };
+}
+
+const qmlDebuggerArgs =
+  '-qmljsdebugger=host:localhost,port:${command:qt-qml.debugPort},' +
+  'block,services:DebugMessages,QmlDebugger,V8Debugger';
+
+function cppQmlCppdbgLaunchConfig(): LaunchConfiguration {
+  return {
+    name: 'C++ launch for QML debugging (cppdbg)',
+    type: 'cppdbg',
+    request: 'launch',
+    program: '${command:cmake.launchTargetPath}',
+    stopAtEntry: false,
+    cwd: '${workspaceFolder}',
+    visualizerFile: '${command:qt-cpp.natvis}',
+    showDisplayString: true,
+    args: [qmlDebuggerArgs],
+    linux: {
+      MIMode: 'gdb',
+      miDebuggerPath: '/usr/bin/gdb',
+      sourceFileMap: {
+        '/home/qt/work/qt': '${command:qt-cpp.sourceDirectory}'
+      }
+    },
+    osx: {
+      MIMode: 'lldb',
+      sourceFileMap: {
+        '/Users/qt/work/qt': '${command:qt-cpp.sourceDirectory}'
+      }
+    },
+    windows: {
+      sourceFileMap: {
+        'Q:/qt5_workdir/w/s': '${command:qt-cpp.sourceDirectory}',
+        'C:/work/build/qt5_workdir/w/s': '${command:qt-cpp.sourceDirectory}',
+        'c:/users/qt/work/qt': '${command:qt-cpp.sourceDirectory}',
+        'c:/Users/qt/work/install': '${command:qt-cpp.sourceDirectory}',
+        '/Users/qt/work/qt': '${command:qt-cpp.sourceDirectory}'
+      },
+      environment: [
+        {
+          name: 'PATH',
+          value: '${env:PATH};${command:qt-cpp.qtDir}'
+        },
+        {
+          name: 'QT_QPA_PLATFORM_PLUGIN_PATH',
+          value: '${command:qt-cpp.QT_QPA_PLATFORM_PLUGIN_PATH}'
+        },
+        {
+          name: 'QML_IMPORT_PATH',
+          value: '${command:qt-cpp.QML_IMPORT_PATH}'
+        }
+      ],
+      MIMode: 'gdb',
+      miDebuggerPath: '${command:qt-cpp.minGWgdb}'
+    }
+  };
+}
+
+function cppQmlCppvsdbgLaunchConfig(): LaunchConfiguration {
+  return {
+    name: 'C++ launch for QML debugging (cppvsdbg)',
+    type: 'cppvsdbg',
+    request: 'launch',
+    program: '${command:cmake.launchTargetPath}',
+    stopAtEntry: false,
+    cwd: '${workspaceFolder}',
+    visualizerFile: '${command:qt-cpp.natvis}',
+    args: [qmlDebuggerArgs],
+    windows: {
+      sourceFileMap: {
+        'Q:/qt5_workdir/w/s': '${command:qt-cpp.sourceDirectory}',
+        'C:/work/build/qt5_workdir/w/s': '${command:qt-cpp.sourceDirectory}',
+        'c:/users/qt/work/qt': '${command:qt-cpp.sourceDirectory}',
+        'c:/Users/qt/work/install': '${command:qt-cpp.sourceDirectory}',
+        '/Users/qt/work/qt': '${command:qt-cpp.sourceDirectory}'
+      },
+      environment: [
+        {
+          name: 'PATH',
+          value: '${env:PATH};${command:qt-cpp.qtDir}'
+        },
+        {
+          name: 'QT_QPA_PLATFORM_PLUGIN_PATH',
+          value: '${command:qt-cpp.QT_QPA_PLATFORM_PLUGIN_PATH}'
+        },
+        {
+          name: 'QML_IMPORT_PATH',
+          value: '${command:qt-cpp.QML_IMPORT_PATH}'
+        }
+      ]
+    }
+  };
+}
+
+function hasQmlFiles(projectDir: string): boolean {
+  function search(dir: string): boolean {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return false;
+    }
+
+    for (const entry of entries) {
+      if (entry.isFile() && entry.name.endsWith('.qml')) {
+        return true;
+      }
+      if (
+        entry.isDirectory() &&
+        entry.name !== 'build' &&
+        entry.name !== 'builds'
+      ) {
+        if (search(path.join(dir, entry.name))) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  return search(projectDir);
+}
+
+function launchConfigurations(qml: boolean): {
+  configurations: LaunchConfiguration[];
+  compounds: CompoundConfiguration[];
+} {
+  const configs: LaunchConfiguration[] = [cppdbgLaunchConfig()];
+  const compounds: CompoundConfiguration[] = [];
+
+  if (IsWindows) {
+    configs.push(cppvsdbgLaunchConfig());
+  }
+
+  if (qml) {
+    const cppQmlCppdbg = cppQmlCppdbgLaunchConfig();
+    const qmlAttach = qmlAttachLaunchConfig();
+    configs.push(cppQmlCppdbg, qmlAttach);
+
+    if (IsWindows) {
+      const cppQmlVsdbg = cppQmlCppvsdbgLaunchConfig();
+      configs.push(cppQmlVsdbg);
+
+      compounds.push({
+        name: 'C++/QML (cppvsdbg)',
+        configurations: [cppQmlVsdbg.name, qmlAttach.name],
+        preLaunchTask: 'Qt: Acquire Port'
+      });
+    }
+
+    compounds.push({
+      name: 'C++/QML',
+      configurations: [cppQmlCppdbg.name, qmlAttach.name],
+      preLaunchTask: 'Qt: Acquire Port'
+    });
+  }
+
+  return { configurations: configs, compounds };
+}
+
+function writeJsonFile(filePath: string, content: unknown) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  fs.writeFileSync(filePath, JSON.stringify(content, undefined, 4) + '\n');
+}
+
+export function generateProjectConfigs(projectDir: string) {
+  const vscodeDir = path.join(projectDir, '.vscode');
+
+  try {
+    const settingsPath = path.join(vscodeDir, 'settings.json');
+    if (!fs.existsSync(settingsPath)) {
+      writeJsonFile(settingsPath, recommendedSettings());
+    }
+
+    const launchPath = path.join(vscodeDir, 'launch.json');
+    if (!fs.existsSync(launchPath)) {
+      const qml = hasQmlFiles(projectDir);
+      const { configurations, compounds } = launchConfigurations(qml);
+
+      const launchJson: Record<string, unknown> = {
+        version: '0.2.0',
+        configurations
+      };
+
+      if (compounds.length > 0) {
+        launchJson.compounds = compounds;
+      }
+
+      writeJsonFile(launchPath, launchJson);
+    }
+  } catch (e) {
+    logger.error(`Failed to generate project configs: ${String(e)}`);
+  }
+}

--- a/qt-core/src/webview/ex-browser/helpers.ts
+++ b/qt-core/src/webview/ex-browser/helpers.ts
@@ -17,6 +17,7 @@ import {
   ExBrowserViewConfig
 } from '@/webview/shared/ex-browser';
 import { fsDir } from '@/fs-utils';
+import { generateProjectConfigs } from '@/project-config-generator';
 
 type Context = vscode.ExtensionContext;
 
@@ -70,6 +71,7 @@ export function createNewProject(
   const targetDir = fsDir(args.workingDir, name);
 
   sourceDir.copyAll(targetDir.toString());
+  generateProjectConfigs(targetDir.toString());
 
   void targetDir.openAsWorkspace({
     newWindow: args.openIn === 'newWindow'

--- a/qt-core/src/webview/new-item/dispatcher.ts
+++ b/qt-core/src/webview/new-item/dispatcher.ts
@@ -10,6 +10,7 @@ import * as texts from '@/texts';
 import { QtcliRestClient, QtcliRestError } from '@/qtcli/rest';
 import { openFilesUnder, openUri } from '@/qtcli/common';
 import { getNewProjectBaseDir, setDefaultProjectDir } from '@/qtcli/commands';
+import { generateProjectConfigs } from '@/project-config-generator';
 import { WebviewChannel } from '@/webview/channel';
 import { Command, CommandId, IsCommand } from '@/webview/shared/message';
 import { GlobalStateManager } from '@/state';
@@ -257,6 +258,7 @@ function openItemsFromQtcliResponseData(
   }
 
   if (type === 'project') {
+    generateProjectConfigs(path.normalize(filesDir));
     const uri = vscode.Uri.file(path.normalize(filesDir));
     if (openIn === 'newWindow') {
       void vscode.commands.executeCommand('vscode.openFolder', uri, true);

--- a/qt-qml/package.json
+++ b/qt-qml/package.json
@@ -29,6 +29,8 @@
   "qna": "marketplace",
   "pricing": "Free",
   "activationEvents": [
+    "workspaceContains:**/*.qml",
+    "workspaceContains:**/*.qmlproject",
     "workspaceContains:**/*.qtd",
     "workspaceContains:**/*.qzt"
   ],


### PR DESCRIPTION
- qt-core: Generate .vscode/settings.json and launch.json for new projects and examples
Add project-config-generator module that writes .vscode/settings.json
with recommended CMake settings and .vscode/launch.json with debug
configurations when creating projects from the wizard or examples
browser. Launch configs include cppdbg (cross-platform), cppvsdbg
(Windows), and QML-specific configs with C++/QML compounds when the
project contains .qml files. Existing files are not overwritten.
- qt-qml: Activate extension for .qml and .qmlproject files
When users don't have open .qml and .qmlproject files in their workspace
, qt-qml extension is not activated. If users wants to use qt-qml
commands, the command will not be found. That's why we need to
activate qt-qml extension for .qml and .qmlproject files.
