### PR TITLE
qt-core: qt-cpp: qt-lib: Add QtToolsPaths CoreAPI contract for shared CMake/Ninja paths & Use CMake/Ninja  in qt-cpp and qt-core

### DIFF
--- a/qt-core/src/webview/ex-browser/helpers.ts
+++ b/qt-core/src/webview/ex-browser/helpers.ts
@@ -13,7 +13,9 @@ import {
   generateDefaultQtPathsName,
   getMsvcInfo,
   IsWindows,
-  QtInfo
+  QtInfo,
+  QtToolsPaths,
+  CoreKey
 } from 'qt-lib';
 import { coreAPI } from '@/extension';
 import { GlobalStateManager } from '@/state';
@@ -33,6 +35,15 @@ import { generateProjectConfigs } from '@/project-config-generator';
 type Context = vscode.ExtensionContext;
 
 const logger = createLogger('ex-browser-helpers');
+
+// Build-tool paths (CMake, Ninja) bundled with the Qt installation and shared
+// by qt-sm via CoreAPI.
+function getSharedQtToolsPaths(): QtToolsPaths | undefined {
+  return coreAPI?.getValue<QtToolsPaths>(
+    CoreKey.GLOBAL_WORKSPACE,
+    CoreKey.QT_TOOLS_PATHS
+  );
+}
 
 export function createViewConfig(context: Context): ExBrowserViewConfig {
   return {
@@ -347,6 +358,14 @@ function generateCMakePresets(
   } else {
     if (commandExists.sync('ninja')) {
       commonFields.generator = 'Ninja';
+    } else {
+      // Ninja is not on PATH; fall back to the one shared by qt-sm via CoreAPI
+      // and point CMake at it explicitly.
+      const sharedNinjaPath = getSharedQtToolsPaths()?.ninja;
+      if (sharedNinjaPath) {
+        commonFields.generator = 'Ninja';
+        commonCacheVariables.CMAKE_MAKE_PROGRAM = sharedNinjaPath;
+      }
     }
 
     // Single-config generators: separate configure presets per build type

--- a/qt-cpp/src/extension.ts
+++ b/qt-cpp/src/extension.ts
@@ -147,6 +147,13 @@ async function processMessage(message: QtWorkspaceConfigMessage) {
       await kitManager.onQtPathsChanged(additionalQtPaths, project?.folder);
       continue;
     }
+
+    if (key === CoreKey.QT_TOOLS_PATHS) {
+      // Shared CMake/Ninja paths arrived (or changed); pick up the bundled
+      // CMake if the cmake command is still missing.
+      void tryToUseCMakeFromQtTools();
+      continue;
+    }
   }
 }
 

--- a/qt-cpp/src/kit-manager.ts
+++ b/qt-cpp/src/kit-manager.ts
@@ -17,6 +17,7 @@ import {
   isError,
   QtInfo,
   QtAdditionalPath,
+  QtToolsPaths,
   generateDefaultQtPathsName,
   IsWindows,
   getVCPKGRoot,
@@ -532,8 +533,11 @@ export class KitManager {
     let qtPathEnv = KitManager.generateEnvPathForQtInstallation(installation);
     let locatedNinjaExePath = '';
     if (!commandExists.sync('ninja')) {
-      const promiseNinjaExecutable = qtPath.locateNinjaExecutable(qtInsRoot);
-      locatedNinjaExePath = await promiseNinjaExecutable;
+      // Prefer the Ninja shared by qt-sm via CoreAPI, falling back to the one
+      // bundled under the Qt installation root.
+      locatedNinjaExePath =
+        getSharedQtToolsPaths()?.ninja ??
+        (await qtPath.locateNinjaExecutable(qtInsRoot));
     }
     if (locatedNinjaExePath) {
       if (qtPathEnv) {
@@ -878,12 +882,16 @@ function getCurrentGlobalAdditionalQtPaths(): QtAdditionalPath[] {
     ) ?? []
   );
 }
+// Build-tool paths (CMake, Ninja) bundled with the Qt installation and shared
+// by qt-sm via CoreAPI.
+function getSharedQtToolsPaths(): QtToolsPaths | undefined {
+  return coreAPI?.getValue<QtToolsPaths>(
+    CoreKey.GLOBAL_WORKSPACE,
+    CoreKey.QT_TOOLS_PATHS
+  );
+}
 
 export async function tryToUseCMakeFromQtTools() {
-  if (getDoNotAskForCMakePath()) {
-    logger.info('doNotAskForCMakePath is set');
-    return;
-  }
   // check if cmake.cmakePath is set
   const cmakePathConfig = 'cmakePath';
   const cmakeConfig = vscode.workspace.getConfiguration('cmake');
@@ -891,6 +899,24 @@ export async function tryToUseCMakeFromQtTools() {
   const IsCustomCmakePath =
     cmakeConfig.get<string>(cmakePathConfig) !== 'cmake';
   if (IsCustomCmakePath || commandExists.sync('cmake')) {
+    return;
+  }
+
+  // If qt-sm shared a CMake via CoreAPI, set it globally without prompting:
+  // the cmake command is missing and cmake.cmakePath is still the default.
+  const sharedCMakePath = getSharedQtToolsPaths()?.cmake;
+  if (sharedCMakePath) {
+    logger.info(`Setting cmakePath to shared CMake "${sharedCMakePath}"`);
+    void cmakeConfig.update(
+      cmakePathConfig,
+      sharedCMakePath,
+      vscode.ConfigurationTarget.Global
+    );
+    return;
+  }
+
+  if (getDoNotAskForCMakePath()) {
+    logger.info('doNotAskForCMakePath is set');
     return;
   }
 

--- a/qt-lib/src/constants.ts
+++ b/qt-lib/src/constants.ts
@@ -12,5 +12,6 @@ export const CoreKey = {
   WORKSPACE_FEATURES: 'workspaceFeatures',
   SELECTED_QT_PATHS: 'selectedQtPaths',
   BUILD_DIR: 'buildDir',
+  QT_TOOLS_PATHS: 'qtToolsPaths',
   GLOBAL_WORKSPACE: 'global'
 };

--- a/qt-lib/src/core-api.ts
+++ b/qt-lib/src/core-api.ts
@@ -32,11 +32,23 @@ export function compareQtAdditionalPath(
   return a.name.localeCompare(b.name);
 }
 
+/**
+ * Absolute paths to the build tools (CMake, Ninja) bundled with a Qt
+ * installation, as detected under the installation root's `Tools/` directory.
+ * Published by qt-sm via CoreAPI so qt-core/qt-cpp can pick them up. A field is
+ * omitted when that tool is not present on disk.
+ */
+export interface QtToolsPaths {
+  cmake?: string;
+  ninja?: string;
+}
+
 export type ConfigType =
   | string
   | QtAdditionalPath[]
   | QtWorkspaceFeatures
   | PySideEnvData
+  | QtToolsPaths
   | undefined;
 
 export type QtWorkspaceConfig = Map<string, ConfigType>;


### PR DESCRIPTION
* qt-lib: Add QtToolsPaths CoreAPI contract for shared CMake/Ninja paths
Introduce the QtToolsPaths interface (cmake/ninja) and the
QT_TOOLS_PATHS CoreKey so qt-core/qt-cpp can consume bundled build-tool
paths published by qt-sm via CoreAPI.

* qt-cpp,qt-core: Consume shared CMake/Ninja paths from CoreAPI
Use QtToolsPaths (QT_TOOLS_PATHS) to fall back to the bundled build
tools when they are not otherwise available:
qt-cpp: set cmake.cmakePath globally to the shared CMake when `cmake`
  is missing and the path is still default; re-run on QT_TOOLS_PATHS
  changes.
qt-cpp: prefer the shared Ninja while generating kits.
qt-core: use the shared Ninja for CMakePresets.json via the
  CMAKE_MAKE_PROGRAM cache variable.