### PR TITLE
Improve the welcome page & Open the walkthrough instead of the welcome if qt-sm is installed

### DIFF
--- a/qt-core/package.json
+++ b/qt-core/package.json
@@ -31,7 +31,8 @@
   "qna": "marketplace",
   "pricing": "Free",
   "activationEvents": [
-    "workspaceContains:**/*.qrc"
+    "workspaceContains:**/*.qrc",
+    "onWebviewPanel:ViewTypeWelcomePage"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/qt-core/src/extension.ts
+++ b/qt-core/src/extension.ts
@@ -92,7 +92,7 @@ export async function activate(context: vscode.ExtensionContext) {
   checkVcpkg();
   checkQtpathsInEnvPath();
   initCoreValues();
-  tryOpenWelcomePage(context);
+  void tryOpenWelcomePage(context);
 
   return coreAPI;
 }

--- a/qt-core/src/extension.ts
+++ b/qt-core/src/extension.ts
@@ -34,7 +34,8 @@ import { registerOpenExBrowserCommand } from '@/webview/ex-browser/controller';
 import { registerOpenCoursesBrowserCommand } from '@/webview/courses/controller';
 import {
   tryOpenWelcomePage,
-  registerOpenWelcomePageCommand
+  registerOpenWelcomePageCommand,
+  registerWelcomePageSerializer
 } from '@/webview/welcome/controller';
 import { registerCreateNewItemPanelCommand } from '@/webview/new-item/panel';
 import { registerQrcEditorProvider } from '@/webview/qrc-editor/editor-provider';
@@ -73,6 +74,7 @@ export async function activate(context: vscode.ExtensionContext) {
     registerOpenExBrowserCommand(context),
     registerOpenCoursesBrowserCommand(context),
     registerOpenWelcomePageCommand(context),
+    registerWelcomePageSerializer(context),
     registerCreateNewItemPanelCommand(context),
     vscode.languages.registerColorProvider('qss', createColorProvider()),
     reportIssueCommand()

--- a/qt-core/src/webview/shared/welcome.ts
+++ b/qt-core/src/webview/shared/welcome.ts
@@ -110,4 +110,4 @@ export type WebsiteId =
   | 'bug-report'
   | 'documentation';
 
-export type WebviewId = 'new-project' | 'examples' | 'courses';
+export type WebviewId = 'new-project' | 'examples' | 'courses' | 'walkthrough';

--- a/qt-core/src/webview/welcome/constants.ts
+++ b/qt-core/src/webview/welcome/constants.ts
@@ -23,7 +23,7 @@ export const BUG_REPORT_URL =
 export const FALLBACK_IMAGE_FILE_IN_RES = 'qt-blog.jpg';
 
 export const WEBVIEW_PANEL_COLUMN = vscode.ViewColumn.One;
-export const WEBVIEW_PANEL_VIEW_TYPE = 'ViewTypeCoursesBrowser';
+export const WEBVIEW_PANEL_VIEW_TYPE = 'ViewTypeWelcomePage';
 
 export const CONFIG_KEY_SHOW_ON_ACTIVATION = 'showWelcomePageOnActivation';
 

--- a/qt-core/src/webview/welcome/constants.ts
+++ b/qt-core/src/webview/welcome/constants.ts
@@ -27,4 +27,7 @@ export const WEBVIEW_PANEL_VIEW_TYPE = 'ViewTypeWelcomePage';
 
 export const CONFIG_KEY_SHOW_ON_ACTIVATION = 'showWelcomePageOnActivation';
 
+export const QT_SM_EXTENSION_ID = 'theqtcompany.qt-sm';
+export const QT_SM_WALKTHROUGH_COMMAND = 'qt-sm.openWalkthrough';
+
 export { EXTENSION_ID } from '@/constants';

--- a/qt-core/src/webview/welcome/constants.ts
+++ b/qt-core/src/webview/welcome/constants.ts
@@ -28,6 +28,8 @@ export const WEBVIEW_PANEL_VIEW_TYPE = 'ViewTypeWelcomePage';
 export const CONFIG_KEY_SHOW_ON_ACTIVATION = 'showWelcomePageOnActivation';
 
 export const QT_SM_EXTENSION_ID = 'theqtcompany.qt-sm';
+export const QT_SM_CONFIG_SECTION = 'qt-sm';
+export const QT_SM_CONFIG_GET_STARTED_DONE = 'getStartedDone';
 export const QT_SM_WALKTHROUGH_COMMAND = 'qt-sm.openWalkthrough';
 
 export { EXTENSION_ID } from '@/constants';

--- a/qt-core/src/webview/welcome/controller.ts
+++ b/qt-core/src/webview/welcome/controller.ts
@@ -38,6 +38,18 @@ export function tryOpenWelcomePage(context: Context) {
   }
 }
 
+export function registerWelcomePageSerializer(context: Context) {
+  return vscode.window.registerWebviewPanelSerializer(
+    consts.WEBVIEW_PANEL_VIEW_TYPE,
+    {
+      async deserializeWebviewPanel(panel: Panel) {
+        WelcomePageController.restore(context, panel);
+        return Promise.resolve();
+      }
+    }
+  );
+}
+
 export class WelcomePageController {
   public static instance: WelcomePageController | undefined;
 
@@ -90,5 +102,14 @@ export class WelcomePageController {
     }
 
     WelcomePageController.instance._panel.reveal(consts.WEBVIEW_PANEL_COLUMN);
+  }
+
+  public static restore(context: Context, panel: Panel) {
+    if (WelcomePageController.instance) {
+      panel.dispose();
+      return;
+    }
+
+    WelcomePageController.instance = new WelcomePageController(context, panel);
   }
 }

--- a/qt-core/src/webview/welcome/controller.ts
+++ b/qt-core/src/webview/welcome/controller.ts
@@ -14,10 +14,18 @@ import {
 import * as texts from '@/texts';
 import { WelcomePageDispatcher as WelcomeScreenDispatcher } from './dispatcher';
 import { WelcomePageDataManager } from './data-manager';
+import {
+  isWalkthroughAvailable,
+  isGetStartedDone,
+  openWalkthrough
+} from './walkthrough';
 import * as consts from './constants';
+import { createLogger } from 'qt-lib';
 
 type Panel = vscode.WebviewPanel;
 type Context = vscode.ExtensionContext;
+
+const logger = createLogger('welcome-controller');
 
 export function registerOpenWelcomePageCommand(context: Context) {
   const name = 'openWelcomePage';
@@ -29,7 +37,15 @@ export function registerOpenWelcomePageCommand(context: Context) {
   });
 }
 
-export function tryOpenWelcomePage(context: Context) {
+export async function tryOpenWelcomePage(context: Context) {
+  // While the qt-sm "Get Started" walkthrough is available but not yet
+  // completed, guide the user through it instead of the welcome page.
+  if (isWalkthroughAvailable() && !isGetStartedDone()) {
+    logger.info('Opening the qt-sm walkthrough; get started not done yet');
+    await openWalkthrough();
+    return;
+  }
+
   const key = consts.CONFIG_KEY_SHOW_ON_ACTIVATION;
   const config = vscode.workspace.getConfiguration(consts.EXTENSION_ID);
 

--- a/qt-core/src/webview/welcome/dispatcher.ts
+++ b/qt-core/src/webview/welcome/dispatcher.ts
@@ -14,6 +14,7 @@ import {
   IsCommand
 } from '@/webview/shared/message';
 import { WelcomePageDataManager } from './data-manager';
+import { isWalkthroughAvailable } from './walkthrough';
 import * as consts from './constants';
 
 const logger = createLogger('tutorial-dispatcher');
@@ -171,10 +172,4 @@ export class WelcomePageDispatcher {
 // helpers
 async function openExt(url: string) {
   await vscode.env.openExternal(vscode.Uri.parse(url));
-}
-
-function isWalkthroughAvailable() {
-  return (
-    vscode.extensions.getExtension(consts.QT_SM_EXTENSION_ID) !== undefined
-  );
 }

--- a/qt-core/src/webview/welcome/dispatcher.ts
+++ b/qt-core/src/webview/welcome/dispatcher.ts
@@ -74,7 +74,8 @@ export class WelcomePageDispatcher {
       extInfo: this._data.extInfo,
       blogArticles: this._data.blogArticles,
       videoEntries: this._data.videoEntries,
-      timestamps: this._data.timestamps
+      timestamps: this._data.timestamps,
+      walkthroughAvailable: isWalkthroughAvailable()
     });
   };
 
@@ -132,7 +133,8 @@ export class WelcomePageDispatcher {
         const commands: Record<string, string> = {
           'new-project': 'qt-core.createNewItem',
           examples: 'qt-core.openExamplesBrowser',
-          courses: 'qt-core.openCoursesBrowser'
+          courses: 'qt-core.openCoursesBrowser',
+          walkthrough: consts.QT_SM_WALKTHROUGH_COMMAND
         };
 
         const c = commands[webview];
@@ -169,4 +171,10 @@ export class WelcomePageDispatcher {
 // helpers
 async function openExt(url: string) {
   await vscode.env.openExternal(vscode.Uri.parse(url));
+}
+
+function isWalkthroughAvailable() {
+  return (
+    vscode.extensions.getExtension(consts.QT_SM_EXTENSION_ID) !== undefined
+  );
 }

--- a/qt-core/src/webview/welcome/walkthrough.ts
+++ b/qt-core/src/webview/welcome/walkthrough.ts
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+
+import * as consts from './constants';
+
+export function isWalkthroughAvailable() {
+  return (
+    vscode.extensions.getExtension(consts.QT_SM_EXTENSION_ID) !== undefined
+  );
+}
+
+// Reads the qt-sm.getStartedDone flag, which qt-sm sets once the user
+// completes or dismisses the "Get Started with Qt" walkthrough.
+export function isGetStartedDone() {
+  return (
+    vscode.workspace
+      .getConfiguration(consts.QT_SM_CONFIG_SECTION)
+      .get<boolean>(consts.QT_SM_CONFIG_GET_STARTED_DONE) ?? false
+  );
+}
+
+export async function openWalkthrough() {
+  await vscode.commands.executeCommand(consts.QT_SM_WALKTHROUGH_COMMAND);
+}

--- a/qt-core/webview-ui/src/apps/texts.ts
+++ b/qt-core/webview-ui/src/apps/texts.ts
@@ -284,6 +284,11 @@ export const welcome = {
   getStarted: {
     title: 'Get started',
 
+    walkthrough: {
+      title: 'Set up Qt',
+      description: 'Follow the guided walkthrough to get Qt ready'
+    },
+
     newProject: {
       title: 'New project',
       description: 'Start from a template'

--- a/qt-core/webview-ui/src/apps/welcome/WelcomeGetStarted.svelte
+++ b/qt-core/webview-ui/src/apps/welcome/WelcomeGetStarted.svelte
@@ -9,6 +9,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
     Bug,
     Book,
     Blocks,
+    Compass,
     PlusSquare
   } from '@lucide/svelte';
 
@@ -17,6 +18,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   import { welcome } from '@/apps/texts';
 
   import * as viewlogic from './viewlogic.svelte';
+  import { data } from './states.svelte';
 
   interface Item {
     id?: string,
@@ -32,7 +34,15 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   }
 
   const texts = welcome.getStarted;
-  const items: Item[] = [
+  const walkthroughItem: Item = {
+    ...texts.walkthrough,
+    icon: Compass,
+    onclick: () => {
+      viewlogic.openWebview('walkthrough');
+    },
+  };
+
+  const items: Item[] = $derived([
     {
       ...texts.newProject,
       icon: PlusSquare,
@@ -55,6 +65,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
       },
       id: 'doc',
     },
+    ...(data.walkthroughAvailable ? [walkthroughItem] : []),
     {
       ...texts.bugreport,
       icon: Bug,
@@ -62,7 +73,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
         viewlogic.openWebsite('bug-report');
       },
     },
-  ];
+  ]);
 
   const docShortcuts: LinkItem[] = [
     {

--- a/qt-core/webview-ui/src/apps/welcome/states.svelte.ts
+++ b/qt-core/webview-ui/src/apps/welcome/states.svelte.ts
@@ -11,6 +11,7 @@ export const data = $state({
   ext: [] as ExtInfo[],
   blogs: [] as BlogArticle[],
   videos: [] as VideoEntry[],
+  walkthroughAvailable: false,
   timestamps: {
     blog: 0,
     video: 0

--- a/qt-core/webview-ui/src/apps/welcome/viewlogic.svelte.ts
+++ b/qt-core/webview-ui/src/apps/welcome/viewlogic.svelte.ts
@@ -62,6 +62,10 @@ async function loadData() {
     data.videos = videos.slice(0, MaxItems);
   }
 
+  data.walkthroughAvailable = Boolean(
+    _.get(r, 'walkthroughAvailable', data.walkthroughAvailable)
+  );
+
   data.timestamps.blog = _.get(r, 'timestamps.blog', data.timestamps.blog);
   data.timestamps.video = _.get(r, 'timestamps.video', data.timestamps.video);
 }


### PR DESCRIPTION
- **qt-core: Restore Welcome page webview on window reload**
- **qt-core: Add Qt setup walkthrough entry to Welcome page**
- **qt-core: Open qt-sm walkthrough on activation until completed**
