### PR TITLE
qt-core: Add Ctrl+F1 (or Cmd+F1 for macOS) key binding for help

### DIFF
--- a/qt-core/package.json
+++ b/qt-core/package.json
@@ -227,6 +227,14 @@
         }
       }
     ],
+    "keybindings": [
+      {
+        "key": "ctrl+f1",
+        "mac": "cmd+f1",
+        "when": "editorTextFocus && (editorLangId == cpp || editorLangId == qml || editorLangId == qt-ui || editorLangId == python)",
+        "command": "qt-core.documentationSearchForCurrentWord"
+      }
+    ],
     "grammars": [
       {
         "language": "qdoc",


### PR DESCRIPTION
F1 was previously used to open Qt documentation, but it was reverted following user feedback, as it conflicted with the Command Palette shortcut. [VSCODEEXT-123](https://qt-project.atlassian.net/browse/VSCODEEXT-123)

This patch reassigns the key binding to Ctrl+F1, which appears to be available by default.

To reduce unexpected conflicts, the key binding is also scoped to only trigger when relevant files are open and being edited.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
