### PR TITLE
qt-core: Implement hover providers with links to documentation

### DIFF
--- a/qt-core/src/docs/hover-provider.ts
+++ b/qt-core/src/docs/hover-provider.ts
@@ -1,0 +1,62 @@
+// Copyright (C) 2024 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as vscode from 'vscode';
+
+const QtGeneralPatterns: RegExp[] = [
+  /Q[A-Za-z][A-Za-z0-9_]*/, // Classes/types, e.g. QString, QColor, Qt
+  /q[A-Z][A-Za-z0-9_]*/, // Global functions, e.g. qDebug, qRound, qColor
+  /Q_[A-Z][A-Za-z0-9_]*/ // Macros, e.g. Q_ASSERT, Q_UNUSED
+];
+
+const QtCMakePattern = /\bqt_[a-z][a-z0-9_]*\b/; // e.g. qt_add_executable, qt_add_qml_module
+const QtGeneralPatternsMerged = new RegExp(
+  `\\b(?:${QtGeneralPatterns.map((p) => p.source).join('|')})\\b`
+);
+
+class QtHoverProvider implements vscode.HoverProvider {
+  constructor(private readonly pattern: RegExp) {}
+
+  provideHover(doc: vscode.TextDocument, pos: vscode.Position) {
+    const range = doc.getWordRangeAtPosition(pos, this.pattern);
+    if (!range) {
+      return undefined;
+    }
+
+    return createHoverLink(doc.getText(range));
+  }
+}
+
+export function registerQtDocsHoverProvider(context: vscode.ExtensionContext) {
+  const generalSelector = [
+    { language: 'h' },
+    { language: 'cpp' },
+    { language: 'qml' },
+    { language: 'qt-ui' },
+    { language: 'python' }
+  ];
+
+  const cmakeSelector = [{ language: 'cmake' }];
+  const register = vscode.languages.registerHoverProvider;
+
+  context.subscriptions.push(
+    register(cmakeSelector, new QtHoverProvider(QtCMakePattern)),
+    register(generalSelector, new QtHoverProvider(QtGeneralPatternsMerged))
+  );
+}
+
+// helper
+function createHoverLink(linkText: string): vscode.Hover {
+  const guide = '$(book)';
+  const linkTarget = [
+    'command:qt-core.documentationSearchForCurrentWord',
+    encodeURIComponent(JSON.stringify([linkText]))
+  ].join('?');
+
+  const link = `${guide} [${linkText}](${linkTarget})`;
+  const markdown = new vscode.MarkdownString(link);
+  markdown.isTrusted = true;
+  markdown.supportThemeIcons = true;
+
+  return new vscode.Hover(markdown);
+}

--- a/qt-core/src/docs/online-docs.ts
+++ b/qt-core/src/docs/online-docs.ts
@@ -223,8 +223,13 @@ async function onSearchManually() {
   }
 }
 
-function onSearchForCurrentWord() {
-  const edit = getCurrentEdit();
+function onSearchForCurrentWord(...args: unknown[]) {
+  const given = typeof args[0] === 'string' ? args[0].trim() : undefined;
+  const current = getCurrentEdit();
+  const edit = given
+    ? { word: given, filePath: current?.filePath ?? '' }
+    : current;
+
   if (!edit || edit.word.length === 0) {
     void vscode.window.showInformationMessage('No word found at the cursor.');
     return;
@@ -233,20 +238,20 @@ function onSearchForCurrentWord() {
   openOrSearchAndPick(edit);
 }
 
-export function registerDocumentationCommands() {
+export function registerQtDocsCommands(context: vscode.ExtensionContext) {
   function register(cmd: string, callback: (...args: unknown[]) => unknown) {
-    return vscode.commands.registerCommand(
-      `${EXTENSION_ID}.${cmd}`,
-      async () => {
-        telemetry.sendAction(cmd);
-        await callback();
-      }
+    const fullCmd = `${EXTENSION_ID}.${cmd}`;
+    const handler = async (...args: unknown[]) => {
+      telemetry.sendAction(cmd);
+      await callback(...args);
+    };
+
+    context.subscriptions.push(
+      vscode.commands.registerCommand(fullCmd, handler)
     );
   }
 
-  return [
-    register('documentationHomepage', onOpenHomePage),
-    register('documentationSearchManually', onSearchManually),
-    register('documentationSearchForCurrentWord', onSearchForCurrentWord)
-  ];
+  register('documentationHomepage', onOpenHomePage);
+  register('documentationSearchManually', onSearchManually);
+  register('documentationSearchForCurrentWord', onSearchForCurrentWord);
 }

--- a/qt-core/src/extension.ts
+++ b/qt-core/src/extension.ts
@@ -12,7 +12,8 @@ import {
   createColorProvider
 } from 'qt-lib';
 import { CoreAPIImpl } from '@/api';
-import { registerDocumentationCommands } from '@/online-docs';
+import { registerQtDocsHoverProvider } from '@/docs/hover-provider';
+import { registerQtDocsCommands } from '@/docs/online-docs';
 import { registerSetRecommendedSettingsCommand } from '@/recommended-settings';
 import {
   checkDefaultQtInsRootPath,
@@ -63,7 +64,6 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   context.subscriptions.push(
-    ...registerDocumentationCommands(),
     registerSetRecommendedSettingsCommand(),
     resetCommand(),
     registerQtByQtpaths(),
@@ -80,6 +80,8 @@ export async function activate(context: vscode.ExtensionContext) {
     reportIssueCommand()
   );
 
+  registerQtDocsCommands(context);
+  registerQtDocsHoverProvider(context);
   registerQrcEditorProvider(context);
   registerQmlTraceProvider(context);
   await enableQtTsFileSupport(context);


### PR DESCRIPTION
Add two `vscode.HoverProvider` implementations that provide links to the relevant Qt documentation in hover tooltips, making it easier to access the documentation.

One provider is used for general source files, while the other is specifically for `CMakeLists.txt`.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
