### PR TITLE
Update contribution docs for GitHub workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,24 @@
-<!---
-# Qt contribution guidelines
+## Description
 
-We welcome contributions to Qt!
+<!-- Describe what this pull request changes and why. -->
 
-Read the
-[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
-<!---
+## Related issue
+
+<!-- Link the issue this PR addresses, e.g. VSCODEEXT-123, or remove this section. -->
+
+## Type of change
+
+<!-- Put an "x" in the boxes that apply. -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would change existing behavior)
+- [ ] Documentation update
+- [ ] Other (please describe)
+
+## Checklist
+
+- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
+- [ ] My changes follow the code style of this project (`npm run ci-lint:all` passes).
+- [ ] I have tested my changes locally. ([ ] Windows, [ ] Linux, [] MacOS)
+- [ ] I have updated the documentation where necessary.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,31 @@
-# Qt contribution guidelines
+# Contributing
 
-We welcome contributions to Qt!
+We welcome contributions to the Qt Extension for VS Code!
 
-Note that we cannot accept pull requests on GitHub. All contributions to the Qt project are exclusively handled through the [Gerrit code review system](https://codereview.qt-project.org).
+## Reporting issues
 
-Read the [Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
+If you find a bug or have a feature request, please [report it](https://qt-project.atlassian.net/jira/software/c/projects/VSCODEEXT/issues)
+before opening a pull request. This lets us discuss the change and avoid
+duplicated effort.
+
+## Submitting changes
+
+1. Fork the repository and create a topic branch for your change.
+2. Set up your development environment and build the extensions as described in
+   [Development.md](Development.md).
+3. Make your changes, keeping commits focused and with clear commit messages.
+4. Run `npm run ci-lint:all` and make sure it passes.
+5. Test your changes locally.
+6. Open a pull request against the `dev` branch and fill out the pull request
+   template.
+
+## Code style
+
+Please follow the existing code style. Linting and formatting are enforced via
+`npm run ci-lint:all`.
+
+## License
+
+This extension is licensed under the Qt Commercial License and the LGPL 3.0. See
+the [LICENSE](LICENSE) file for details. By contributing, you agree that your
+contributions are licensed under the same terms.


### PR DESCRIPTION
Rewrite the PR template with a standard GitHub structure and update CONTRIBUTING.md to describe the GitHub pull request workflow instead of Gerrit.

<!---
# Qt contribution guidelines

We welcome contributions to Qt!

Read the
[Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) to learn more.
<!---
