### PR TITLE
Improve handling of missing Qt paths

### DIFF
--- a/qt-core/src/extension.ts
+++ b/qt-core/src/extension.ts
@@ -1,6 +1,7 @@
 // Copyright (C) 2024 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
+import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { isEmpty } from 'lodash';
 
@@ -30,7 +31,11 @@ import {
   resetCommand,
   registerShowLogCommand
 } from '@/small-commands';
-import { checkQtpathsInEnvPath, registerQtByQtpaths } from '@/qtpaths';
+import {
+  checkQtpathsInEnvPath,
+  registerQtByQtpaths,
+  warnAboutMissingQtPath
+} from '@/qtpaths';
 import { checkVcpkg } from '@/vcpkg';
 import { registerOpenExBrowserCommand } from '@/webview/ex-browser/controller';
 import { registerOpenCoursesBrowserCommand } from '@/webview/courses/controller';
@@ -130,6 +135,11 @@ export function initCoreValues() {
   );
   if (!isEmpty(currentAdditionalQtPaths)) {
     telemetry.sendEvent('additionalQtPathsUsedGlobal');
+  }
+  for (const p of currentAdditionalQtPaths) {
+    if (!fs.existsSync(p.path)) {
+      warnAboutMissingQtPath(p);
+    }
   }
 
   for (const project of projectManager.getProjects()) {

--- a/qt-core/src/installation-root.ts
+++ b/qt-core/src/installation-root.ts
@@ -23,6 +23,7 @@ import {
 import { EXTENSION_ID } from '@/constants';
 import { coreAPI } from '@/extension';
 import { convertAdditionalQtPaths } from '@/util';
+import { warnAboutMissingQtPath } from '@/qtpaths';
 
 const logger = createLogger('installation-root');
 
@@ -243,9 +244,7 @@ export function onAdditionalQtPathsUpdated(
 ) {
   for (const p of newPaths) {
     if (!fs.existsSync(p.path)) {
-      const msg = `The specified additional Qt installation '${p.path}' does not exist.`;
-      logger.warn(msg);
-      void vscode.window.showWarningMessage(msg);
+      warnAboutMissingQtPath(p, folder);
     } else if (!isPathToQtPathsOrQMake(p.path)) {
       const msg = `The specified additional Qt installation '${p.path}' does not point to qtpaths nor qmake.`;
       logger.error(msg);

--- a/qt-core/src/project.ts
+++ b/qt-core/src/project.ts
@@ -1,6 +1,7 @@
 // Copyright (C) 2024 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
+import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { isEmpty, isEqual } from 'lodash';
 
@@ -24,6 +25,7 @@ import {
   onAdditionalQtPathsUpdated
 } from '@/installation-root';
 import { coreAPI } from '@/extension';
+import { warnAboutMissingQtPath } from '@/qtpaths';
 import { UiDesignerSession } from '@/ui-designer/session';
 
 const logger = createLogger('project');
@@ -120,6 +122,11 @@ export class CoreProject implements Project {
     logger.info('Config values initialized for:', folder.uri.fsPath);
     if (!isEmpty(additionalQtPaths)) {
       telemetry.sendEvent('additionalQtPathsUsedWorkspace');
+    }
+    for (const p of additionalQtPaths) {
+      if (!fs.existsSync(p.path)) {
+        warnAboutMissingQtPath(p, folder);
+      }
     }
   }
 

--- a/qt-core/src/qtpaths.ts
+++ b/qt-core/src/qtpaths.ts
@@ -10,6 +10,7 @@ import {
   generateDefaultQtPathsName,
   CoreKey,
   QtAdditionalPath,
+  resolveConfiguration,
   telemetry
 } from 'qt-lib';
 import { convertAdditionalQtPaths, getConfiguration } from '@/util';
@@ -116,4 +117,62 @@ export function addQtPathToSettings(qtPath: QtAdditionalPath) {
   );
   const convertedValue = convertAdditionalQtPaths(valueToSet);
   onAdditionalQtPathsUpdated(convertedValue, CoreKey.GLOBAL_WORKSPACE);
+}
+
+export const RemoveFromSettingsButton = 'Remove from settings';
+
+export function removeQtPathFromSettings(
+  targetPath: string,
+  folder?: vscode.WorkspaceFolder
+) {
+  const config = getConfiguration(folder);
+  const inspected = config.inspect<(string | object)[]>(AdditionalQtPathsName);
+  const currentValue = folder
+    ? inspected?.workspaceFolderValue
+    : inspected?.globalValue;
+  if (!currentValue) {
+    logger.warn(`${AdditionalQtPathsName} not found in the settings`);
+    return;
+  }
+  const matchesTarget = (entry: string | object) => {
+    const rawPath =
+      typeof entry === 'string' ? entry : (entry as QtAdditionalPath).path;
+    return resolveConfiguration(rawPath) === targetPath;
+  };
+  const filtered = currentValue.filter((entry) => !matchesTarget(entry));
+  if (filtered.length === currentValue.length) {
+    const msg = `"${targetPath}" was not found in ${AdditionalQtPathsName}`;
+    logger.warn(msg);
+    void vscode.window.showInformationMessage(msg);
+    return;
+  }
+  logger.info(`Removing ${targetPath} from the settings`);
+  config
+    .update(
+      AdditionalQtPathsName,
+      filtered,
+      folder
+        ? vscode.ConfigurationTarget.WorkspaceFolder
+        : vscode.ConfigurationTarget.Global
+    )
+    .then(undefined, (err) => {
+      logger.error(`Failed to update ${AdditionalQtPathsName}: ${String(err)}`);
+    });
+}
+
+export function warnAboutMissingQtPath(
+  p: QtAdditionalPath,
+  folder?: vscode.WorkspaceFolder | string
+) {
+  // A string folder means the global workspace (CoreKey.GLOBAL_WORKSPACE).
+  const workspaceFolder = typeof folder === 'string' ? undefined : folder;
+  const msg = `The specified additional Qt installation '${p.path}' does not exist.`;
+  logger.warn(msg);
+  void vscode.window
+    .showWarningMessage(msg, RemoveFromSettingsButton)
+    .then((response) => {
+      if (response === RemoveFromSettingsButton) {
+        removeQtPathFromSettings(p.path, workspaceFolder);
+      }
+    });
 }

--- a/qt-core/test/helper.mts
+++ b/qt-core/test/helper.mts
@@ -721,11 +721,11 @@ export function stubWarningMessage(
   sb: sinon.SinonSandbox,
   message?: string
 ): sinon.SinonStub {
-  let stub: sinon.SinonStub;
+  // Resolve like the real API (user dismissed the popup) so production code
+  // may chain `.then()` on the returned value.
+  const stub = sb.stub(vscode.window, 'showWarningMessage').resolves(undefined);
   if (message) {
-    stub = sb.stub(vscode.window, 'showWarningMessage').withArgs(message);
-  } else {
-    stub = sb.stub(vscode.window, 'showWarningMessage');
+    return stub.withArgs(message);
   }
   return stub;
 }

--- a/qt-core/test/suite/commands.test.mts
+++ b/qt-core/test/suite/commands.test.mts
@@ -14,7 +14,10 @@ import {
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { addQtPathToSettings } from '../../src/qtpaths.ts';
+import {
+  addQtPathToSettings,
+  RemoveFromSettingsButton
+} from '../../src/qtpaths.ts';
 import * as texts from '../../src/texts.ts';
 import { getDefaultQtRootCandidates } from '../../src/installation-root.ts';
 
@@ -606,8 +609,10 @@ describe('command: registerQtByQtpaths', () => {
       showWarningMessageStub.calledTwice,
       'Expected 2 warnings to be shown'
     ).to.be.true;
-    expect(showWarningMessageStub.calledWith(msg1)).to.be.true;
-    expect(showWarningMessageStub.calledWith(msg2)).to.be.true;
+    expect(showWarningMessageStub.calledWith(msg1, RemoveFromSettingsButton)).to
+      .be.true;
+    expect(showWarningMessageStub.calledWith(msg2, RemoveFromSettingsButton)).to
+      .be.true;
   });
 
   // To do in specific test file to:

--- a/qt-cpp/src/kit-manager.ts
+++ b/qt-cpp/src/kit-manager.ts
@@ -324,8 +324,12 @@ export class KitManager {
         if (qtInfo?.err) {
           warningMessage += ` Error: "${qtInfo.err.message}"`;
         }
-        void vscode.window.showWarningMessage(warningMessage);
         logger.info(warningMessage);
+        // qt-core already shows an actionable warning when the binary is
+        // missing; only popup when it exists but qtpaths failed.
+        if (fsSync.existsSync(p.path)) {
+          void vscode.window.showWarningMessage(warningMessage);
+        }
         continue;
       }
       const kit = KitManager.generateKitFromQtInfo(


### PR DESCRIPTION
- qt-core: warn about missing `additionalQtPaths` entries and offer to remove them from settings
- qt-cpp: skip the qtPaths error popup when the binary is missing, since qt-core already shows an actionable warning