### PR TITLE
qt-qml: Fix qmlls updating problem with multiple instances

### DIFF
--- a/qt-qml/esbuild.mjs
+++ b/qt-qml/esbuild.mjs
@@ -19,6 +19,7 @@ await runEsbuild({
     './test/runTestHelper.mts',
     './test/suite/index-qml-debug.mts',
     './test/suite/qml-debug.test.mts',
+    './test/suite/versioned-installations.test.mts',
     './test/debug-helper.mts'
   ]
 });

--- a/qt-qml/src/extension.mts
+++ b/qt-qml/src/extension.mts
@@ -18,7 +18,11 @@ import { registerRestartQmllsCommand } from '@cmd/restart-qmlls.mjs';
 import { registerDownloadQmllsCommand } from '@cmd/download-qmlls.mjs';
 import { registerDebugPort } from '@cmd/debug.mjs';
 import { registerCheckQmllsUpdateCommand } from '@cmd/check-qmlls-update.mjs';
-import { getDoNotAskForDownloadingQmlls, Qmlls } from '@/qmlls.mjs';
+import {
+  getDoNotAskForDownloadingQmlls,
+  Qmlls,
+  registerQmllsManifestWatcher
+} from '@/qmlls.mjs';
 import * as installer from '@/installer.mjs';
 import * as consts from '@/constants.js';
 import { QMLProjectManager, createQMLProject } from '@/project.mjs';
@@ -86,6 +90,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.window.onDidChangeActiveTextEditor(() => {
       updatePreviewLaunchContext();
     }),
+    registerQmllsManifestWatcher(),
     registerDebugPort(),
     registerRestartQmllsCommand(),
     registerCheckQmllsUpdateCommand(),

--- a/qt-qml/src/installer.mts
+++ b/qt-qml/src/installer.mts
@@ -16,23 +16,28 @@ import {
   IsWindows,
   IsMacOS,
   IsLinux,
-  IsArm64,
-  IsUnix
+  IsArm64
 } from 'qt-lib';
 import * as unzipper from '@/unzipper.js';
 import * as downloader from '@/downloader.js';
 import { setDoNotAskForDownloadingQmlls } from '@/qmlls.mjs';
+import {
+  VersionedInstallations,
+  type InstallVersion
+} from '@/versioned-installations.mjs';
 import { projectManager } from './extension.mts';
 import { QmllsOperationType } from './qmlls-queue.mts';
+
+export { ManifestFileName } from '@/versioned-installations.mjs';
+export type { InstallVersion } from '@/versioned-installations.mjs';
 
 const ReleaseInfoUrl = 'https://qtccache.qt.io/QMLLS/LatestRelease';
 const ReleaseInfoTimeout = 10 * 1000;
 const DownloadDir = os.tmpdir();
+const QmllsExeName = 'qmlls' + OSExeSuffix;
 
 let InstallDir: string;
-let ExtractDir: string;
-let QmllsExePath: string;
-let ReleaseJsonPath: string;
+let installations: VersionedInstallations;
 
 const logger = createLogger('installer');
 
@@ -44,13 +49,85 @@ const logger = createLogger('installer');
 export function initialize(globalStorageUri: vscode.Uri) {
   const globalStoragePath = globalStorageUri.fsPath;
   InstallDir = path.join(globalStoragePath, 'qmlls');
-  ExtractDir = path.join(InstallDir, 'files');
-  QmllsExePath = path.join(InstallDir, 'files', 'qmlls' + OSExeSuffix);
-  ReleaseJsonPath = path.join(InstallDir, 'release.json');
+  installations = new VersionedInstallations(InstallDir, QmllsExeName);
+  // The manifest watcher needs an existing directory to watch.
+  fs.mkdirSync(InstallDir, { recursive: true });
   logger.info(`Installer initialized with path: ${InstallDir}`);
 
   // Clean up old installation directory that polluted the user file system
   cleanupOldInstallation();
+
+  try {
+    const migrated = installations.migrateLegacyLayout(
+      path.join(InstallDir, 'files'),
+      path.join(InstallDir, 'release.json')
+    );
+    if (migrated) {
+      logger.info('Migrated legacy qmlls installation to the versioned layout');
+    }
+  } catch (error) {
+    logger.warn(`Legacy qmlls layout migration failed: ${String(error)}`);
+  }
+
+  collectGarbage();
+
+  const current = getInstalledVersion();
+  if (current) {
+    logger.info(
+      `Current qmlls version: ${current.tag}, uploaded: ${current.createdAt || '<unknown>'} (${resolveQmllsExePath() ?? 'exe missing'})`
+    );
+  } else {
+    logger.info('No managed qmlls version installed');
+  }
+}
+
+/**
+ * The directory holding the versioned qmlls installations and the manifest.
+ */
+export function getInstallRoot(): string {
+  return InstallDir;
+}
+
+/**
+ * Resolve the exe of the currently published qmlls version, or undefined if
+ * none is installed. Resolved fresh on every call because another VS Code
+ * instance may publish a new version and garbage-collect the previous one at
+ * any time.
+ */
+export function resolveQmllsExePath(): string | undefined {
+  return installations.resolveCurrentExePath();
+}
+
+/**
+ * The identity (tag and asset upload time) of the currently published qmlls
+ * version, if any. The upload time is empty for installs that predate
+ * upload-time tracking.
+ */
+export function getInstalledVersion(): InstallVersion | undefined {
+  return installations.readManifest();
+}
+
+/**
+ * Best-effort removal of everything except the current version. Version
+ * dirs whose exe is still running (Windows locks them) are skipped and
+ * retried on a later run; on Unix, deleting a running exe is harmless.
+ */
+function collectGarbage() {
+  try {
+    const result = installations.collectGarbage();
+    if (result.removed.length > 0) {
+      logger.info(
+        `Removed outdated qmlls installs: ${result.removed.join(', ')}`
+      );
+    }
+    if (result.skipped.length > 0) {
+      logger.info(
+        `Skipped qmlls installs that could not be removed (likely still in use): ${result.skipped.join(', ')}`
+      );
+    }
+  } catch (error) {
+    logger.warn(`qmlls garbage collection failed: ${String(error)}`);
+  }
 }
 
 /**
@@ -108,24 +185,20 @@ interface CheckResult {
   status: AssetStatus;
 }
 
-export function getExpectedQmllsPath() {
-  return QmllsExePath;
+function isRunnable(exePath: string): boolean {
+  const res = spawnSync(exePath, ['--help'], { timeout: 1000 });
+  return res.status === 0;
 }
 
-export function writeReleaseInfo(asset: AssetWithTag): void {
-  fs.writeFileSync(
-    ReleaseJsonPath,
-    JSON.stringify(
-      { tag_name: asset.tag_name, created_at: asset.created_at },
-      null,
-      2
-    )
-  );
+function versionOf(asset: AssetWithTag): InstallVersion {
+  return { tag: asset.tag_name, createdAt: asset.created_at };
 }
 
 export function checkStatusAgainst(asset: AssetWithTag): CheckResult {
   // check installation
-  if (!fs.existsSync(ReleaseJsonPath) || !fs.existsSync(QmllsExePath)) {
+  const local = getInstalledVersion();
+  const exePath = resolveQmllsExePath();
+  if (!local || !exePath) {
     return {
       message: 'Not Installed',
       status: AssetStatus.NotInstalled
@@ -133,34 +206,28 @@ export function checkStatusAgainst(asset: AssetWithTag): CheckResult {
   }
 
   // check if outdated
-  const local = JSON.parse(fs.readFileSync(ReleaseJsonPath, 'utf8')) as {
-    tag_name: string;
-    created_at?: string;
-  };
-
-  if (local.tag_name !== asset.tag_name) {
+  if (local.tag !== asset.tag_name) {
     return {
       message:
         'Tag mismatch, ' +
-        `local = ${local.tag_name}, ` +
+        `local = ${local.tag}, ` +
         `recent = ${asset.tag_name}`,
       status: AssetStatus.Outdated
     };
   }
 
-  if (local.created_at !== asset.created_at) {
+  if (local.createdAt !== asset.created_at) {
     return {
       message:
         'Upload time mismatch, ' +
-        `local = ${local.created_at ?? '<unknown>'}, ` +
+        `local = ${local.createdAt || '<unknown>'}, ` +
         `recent = ${asset.created_at}`,
       status: AssetStatus.Outdated
     };
   }
 
   // check if executable
-  const res = spawnSync(QmllsExePath, ['--help'], { timeout: 1000 });
-  if (res.status !== 0) {
+  if (!isRunnable(exePath)) {
     return {
       message: 'Found, but not executable',
       status: AssetStatus.Broken
@@ -196,32 +263,71 @@ export async function install(asset: AssetWithTag) {
   return projectManager.qmllsQueue.enqueue(
     QmllsOperationType.Install,
     async () => {
-      const tmpPath = path.join(DownloadDir, asset.name);
-
-      logger.info(`Downloading from: ${asset.browser_download_url}`);
-      await downloadWithProgress(asset.browser_download_url, tmpPath);
-
-      // Remove existing files before extraction to avoid ETXTBSY error on Linux.
-      // On Linux, even after the language server process has stopped, the kernel
-      // may still hold a reference to the executable file briefly. Deleting the
-      // file first works because Linux allows deletion of open files - the inode
-      // persists until all handles are closed, but the directory entry is removed,
-      // allowing us to create a new file with the same name.
-      if (IsUnix) {
-        if (fs.existsSync(ExtractDir)) {
-          logger.info(`Removing existing installation: ${ExtractDir}`);
-          fs.rmSync(ExtractDir, { recursive: true, force: true });
-        }
+      // Another VS Code instance may have installed this exact build (same
+      // tag and upload time) already; then only the manifest needs to be
+      // published.
+      const version = versionOf(asset);
+      const existingExe = path.join(
+        installations.versionDirPath(version),
+        QmllsExeName
+      );
+      if (installations.hasVersion(version) && isRunnable(existingExe)) {
+        logger.info(
+          `${asset.tag_name} (uploaded ${asset.created_at}) is already installed, publishing it`
+        );
+        installations.publishCurrent(version);
+        collectGarbage();
+        return;
       }
 
-      logger.info(`Unzipping to: ${ExtractDir}`);
-      await unzipWithProgress(tmpPath);
+      // The pid in the name keeps parallel downloads from different VS Code
+      // instances from clobbering each other's file.
+      const tmpPath = path.join(
+        DownloadDir,
+        `qmlls-${process.pid.toFixed(0)}-${asset.name}`
+      );
 
-      // follow up
-      logger.info(`QML language server installed to: ${QmllsExePath}`);
-      fs.chmodSync(QmllsExePath, 0o755);
-      fs.unlinkSync(tmpPath);
-      writeReleaseInfo(asset);
+      logger.info(
+        `Downloading from: ${asset.browser_download_url} to: ${tmpPath}`
+      );
+      await downloadWithProgress(asset.browser_download_url, tmpPath);
+      logger.info(`Download finished: ${tmpPath}`);
+
+      // Extract into a private staging dir and atomically rename it into
+      // place, so a version dir is either absent or complete and running
+      // exes are never overwritten. If the rename loses the race against
+      // another instance installing the same version, theirs is used.
+      const stagingDir = installations.createStagingDir();
+      try {
+        logger.info(`Unzipping to: ${stagingDir}`);
+        await unzipWithProgress(tmpPath, stagingDir);
+        logger.info(`Unzipping finished: ${stagingDir}`);
+
+        const stagedExe = path.join(stagingDir, QmllsExeName);
+        logger.info(`Setting executable permission for: ${stagedExe}`);
+        fs.chmodSync(stagedExe, 0o755);
+        logger.info(`Executable permission set for: ${stagedExe}`);
+        if (!isRunnable(stagedExe)) {
+          logger.error(`Staged qmlls is not runnable: ${stagedExe}`);
+          throw new Error(`${stagedExe} is not runnable`);
+        }
+        logger.info(`Staged qmlls is runnable: ${stagedExe}`);
+        const versionDir = installations.commitStagedInstall(
+          stagingDir,
+          version
+        );
+        logger.info(`QML language server installed to: ${versionDir}`);
+      } catch (error) {
+        logger.error(`Installation failed: ${String(error)}`);
+        fs.rmSync(stagingDir, { recursive: true, force: true });
+        throw error;
+      } finally {
+        logger.info(`Removing temporary download file: ${tmpPath}`);
+        fs.rmSync(tmpPath, { force: true });
+      }
+
+      installations.publishCurrent(version);
+      collectGarbage();
     }
   );
 }
@@ -345,13 +451,13 @@ async function downloadWithProgress(url: string, destPath: string) {
   await vscode.window.withProgress(options, downloadTask);
 }
 
-async function unzipWithProgress(zipPath: string) {
+async function unzipWithProgress(zipPath: string, destDir: string) {
   const unzipTask = async (
     progress: vscode.Progress<{ message?: string; increment?: number }>
   ) => {
     const unzipStreamProvider = (entry: unzipper.Entry) => {
       const name = entry.fileName;
-      const dest = path.join(ExtractDir, name);
+      const dest = path.join(destDir, name);
 
       fs.mkdirSync(path.dirname(dest), { recursive: true });
       progress.report({ message: name });

--- a/qt-qml/src/project.mts
+++ b/qt-qml/src/project.mts
@@ -55,20 +55,6 @@ export class QMLProjectManager extends ProjectManager<QMLProject> {
   }
 
   /**
-   * Stop all qmlls instances. This is called internally during install,
-   * so it does NOT go through the queue to avoid deadlock.
-   */
-  async stopQmlls() {
-    return this._qmllsQueue.enqueue(QmllsOperationType.Stop, async () => {
-      const promises = [];
-      for (const project of this.getProjects()) {
-        promises.push(project.qmlls.stop());
-      }
-      return Promise.all(promises);
-    });
-  }
-
-  /**
    * Start all qmlls instances through the queue.
    */
   async startQmlls() {

--- a/qt-qml/src/qmlls.mts
+++ b/qt-qml/src/qmlls.mts
@@ -16,7 +16,6 @@ import {
   createLogger,
   findQtKits,
   isError,
-  exists,
   OSExeSuffix,
   compareVersions,
   CoreKey,
@@ -133,6 +132,80 @@ export async function fetchAssetAndDecide(options?: {
   return vscode.window.withProgress(progressOptions, task);
 }
 
+// A tag alone does not identify a build: new assets can be re-published
+// under the same tag, so the upload time is part of the comparison.
+function isSameVersion(
+  a: installer.InstallVersion,
+  b: installer.InstallVersion | undefined
+): boolean {
+  return b !== undefined && a.tag === b.tag && a.createdAt === b.createdAt;
+}
+
+function describeVersion(
+  version: installer.InstallVersion | undefined
+): string {
+  return version
+    ? `${version.tag} (uploaded ${version.createdAt || 'unknown'})`
+    : 'none';
+}
+
+/**
+ * Watch the install manifest for versions published by other VS Code
+ * instances and silently restart the language clients to adopt them. This is
+ * best-effort: if the watcher never fires on some platform, the new version
+ * is still picked up at the next natural (re)start, because the exe path is
+ * resolved fresh from the manifest every time.
+ */
+export function registerQmllsManifestWatcher(): vscode.Disposable {
+  const manifestPath = path.join(
+    installer.getInstallRoot(),
+    installer.ManifestFileName
+  );
+  logger.info(
+    `Watching for qmlls versions published by other VS Code instances: ${manifestPath}`
+  );
+  const watcher = vscode.workspace.createFileSystemWatcher(
+    new vscode.RelativePattern(
+      vscode.Uri.file(installer.getInstallRoot()),
+      installer.ManifestFileName
+    )
+  );
+  let debounce: NodeJS.Timeout | undefined;
+  const onManifestChanged = () => {
+    if (debounce) {
+      clearTimeout(debounce);
+    }
+    debounce = setTimeout(() => {
+      debounce = undefined;
+      const published = installer.getInstalledVersion();
+      // Restarting with an unchanged manifest would only interrupt users:
+      // the publisher is this instance (its install flow already restarts),
+      // or the manifest vanished (start() would fall back to a Qt kit).
+      if (
+        !published ||
+        isSameVersion(published, Qmlls.runningInstalledVersion)
+      ) {
+        logger.info(
+          `Manifest changed but no restart is needed (published: ${describeVersion(published)}, running: ${describeVersion(Qmlls.runningInstalledVersion)})`
+        );
+        return;
+      }
+      logger.info(
+        `qmlls ${describeVersion(published)} was published by another VS Code instance, restarting`
+      );
+      void projectManager.restartQmlls();
+    }, 1000);
+  };
+  watcher.onDidCreate(onManifestChanged);
+  watcher.onDidChange(onManifestChanged);
+  return new vscode.Disposable(() => {
+    if (debounce) {
+      clearTimeout(debounce);
+    }
+    watcher.dispose();
+  });
+}
+
 export class Qmlls {
   private _docsPath: string | undefined;
   private readonly _disposables: vscode.Disposable[] = [];
@@ -182,17 +255,38 @@ export class Qmlls {
     this._importPaths.clear();
   }
 
+  /**
+   * The identity of the managed qmlls install the language clients are
+   * running from or adopting. Used by the manifest watcher to tell a version
+   * published by another VS Code instance apart from our own install. The
+   * upload time is part of the identity: a build re-published under the same
+   * tag must still trigger a restart.
+   */
+  static runningInstalledVersion: installer.InstallVersion | undefined;
+
   public static async install(asset: installer.AssetWithTag) {
     try {
-      logger.info('Stopping QML language server to install new version');
-      await projectManager.stopQmlls();
-
+      // The new version is staged next to the running one, so the language
+      // server keeps serving during the whole download and only restarts
+      // once the new version is published.
       logger.info(`Installing: ${asset.name}, ${asset.tag_name}`);
       await installer.install(asset);
       logger.info('Installation done');
 
+      // Adopt the version before the restart, not in start(): the manifest
+      // watcher's debounce can fire while the restart is still stopping the
+      // old server, and must not mistake our own publish for one made by
+      // another VS Code instance.
+      Qmlls.runningInstalledVersion = {
+        tag: asset.tag_name,
+        createdAt: asset.created_at
+      };
+      logger.info(
+        `Adopted qmlls ${describeVersion(Qmlls.runningInstalledVersion)}, restarting`
+      );
+
       projectManager.updateQmllsParams();
-      await projectManager.startQmlls();
+      await projectManager.restartQmlls();
     } catch (error) {
       logger.warn(isError(error) ? error.message : String(error));
     }
@@ -244,13 +338,24 @@ export class Qmlls {
           throw res.error ?? new Error(res.stderr.toString());
         }
         telemetry.sendAction('customQmllsUsage');
+        logger.info(`Using custom qmlls: ${resolvedCustomPath}`);
         this.startLanguageClient(resolvedCustomPath);
       } else {
-        const installed = installer.getExpectedQmllsPath();
-        if (await exists(installed)) {
+        // Resolved fresh on every start: another VS Code instance may have
+        // published a new version since the last one.
+        const installed = installer.resolveQmllsExePath();
+        if (installed) {
+          const version = installer.getInstalledVersion();
+          Qmlls.runningInstalledVersion = version;
+          logger.info(
+            `Using managed qmlls ${describeVersion(version)}: ${installed}`
+          );
           this.startLanguageClient(installed);
           return;
         }
+        logger.info(
+          'No managed qmlls installed, looking for one in the Qt kits'
+        );
 
         const qmllsExeConfig = await findMostRecentExecutableQmlLS();
         if (!qmllsExeConfig) {
@@ -266,6 +371,9 @@ export class Qmlls {
           return;
         }
 
+        logger.info(
+          `Using qmlls from Qt ${qmllsExeConfig.qtVersion}: ${qmllsExeConfig.qmllsPath}`
+        );
         this.startLanguageClient(qmllsExeConfig.qmllsPath);
       }
     } catch (error) {

--- a/qt-qml/src/qmlls.mts
+++ b/qt-qml/src/qmlls.mts
@@ -31,6 +31,7 @@ import { QmllsOperationType } from '@/qmlls-queue.mjs';
 
 const logger = createLogger('qmlls');
 const QMLLS_CONFIG = `${EXTENSION_ID}.qmlls`;
+const QmllsStopTimeoutMs = 5000;
 
 interface QmllsExeConfig {
   qmllsPath: string;
@@ -136,9 +137,9 @@ export async function fetchAssetAndDecide(options?: {
 // under the same tag, so the upload time is part of the comparison.
 function isSameVersion(
   a: installer.InstallVersion,
-  b: installer.InstallVersion | undefined
+  b: installer.InstallVersion
 ): boolean {
-  return b !== undefined && a.tag === b.tag && a.createdAt === b.createdAt;
+  return a.tag === b.tag && a.createdAt === b.createdAt;
 }
 
 function describeVersion(
@@ -183,6 +184,7 @@ export function registerQmllsManifestWatcher(): vscode.Disposable {
       // or the manifest vanished (start() would fall back to a Qt kit).
       if (
         !published ||
+        !Qmlls.runningInstalledVersion ||
         isSameVersion(published, Qmlls.runningInstalledVersion)
       ) {
         logger.info(
@@ -543,15 +545,19 @@ export class Qmlls {
           }
         }
         if (this._client.isRunning()) {
+          // A busy qmlls (e.g. mid-indexing) often needs more than the
+          // default 2s to answer the shutdown handshake. On timeout the
+          // client force-kills the server, so this failure is recoverable
+          // and only logged as a warning.
           await this._client
-            .stop()
+            .stop(QmllsStopTimeoutMs)
             .then(() => {
               logger.info(
                 `QML Language Server stopped: "${this._folder.name}"`
               );
             })
             .catch((e: unknown) => {
-              logger.error(
+              logger.warn(
                 `QML Language Server stop failed: "${this._folder.name}", ${String(e)}`
               );
             });

--- a/qt-qml/src/unzipper.ts
+++ b/qt-qml/src/unzipper.ts
@@ -11,9 +11,34 @@ export async function unzip(
   streamProvider: (entry: yauzl.Entry) => Writable | null
 ) {
   return new Promise<void>((resolve, reject) => {
+    // Reading an entry only means its bytes have been handed to the
+    // destination stream, not that they have landed on disk. Resolving as
+    // soon as the zip's central directory is exhausted would let callers
+    // touch files (e.g. spawn an extracted exe) while the last entries are
+    // still being flushed. So track outstanding writers and only resolve
+    // once every 'finish' has fired too.
+    let pendingWrites = 0;
+    let allEntriesRead = false;
+    let settled = false;
+
+    const fail = (error: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      reject(error);
+    };
+
+    const resolveIfDone = () => {
+      if (!settled && allEntriesRead && pendingWrites === 0) {
+        settled = true;
+        resolve();
+      }
+    };
+
     const callback = (error: Error | null, zipFile: yauzl.ZipFile) => {
       if (error) {
-        reject(error);
+        fail(error);
         return;
       }
 
@@ -25,9 +50,10 @@ export async function unzip(
           return;
         }
 
+        pendingWrites++;
         zipFile.openReadStream(entry, (e, reader) => {
           if (e) {
-            reject(e);
+            fail(e);
             return;
           }
 
@@ -36,18 +62,24 @@ export async function unzip(
             zipFile.readEntry();
           });
 
-          reader.on('error', reject);
-          writer.on('error', reject);
+          writer.on('finish', () => {
+            pendingWrites--;
+            resolveIfDone();
+          });
+
+          reader.on('error', fail);
+          writer.on('error', fail);
         });
       });
 
       zipFile.on('end', () => {
         zipFile.close();
-        resolve();
+        allEntriesRead = true;
+        resolveIfDone();
       });
 
       zipFile.on('error', () => {
-        reject(new Error('zipfile error'));
+        fail(new Error('zipfile error'));
       });
     };
 

--- a/qt-qml/src/versioned-installations.mts
+++ b/qt-qml/src/versioned-installations.mts
@@ -1,0 +1,331 @@
+// Copyright (C) 2026 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { createLogger } from 'qt-lib';
+
+/**
+ * Side-by-side versioned installation store for a downloaded executable.
+ *
+ * Multiple VS Code instances share the same install directory and must not
+ * disturb each other. The invariants that make this safe without any
+ * cross-process locks:
+ *  - A version's identity is its release tag plus the asset upload time: a
+ *    tag can be re-published with new assets, and such a build gets its own
+ *    version directory instead of mutating the previous one.
+ *  - A version directory is immutable once committed; installs are staged in
+ *    a unique temp directory and atomically renamed into place. A failed
+ *    rename means another instance won the race, which is not an error.
+ *  - The manifest file is the single source of truth for the current version
+ *    and is only ever replaced via atomic rename, so readers see either the
+ *    old or the new state, never a partial write.
+ *  - Garbage collection is best-effort: a version directory that cannot be
+ *    removed (e.g. a running exe on Windows) is skipped and retried on a
+ *    later run.
+ */
+
+const logger = createLogger('versioned-installations');
+
+export const ManifestFileName = 'current.json';
+
+const ManifestSchemaVersion = 1;
+const StagingPrefix = '.staging-';
+const ManifestTmpPrefix = `${ManifestFileName}.tmp-`;
+const DefaultStagingMaxAgeMs = 24 * 60 * 60 * 1000;
+
+export interface InstallVersion {
+  tag: string;
+  /**
+   * Upload time of the release asset (its created_at value). Part of the
+   * version identity because a tag can be re-published with new assets.
+   * Empty for installs that predate upload-time tracking; they count as
+   * outdated and are re-downloaded once.
+   */
+  createdAt: string;
+}
+
+export interface InstallManifest extends InstallVersion {
+  schemaVersion: number;
+  dir: string;
+  installedAt: string;
+}
+
+export interface GcResult {
+  removed: string[];
+  skipped: string[];
+}
+
+function uniqueSuffix(): string {
+  return (
+    `${process.pid.toString(36)}-${Date.now().toString(36)}-` +
+    Math.random().toString(36).slice(2, 10)
+  );
+}
+
+function versionDirName(version: InstallVersion): string {
+  // The upload time is part of the identity, so a build re-published under
+  // the same tag lands in its own directory.
+  const name = version.createdAt
+    ? `${version.tag}-${version.createdAt}`
+    : version.tag;
+  const sanitized = name.replace(/[^A-Za-z0-9._-]/g, '_');
+  // A leading dot would collide with the hidden staging dirs.
+  return sanitized === '' || sanitized.startsWith('.')
+    ? `_${sanitized}`
+    : sanitized;
+}
+
+export class VersionedInstallations {
+  constructor(
+    readonly baseDir: string,
+    readonly exeName: string
+  ) {}
+
+  get manifestPath(): string {
+    return path.join(this.baseDir, ManifestFileName);
+  }
+
+  readManifest(): InstallManifest | undefined {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this.manifestPath, 'utf8');
+    } catch {
+      // A missing manifest is the normal "nothing published" state.
+      return undefined;
+    }
+    try {
+      const parsed = JSON.parse(raw) as Partial<InstallManifest>;
+      if (
+        typeof parsed.tag === 'string' &&
+        parsed.tag !== '' &&
+        typeof parsed.dir === 'string' &&
+        parsed.dir !== ''
+      ) {
+        return {
+          schemaVersion: parsed.schemaVersion ?? ManifestSchemaVersion,
+          tag: parsed.tag,
+          createdAt: parsed.createdAt ?? '',
+          dir: parsed.dir,
+          installedAt: parsed.installedAt ?? ''
+        };
+      }
+      logger.warn(
+        `${ManifestFileName} is missing required fields, treating as not installed: ${this.manifestPath}`
+      );
+    } catch {
+      logger.warn(
+        `${ManifestFileName} is corrupt, treating as not installed: ${this.manifestPath}`
+      );
+    }
+    return undefined;
+  }
+
+  /**
+   * Atomically publish `version` as the current one. This is the commit
+   * point: until the rename lands, other instances keep seeing the previous
+   * version.
+   */
+  publishCurrent(version: InstallVersion): void {
+    const manifest: InstallManifest = {
+      schemaVersion: ManifestSchemaVersion,
+      tag: version.tag,
+      createdAt: version.createdAt,
+      dir: versionDirName(version),
+      installedAt: new Date().toISOString()
+    };
+    fs.mkdirSync(this.baseDir, { recursive: true });
+    const tmpPath = path.join(this.baseDir, ManifestTmpPrefix + uniqueSuffix());
+    fs.writeFileSync(tmpPath, JSON.stringify(manifest, null, 2));
+    fs.renameSync(tmpPath, this.manifestPath);
+    logger.info(
+      `Published ${manifest.tag} as the current version (dir: ${manifest.dir})`
+    );
+  }
+
+  versionDirPath(version: InstallVersion): string {
+    return path.join(this.baseDir, versionDirName(version));
+  }
+
+  /**
+   * Resolve the exe of the currently published version. Callers must not
+   * cache the result: after another instance publishes and garbage-collects,
+   * only a fresh resolution is guaranteed to point at an existing file.
+   */
+  resolveCurrentExePath(): string | undefined {
+    const manifest = this.readManifest();
+    if (!manifest) {
+      return undefined;
+    }
+    const exePath = path.join(this.baseDir, manifest.dir, this.exeName);
+    return fs.existsSync(exePath) ? exePath : undefined;
+  }
+
+  hasVersion(version: InstallVersion): boolean {
+    return fs.existsSync(path.join(this.versionDirPath(version), this.exeName));
+  }
+
+  createStagingDir(): string {
+    fs.mkdirSync(this.baseDir, { recursive: true });
+    const stagingDir = path.join(this.baseDir, StagingPrefix + uniqueSuffix());
+    fs.mkdirSync(stagingDir);
+    logger.info(`Created staging dir: ${stagingDir}`);
+    return stagingDir;
+  }
+
+  /**
+   * Move a fully staged install into its version directory. The atomic
+   * rename doubles as the cross-process lock: if it fails because another
+   * instance already committed the same version, the staging dir is dropped
+   * and the existing directory is used.
+   */
+  commitStagedInstall(stagingDir: string, version: InstallVersion): string {
+    const targetDir = this.versionDirPath(version);
+    try {
+      fs.renameSync(stagingDir, targetDir);
+      logger.info(`Committed "${stagingDir}" as "${targetDir}"`);
+      return targetDir;
+    } catch (renameError) {
+      if (fs.existsSync(path.join(targetDir, this.exeName))) {
+        logger.info(
+          `${targetDir} already exists (another instance installed it), dropping staging dir`
+        );
+        fs.rmSync(stagingDir, { recursive: true, force: true });
+        return targetDir;
+      }
+      // The target exists but is incomplete (a version dir is committed
+      // atomically, so this means corruption): replace it.
+      try {
+        fs.rmSync(targetDir, { recursive: true, force: true });
+        fs.renameSync(stagingDir, targetDir);
+        logger.warn(`Replaced incomplete version dir: ${targetDir}`);
+        return targetDir;
+      } catch {
+        if (fs.existsSync(path.join(targetDir, this.exeName))) {
+          logger.info(
+            `${targetDir} already exists (another instance installed it), dropping staging dir`
+          );
+          fs.rmSync(stagingDir, { recursive: true, force: true });
+          return targetDir;
+        }
+        throw renameError;
+      }
+    }
+  }
+
+  /**
+   * Best-effort cleanup: remove every version dir except the current one,
+   * plus stale staging dirs and manifest temp files from crashed installs.
+   * Removal failures (e.g. an exe still running on Windows) are skipped and
+   * picked up by a later run.
+   */
+  collectGarbage(options?: { stagingMaxAgeMs?: number }): GcResult {
+    const stagingMaxAgeMs = options?.stagingMaxAgeMs ?? DefaultStagingMaxAgeMs;
+    const result: GcResult = { removed: [], skipped: [] };
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(this.baseDir, { withFileTypes: true });
+    } catch {
+      return result;
+    }
+
+    const currentDirName = this.readManifest()?.dir;
+    const isStale = (fullPath: string) => {
+      try {
+        return Date.now() - fs.statSync(fullPath).mtimeMs > stagingMaxAgeMs;
+      } catch {
+        return false;
+      }
+    };
+
+    for (const entry of entries) {
+      const fullPath = path.join(this.baseDir, entry.name);
+
+      let shouldRemove = false;
+      if (entry.isDirectory()) {
+        shouldRemove = entry.name.startsWith(StagingPrefix)
+          ? isStale(fullPath)
+          : entry.name !== currentDirName;
+      } else if (entry.name.startsWith(ManifestTmpPrefix)) {
+        shouldRemove = isStale(fullPath);
+      }
+      if (!shouldRemove) {
+        continue;
+      }
+
+      try {
+        fs.rmSync(fullPath, { recursive: true });
+        result.removed.push(entry.name);
+      } catch {
+        result.skipped.push(entry.name);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * One-time migration from the pre-versioning layout (a single `files` dir
+   * plus `release.json`). Renames the existing install into a version dir so
+   * the user does not have to re-download. Returns true if a migration was
+   * performed.
+   */
+  migrateLegacyLayout(
+    legacyFilesDir: string,
+    legacyReleaseJsonPath: string
+  ): boolean {
+    if (this.readManifest()) {
+      return false;
+    }
+
+    let version: InstallVersion;
+    try {
+      const parsed = JSON.parse(
+        fs.readFileSync(legacyReleaseJsonPath, 'utf8')
+      ) as { tag_name?: string; created_at?: string };
+      if (typeof parsed.tag_name !== 'string' || parsed.tag_name === '') {
+        logger.warn(
+          `Legacy ${legacyReleaseJsonPath} has no usable tag, skipping migration`
+        );
+        return false;
+      }
+      // A legacy release.json without created_at predates upload-time
+      // tracking; the empty value makes the next update check re-download.
+      version = { tag: parsed.tag_name, createdAt: parsed.created_at ?? '' };
+    } catch {
+      // A missing release.json is the normal "no legacy install" state.
+      return false;
+    }
+
+    if (!fs.existsSync(path.join(legacyFilesDir, this.exeName))) {
+      logger.info(`Legacy install has no ${this.exeName}, skipping migration`);
+      return false;
+    }
+
+    logger.info(
+      `Migrating legacy install ${legacyFilesDir} (tag ${version.tag})`
+    );
+    try {
+      fs.renameSync(legacyFilesDir, this.versionDirPath(version));
+    } catch {
+      // An older extension version may be running the legacy exe (rename
+      // fails on Windows then); leave the layout alone and retry later.
+      if (!this.hasVersion(version)) {
+        logger.warn(
+          `Could not move legacy install ${legacyFilesDir}, will retry on a later activation`
+        );
+        return false;
+      }
+    }
+
+    this.publishCurrent(version);
+    try {
+      fs.rmSync(legacyReleaseJsonPath, { force: true });
+    } catch {
+      // Best-effort; a leftover release.json is harmless.
+    }
+    return true;
+  }
+}

--- a/qt-qml/test/suite/index.mts
+++ b/qt-qml/test/suite/index.mts
@@ -14,9 +14,12 @@ export function run(): Promise<void> {
   });
   const testsRoot = path.resolve(__dirname);
   return new Promise((c, e) => {
-    const testFiles = new glob.Glob('{extension,command,installer}.test.js', {
-      cwd: testsRoot
-    });
+    const testFiles = new glob.Glob(
+      '{extension,command,installer,versioned-installations}.test.js',
+      {
+        cwd: testsRoot
+      }
+    );
     const testFileStream = testFiles.stream();
     testFileStream.on('data', (file) => {
       mocha.addFile(path.resolve(testsRoot, file));

--- a/qt-qml/test/suite/installer.test.mts
+++ b/qt-qml/test/suite/installer.test.mts
@@ -8,7 +8,11 @@ import * as path from 'path';
 import { spawnSync } from 'child_process';
 import * as vscode from 'vscode';
 
+import { OSExeSuffix } from 'qt-lib';
 import * as installer from '@/installer.mjs';
+import { VersionedInstallations } from '@/versioned-installations.mjs';
+
+const QmllsExeName = 'qmlls' + OSExeSuffix;
 
 const BASE_ASSET: installer.AssetWithTag = {
   id: '101',
@@ -25,36 +29,30 @@ function makeAsset(
   return { ...BASE_ASSET, ...overrides };
 }
 
-// release.json lives one directory above the qmlls executable
-// (<globalStorage>/qmlls/release.json vs <globalStorage>/qmlls/files/qmlls).
-function releaseJsonPath(): string {
-  return path.resolve(
-    path.dirname(installer.getExpectedQmllsPath()),
-    '..',
-    'release.json'
+// Installs a fake build into the versioned store the installer operates on
+// and publishes it as current, like a finished install() would. The exe is
+// not runnable; only tests that must reach the health check need
+// installRunnableBuild() instead.
+function installFakeBuild(
+  version: installer.InstallVersion,
+  content: string | Buffer = 'not a real executable'
+): string {
+  const installations = new VersionedInstallations(
+    installer.getInstallRoot(),
+    QmllsExeName
   );
+  const stagingDir = installations.createStagingDir();
+  fs.writeFileSync(path.join(stagingDir, QmllsExeName), content);
+  const versionDir = installations.commitStagedInstall(stagingDir, version);
+  installations.publishCurrent(version);
+  return path.join(versionDir, QmllsExeName);
 }
 
-function writeInstalledReleaseJson(record: object): void {
-  fs.mkdirSync(path.dirname(releaseJsonPath()), { recursive: true });
-  fs.writeFileSync(releaseJsonPath(), JSON.stringify(record, null, 2));
-}
-
-// Places a file at the expected qmlls path so the "is installed" checks pass.
-// The file is not a runnable executable; only tests that must reach the
-// health check need provideRunnableQmllsExecutable() instead.
-function provideDummyQmllsFile(): void {
-  const exePath = installer.getExpectedQmllsPath();
-  fs.mkdirSync(path.dirname(exePath), { recursive: true });
-  fs.writeFileSync(exePath, 'not a real executable');
-}
-
-// Places a file at the expected qmlls path that exits 0 for `qmlls --help`,
-// so checkStatusAgainst can reach the UpToDate verdict. Returns false when no
+// Installs a fake build whose exe exits 0 for `qmlls --help`, so
+// checkStatusAgainst can reach the UpToDate verdict. Returns false when no
 // suitable executable can be provided on this machine (caller should skip).
-function provideRunnableQmllsExecutable(): boolean {
-  const exePath = installer.getExpectedQmllsPath();
-  fs.mkdirSync(path.dirname(exePath), { recursive: true });
+function installRunnableBuild(version: installer.InstallVersion): boolean {
+  let content: string | Buffer;
   if (process.platform === 'win32') {
     // A .exe must be a real binary; reuse the node.exe that runs the tests.
     const where = spawnSync('where', ['node'], { encoding: 'utf8' });
@@ -65,10 +63,11 @@ function provideRunnableQmllsExecutable(): boolean {
     if (where.status !== 0 || !nodePath) {
       return false;
     }
-    fs.copyFileSync(nodePath, exePath);
+    content = fs.readFileSync(nodePath);
   } else {
-    fs.writeFileSync(exePath, '#!/bin/sh\nexit 0\n');
+    content = '#!/bin/sh\nexit 0\n';
   }
+  const exePath = installFakeBuild(version, content);
   fs.chmodSync(exePath, 0o755);
   return true;
 }
@@ -92,11 +91,7 @@ describe('installer: qmlls update detection', () => {
   });
 
   it('reports Outdated when the remote tag differs from the installed one', () => {
-    provideDummyQmllsFile();
-    writeInstalledReleaseJson({
-      tag_name: '0.6',
-      created_at: BASE_ASSET.created_at
-    });
+    installFakeBuild({ tag: '0.6', createdAt: BASE_ASSET.created_at });
 
     const result = installer.checkStatusAgainst(makeAsset({ tag_name: '0.7' }));
 
@@ -104,10 +99,9 @@ describe('installer: qmlls update detection', () => {
   });
 
   it('reports Outdated when an asset is re-uploaded under the same tag (revert)', () => {
-    provideDummyQmllsFile();
-    writeInstalledReleaseJson({
-      tag_name: BASE_ASSET.tag_name,
-      created_at: '2026-03-16T16:19:16Z'
+    installFakeBuild({
+      tag: BASE_ASSET.tag_name,
+      createdAt: '2026-03-16T16:19:16Z'
     });
 
     const result = installer.checkStatusAgainst(
@@ -117,21 +111,24 @@ describe('installer: qmlls update detection', () => {
     expect(result.status).to.equal(installer.AssetStatus.Outdated);
   });
 
-  it('reports Outdated when the installed release.json predates upload tracking', () => {
-    provideDummyQmllsFile();
-    // Older extension versions stored only the tag.
-    writeInstalledReleaseJson({ tag_name: BASE_ASSET.tag_name });
+  it('reports Outdated when the install predates upload-time tracking', () => {
+    // Migrated legacy installs may have no recorded upload time.
+    installFakeBuild({ tag: BASE_ASSET.tag_name, createdAt: '' });
 
     const result = installer.checkStatusAgainst(makeAsset());
 
     expect(result.status).to.equal(installer.AssetStatus.Outdated);
   });
 
-  it('recognizes an asset recorded by writeReleaseInfo as up to date', function () {
-    if (!provideRunnableQmllsExecutable()) {
+  it('recognizes the published build as up to date when tag and upload time match', function () {
+    if (
+      !installRunnableBuild({
+        tag: BASE_ASSET.tag_name,
+        createdAt: BASE_ASSET.created_at
+      })
+    ) {
       this.skip();
     }
-    installer.writeReleaseInfo(makeAsset());
 
     const result = installer.checkStatusAgainst(makeAsset());
 

--- a/qt-qml/test/suite/versioned-installations.test.mts
+++ b/qt-qml/test/suite/versioned-installations.test.mts
@@ -1,0 +1,313 @@
+// Copyright (C) 2026 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { activateQtQml } from '../helper.mts';
+import {
+  VersionedInstallations,
+  ManifestFileName
+} from '../../src/versioned-installations.mts';
+
+const exeName = 'fake-exe';
+const defaultCreatedAt = '2026-03-23T04:33:35Z';
+
+describe('VersionedInstallations', () => {
+  let baseDir: string;
+  let installations: VersionedInstallations;
+
+  before('activate', async () => {
+    await activateQtQml();
+  });
+
+  beforeEach(() => {
+    baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qmlls-vinst-test-'));
+    installations = new VersionedInstallations(baseDir, exeName);
+  });
+
+  afterEach(() => {
+    fs.rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  // Simulates a finished download: a staging dir containing the exe.
+  function stageFakeInstall(content = 'binary-content'): string {
+    const staging = installations.createStagingDir();
+    fs.writeFileSync(path.join(staging, exeName), content);
+    return staging;
+  }
+
+  // Installs a complete version: stage, commit, publish.
+  function installVersion(
+    tag: string,
+    createdAt = defaultCreatedAt,
+    content = 'binary-content'
+  ): string {
+    const version = { tag, createdAt };
+    const staging = stageFakeInstall(content);
+    const versionDir = installations.commitStagedInstall(staging, version);
+    installations.publishCurrent(version);
+    return versionDir;
+  }
+
+  describe('on a fresh machine (nothing installed)', () => {
+    it('has no manifest', () => {
+      expect(installations.readManifest()).to.be.undefined;
+    });
+
+    it('resolves no exe path', () => {
+      expect(installations.resolveCurrentExePath()).to.be.undefined;
+    });
+
+    it('reports no installed version', () => {
+      expect(
+        installations.hasVersion({
+          tag: 'v6.9.2',
+          createdAt: defaultCreatedAt
+        })
+      ).to.be.false;
+    });
+  });
+
+  describe('installing one version', () => {
+    it('publishes the tag and upload time in the manifest', () => {
+      installVersion('v6.9.2');
+      const manifest = installations.readManifest();
+      expect(manifest?.tag).to.equal('v6.9.2');
+      expect(manifest?.createdAt).to.equal(defaultCreatedAt);
+    });
+
+    it('resolves the exe path of the installed version', () => {
+      const versionDir = installVersion('v6.9.2');
+      expect(installations.resolveCurrentExePath()).to.equal(
+        path.join(versionDir, exeName)
+      );
+    });
+
+    it('moves the staged files into the version dir', () => {
+      const staging = stageFakeInstall('the-binary');
+      const versionDir = installations.commitStagedInstall(staging, {
+        tag: 'v6.9.2',
+        createdAt: defaultCreatedAt
+      });
+
+      expect(fs.readFileSync(path.join(versionDir, exeName), 'utf8')).to.equal(
+        'the-binary'
+      );
+      expect(fs.existsSync(staging)).to.be.false;
+    });
+
+    it('reports the version as installed', () => {
+      installVersion('v6.9.2');
+      expect(
+        installations.hasVersion({
+          tag: 'v6.9.2',
+          createdAt: defaultCreatedAt
+        })
+      ).to.be.true;
+    });
+  });
+
+  describe('updating to a newer version', () => {
+    it('the manifest points to the new version', () => {
+      installVersion('v6.9.1');
+      installVersion('v6.9.2');
+      expect(installations.readManifest()?.tag).to.equal('v6.9.2');
+    });
+
+    it('collectGarbage removes the old version and keeps the new one', () => {
+      const oldDir = installVersion('v6.9.1');
+      const newDir = installVersion('v6.9.2');
+
+      const result = installations.collectGarbage();
+
+      expect(fs.existsSync(oldDir)).to.be.false;
+      expect(fs.existsSync(newDir)).to.be.true;
+      expect(installations.readManifest()?.tag).to.equal('v6.9.2');
+      expect(result.removed).to.include(path.basename(oldDir));
+    });
+  });
+
+  describe('a build re-published under the same tag', () => {
+    it('gets its own version dir and becomes current', () => {
+      const oldDir = installVersion('v6.9.2', '2026-03-16T16:19:16Z');
+      const newDir = installVersion('v6.9.2', '2026-03-23T04:33:35Z');
+
+      expect(newDir).to.not.equal(oldDir);
+      const manifest = installations.readManifest();
+      expect(manifest?.tag).to.equal('v6.9.2');
+      expect(manifest?.createdAt).to.equal('2026-03-23T04:33:35Z');
+      expect(installations.resolveCurrentExePath()).to.equal(
+        path.join(newDir, exeName)
+      );
+    });
+
+    it('collectGarbage removes the replaced build', () => {
+      const oldDir = installVersion('v6.9.2', '2026-03-16T16:19:16Z');
+      const newDir = installVersion('v6.9.2', '2026-03-23T04:33:35Z');
+
+      const result = installations.collectGarbage();
+
+      expect(fs.existsSync(oldDir)).to.be.false;
+      expect(fs.existsSync(newDir)).to.be.true;
+      expect(result.removed).to.include(path.basename(oldDir));
+    });
+  });
+
+  describe('two VS Code instances installing the same version', () => {
+    it('the loser adopts the winner files and its staging dir is removed', () => {
+      const version = { tag: 'v6.9.2', createdAt: defaultCreatedAt };
+      const winnerStaging = stageFakeInstall('winner');
+      const winnerDir = installations.commitStagedInstall(
+        winnerStaging,
+        version
+      );
+
+      const loserStaging = stageFakeInstall('loser');
+      const loserDir = installations.commitStagedInstall(loserStaging, version);
+
+      expect(loserDir).to.equal(winnerDir);
+      expect(fs.readFileSync(path.join(winnerDir, exeName), 'utf8')).to.equal(
+        'winner'
+      );
+      expect(fs.existsSync(loserStaging)).to.be.false;
+    });
+  });
+
+  describe('broken states', () => {
+    it('a corrupt manifest counts as not installed', () => {
+      fs.writeFileSync(path.join(baseDir, ManifestFileName), '{ not json');
+      expect(installations.readManifest()).to.be.undefined;
+    });
+
+    it('a manifest pointing to a deleted version resolves no exe path', () => {
+      const versionDir = installVersion('v6.9.2');
+      fs.rmSync(versionDir, { recursive: true, force: true });
+      expect(installations.resolveCurrentExePath()).to.be.undefined;
+    });
+
+    it('a version dir without the exe does not count as installed', () => {
+      const version = { tag: 'v6.9.2', createdAt: defaultCreatedAt };
+      fs.mkdirSync(installations.versionDirPath(version), {
+        recursive: true
+      });
+      expect(installations.hasVersion(version)).to.be.false;
+    });
+  });
+
+  describe('migration from the old files/ + release.json layout', () => {
+    function createLegacyLayout(tag: string, createdAt?: string) {
+      const legacyFilesDir = path.join(baseDir, 'files');
+      fs.mkdirSync(legacyFilesDir, { recursive: true });
+      fs.writeFileSync(path.join(legacyFilesDir, exeName), 'legacy-binary');
+      const legacyReleaseJsonPath = path.join(baseDir, 'release.json');
+      fs.writeFileSync(
+        legacyReleaseJsonPath,
+        JSON.stringify(
+          createdAt
+            ? { tag_name: tag, created_at: createdAt }
+            : { tag_name: tag }
+        )
+      );
+      return { legacyFilesDir, legacyReleaseJsonPath };
+    }
+
+    it('turns the legacy install into a published version', () => {
+      const { legacyFilesDir, legacyReleaseJsonPath } =
+        createLegacyLayout('v6.9.1');
+
+      const migrated = installations.migrateLegacyLayout(
+        legacyFilesDir,
+        legacyReleaseJsonPath
+      );
+
+      expect(migrated).to.be.true;
+      expect(fs.existsSync(legacyFilesDir)).to.be.false;
+      expect(fs.existsSync(legacyReleaseJsonPath)).to.be.false;
+      const manifest = installations.readManifest();
+      expect(manifest?.tag).to.equal('v6.9.1');
+      // No recorded upload time: the next update check re-downloads once.
+      expect(manifest?.createdAt).to.equal('');
+      const exePath = installations.resolveCurrentExePath();
+      expect(exePath).to.not.be.undefined;
+      expect(fs.readFileSync(exePath ?? '', 'utf8')).to.equal('legacy-binary');
+    });
+
+    it('carries the recorded upload time into the manifest', () => {
+      const { legacyFilesDir, legacyReleaseJsonPath } = createLegacyLayout(
+        'v6.9.1',
+        defaultCreatedAt
+      );
+
+      const migrated = installations.migrateLegacyLayout(
+        legacyFilesDir,
+        legacyReleaseJsonPath
+      );
+
+      expect(migrated).to.be.true;
+      const manifest = installations.readManifest();
+      expect(manifest?.tag).to.equal('v6.9.1');
+      expect(manifest?.createdAt).to.equal(defaultCreatedAt);
+    });
+
+    it('does not migrate when a version is already installed', () => {
+      installVersion('v6.9.2');
+      const { legacyFilesDir, legacyReleaseJsonPath } =
+        createLegacyLayout('v6.9.1');
+
+      const migrated = installations.migrateLegacyLayout(
+        legacyFilesDir,
+        legacyReleaseJsonPath
+      );
+
+      expect(migrated).to.be.false;
+      expect(installations.readManifest()?.tag).to.equal('v6.9.2');
+      expect(fs.existsSync(legacyFilesDir)).to.be.true;
+    });
+
+    it('does nothing when there is no legacy install', () => {
+      const migrated = installations.migrateLegacyLayout(
+        path.join(baseDir, 'files'),
+        path.join(baseDir, 'release.json')
+      );
+      expect(migrated).to.be.false;
+      expect(installations.readManifest()).to.be.undefined;
+    });
+  });
+
+  describe('other behavior', () => {
+    it('tags with unsafe characters get safe dir names', () => {
+      const versionDir = installVersion('feature/v6.9.2:beta');
+      expect(path.dirname(versionDir)).to.equal(baseDir);
+      expect(installations.readManifest()?.tag).to.equal('feature/v6.9.2:beta');
+      expect(
+        installations.hasVersion({
+          tag: 'feature/v6.9.2:beta',
+          createdAt: defaultCreatedAt
+        })
+      ).to.be.true;
+    });
+
+    it('publishing leaves no temporary files behind', () => {
+      installVersion('v6.9.2');
+      const leftovers = fs
+        .readdirSync(baseDir)
+        .filter(
+          (name) => name.includes(ManifestFileName) && name !== ManifestFileName
+        );
+      expect(leftovers).to.deep.equal([]);
+    });
+
+    it('collectGarbage does nothing when the base dir does not exist', () => {
+      const missing = new VersionedInstallations(
+        path.join(baseDir, 'does-not-exist'),
+        exeName
+      );
+      const result = missing.collectGarbage();
+      expect(result.removed).to.deep.equal([]);
+      expect(result.skipped).to.deep.equal([]);
+    });
+  });
+});


### PR DESCRIPTION
## Description

* Give qmlls more time to stop
A busy qmlls often needs more than 2 seconds to answer the shutdown
request. The default stop timeout of vscode-languageclient is 2
seconds. Because of this, restarts after an update often showed the
error "Stopping the server timed out". Raise the timeout to 5 seconds.
Also log this case as a warning, not an error. The client kills the
server after the timeout anyway, so the restart still works.

* Install each qmlls version into its own directory
Many VS Code windows share the same qmlls installation. Before this
change, they could break each other. Two windows could download to the
same temp file at the same time. An update could overwrite a qmlls
binary that was still running. The language server was also stopped
during the whole download.
Now every version gets its own directory. A new version is unpacked
into a temp directory first. Then it is moved into place with one
atomic rename. If two windows install the same version, the second one
simply uses the files from the first one. The file current.json points
to the current version. It is always written atomically. The exe path
is read fresh from it on every start.
Old versions are deleted on a best-effort basis. If a directory cannot
be deleted (for example a running exe on Windows), it is skipped and
deleted later. The old files/ + release.json layout is converted in
place, without a new download.
Other windows watch current.json. When a new version appears, they
restart their language server silently. The server also keeps running
during the download now. It only restarts after the new version is
ready. Because nothing is overwritten anymore, the old ETXTBSY
workaround was removed.
## Related issue

[VSCODEEXT-279](https://qt-project.atlassian.net/browse/VSCODEEXT-279)

## Type of change

<!-- Put an "x" in the boxes that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue) https://qt-project.atlassian.net/browse/VSCODEEXT-279
- [x] Breaking change (fix or feature that would change existing behavior)
