### PR TITLE
qt-qml, qt-core: Pass 127.0.0.1 instead of localhost to the QML debugger

### DIFF
--- a/qt-core/src/project-config-generator.ts
+++ b/qt-core/src/project-config-generator.ts
@@ -121,13 +121,15 @@ function qmlAttachLaunchConfig(): LaunchConfiguration {
     name: 'Attach to QML debugger',
     type: 'qml',
     request: 'attach',
-    host: 'localhost',
+    host: '127.0.0.1',
     port: '${command:qt-qml.debugPort}'
   };
 }
 
+// The QML debug server only accepts an IP address literal as the host, so
+// "localhost" would make it listen on all interfaces (VSCODEEXT-219).
 const qmlDebuggerArgs =
-  '-qmljsdebugger=host:localhost,port:${command:qt-qml.debugPort},' +
+  '-qmljsdebugger=host:127.0.0.1,port:${command:qt-qml.debugPort},' +
   'block,services:DebugMessages,QmlDebugger,V8Debugger';
 
 function cppQmlCppdbgLaunchConfig(): LaunchConfiguration {

--- a/qt-qml/package.json
+++ b/qt-qml/package.json
@@ -365,7 +365,7 @@
               "host": {
                 "type": "string",
                 "description": "Hostname (or IP address) of the target program's debug service",
-                "default": "localhost"
+                "default": "127.0.0.1"
               },
               "port": {
                 "type": [
@@ -418,7 +418,7 @@
             "type": "qml",
             "request": "attach",
             "name": "Attach to QML debugger",
-            "host": "localhost",
+            "host": "127.0.0.1",
             "port": "^\"Custom port or \\${command:qt-qml.debugPort} for compound usage\""
           }
         ],
@@ -440,7 +440,7 @@
               "name": "%qt-qml.debug.qmlDebuggingAttach.label%",
               "type": "qml",
               "request": "attach",
-              "host": "localhost",
+              "host": "127.0.0.1",
               "port": "^\"Custom port or \\${command:qt-qml.debugPort} for compound usage\""
             }
           },
@@ -457,7 +457,7 @@
               "visualizerFile": "^\"\\${command:qt-cpp.natvis}\"",
               "showDisplayString": true,
               "args": [
-                "^\"-qmljsdebugger=host:localhost,port:\\${command:qt-qml.debugPort},block,services:DebugMessages,QmlDebugger,V8Debugger\""
+                "^\"-qmljsdebugger=host:127.0.0.1,port:\\${command:qt-qml.debugPort},block,services:DebugMessages,QmlDebugger,V8Debugger\""
               ],
               "linux": {
                 "MIMode": "gdb",
@@ -511,7 +511,7 @@
               "cwd": "^\"\\${workspaceFolder}\"",
               "visualizerFile": "^\"\\${command:qt-cpp.natvis}\"",
               "args": [
-                "^\"-qmljsdebugger=host:localhost,port:\\${command:qt-qml.debugPort},block,services:DebugMessages,QmlDebugger,V8Debugger\""
+                "^\"-qmljsdebugger=host:127.0.0.1,port:\\${command:qt-qml.debugPort},block,services:DebugMessages,QmlDebugger,V8Debugger\""
               ],
               "windows": {
                 "sourceFileMap": {

--- a/qt-qml/src/debug/debug-adapter.mts
+++ b/qt-qml/src/debug/debug-adapter.mts
@@ -595,7 +595,10 @@ export class QmlDebugSession extends LoggingDebugSession {
       let port: number | undefined;
       let host: string | undefined;
       if (args.debuggerArgs === undefined) {
-        host = 'localhost';
+        // The QML debug server parses the host as an IP address literal, so
+        // hostnames like "localhost" are rejected and the server would fall
+        // back to listening on all interfaces (VSCODEEXT-219).
+        host = '127.0.0.1';
         port = await getPort();
         debuggerArgs = `-qmljsdebugger=host:${host},port:${port.toString()},block,services:DebugMessages,QmlDebugger,V8Debugger`;
       } else {


### PR DESCRIPTION
The QML debug server only accepts an IP address literal as the host, so
"localhost" is rejected and the server falls back to listening on all
interfaces. Use 127.0.0.1 in the debugger arguments and in the launch
and attach configuration defaults.

Fixes: [VSCODEEXT-219](https://qt-project.atlassian.net/browse/VSCODEEXT-219)
