### PR TITLE
Use qt-lib platform constants instead of ad-hoc platform checks

### DIFF
--- a/qt-core/src/qtcli/commands.ts
+++ b/qt-core/src/qtcli/commands.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import { exists, IsArm64 } from 'qt-lib';
+import { exists, IsArm64, IsLinux, IsMacOS, IsWindows } from 'qt-lib';
 import { EXTENSION_ID } from '@/constants';
 import {
   qtcliExeName,
@@ -53,16 +53,14 @@ function getDefaultProjectDir(): string | undefined {
 }
 
 function findQtcliOsPrefix(): string {
-  const platform = process.platform;
-
-  if (platform === 'win32') {
+  if (IsWindows) {
     return `qtcli-windows-${IsArm64 ? 'arm64-' : 'amd64-'}`;
-  } else if (platform === 'linux') {
+  } else if (IsLinux) {
     return `qtcli-linux-${IsArm64 ? 'arm64-' : 'amd64-'}`;
-  } else if (platform === 'darwin') {
+  } else if (IsMacOS) {
     return 'qtcli-darwin-all-';
   } else {
-    throw new Error(`Platform '${platform}' is not supported`);
+    throw new Error(`Platform '${process.platform}' is not supported`);
   }
 }
 

--- a/qt-core/src/qtcli/common.ts
+++ b/qt-core/src/qtcli/common.ts
@@ -1,19 +1,18 @@
 // Copyright (C) 2024 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
-import * as os from 'os';
 import * as fs from 'fs/promises';
 import * as fsSync from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import { createLogger, OSExeSuffix } from 'qt-lib';
+import { createLogger, Home, OSExeSuffix } from 'qt-lib';
 
 export const qtcliExeName = 'qtcli' + OSExeSuffix;
 const logger = createLogger('qtcli');
 
 export function fallbackWorkingDir(): string {
-  const docs = path.join(os.homedir(), 'Documents');
+  const docs = path.join(Home, 'Documents');
   const settings =
     vscode.workspace
       .getConfiguration('files')

--- a/qt-core/src/qtcli/rest.ts
+++ b/qt-core/src/qtcli/rest.ts
@@ -1,13 +1,12 @@
 // Copyright (C) 2025 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
-import os from 'os';
 import * as vscode from 'vscode';
 import * as childProcess from 'child_process';
 import { randomUUID } from 'crypto';
 import axios, { AxiosRequestConfig, isAxiosError } from 'axios';
 
-import { createLogger } from 'qt-lib';
+import { createLogger, IsWindows } from 'qt-lib';
 import { findQtcliExePath } from '@/qtcli/commands';
 import { isErrorResponse, Issue } from '@/webview/shared/message';
 
@@ -33,10 +32,9 @@ export class QtcliRestClient {
     this._api = axios.create({
       baseURL: 'http://unix',
       timeout: 15 * 1000,
-      socketPath:
-        os.platform() !== 'win32'
-          ? `/tmp/qtcli/${socketName}.sock`
-          : String.raw`\\.\pipe\qtcli` + `\\${socketName}.pipe`
+      socketPath: !IsWindows
+        ? `/tmp/qtcli/${socketName}.sock`
+        : String.raw`\\.\pipe\qtcli` + `\\${socketName}.pipe`
     });
 
     this._timerId = setInterval(() => {

--- a/qt-core/src/ui-designer/locator.ts
+++ b/qt-core/src/ui-designer/locator.ts
@@ -1,7 +1,6 @@
 // Copyright (C) 2026 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
-import * as os from 'os';
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
@@ -9,6 +8,7 @@ import * as vscode from 'vscode';
 
 import {
   IsMacOS,
+  IsWindows,
   OSExeSuffix,
   createWrappedLogger,
   resolveConfiguration,
@@ -204,7 +204,7 @@ async function checkExeStatus(input: string): Promise<ExeCheckResult> {
     return ExeCheckResult.NotAFile;
   }
 
-  if (os.platform() === 'win32') {
+  if (IsWindows) {
     const args = ['.exe', '.cmd', '.bat', '.com'];
     if (!args.includes(path.extname(normalized).toLowerCase())) {
       return ExeCheckResult.NotExecutableExtension;

--- a/qt-core/src/webview/ex-browser/dispatcher.ts
+++ b/qt-core/src/webview/ex-browser/dispatcher.ts
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import { createLogger } from 'qt-lib';
+import { createLogger, normalizeDriveLetter } from 'qt-lib';
 import { WebviewChannel } from '@/webview/channel';
 import {
   Command,
@@ -229,11 +229,7 @@ export class ExBrowserDispatcher {
 
     const folderUri = await vscode.window.showOpenDialog(options);
     if (folderUri && folderUri.length > 0) {
-      let folder = folderUri[0]?.fsPath ?? '';
-      if (process.platform === 'win32' && /^[a-z]:/.test(folder)) {
-        folder = folder.charAt(0).toUpperCase() + folder.slice(1);
-      }
-
+      const folder = normalizeDriveLetter(folderUri[0]?.fsPath ?? '');
       this._comm.postDataReply(cmd, folder);
     }
   };

--- a/qt-core/src/webview/new-item/dispatcher.ts
+++ b/qt-core/src/webview/new-item/dispatcher.ts
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import { createLogger, telemetry } from 'qt-lib';
+import { createLogger, normalizeDriveLetter, telemetry } from 'qt-lib';
 import * as texts from '@/texts';
 import { QtcliRestClient, QtcliRestError } from '@/qtcli/rest';
 import { openFilesUnder, openUri } from '@/qtcli/common';
@@ -227,11 +227,7 @@ export class NewItemDispatcher {
 
     const folderUri = await vscode.window.showOpenDialog(options);
     if (folderUri && folderUri.length > 0) {
-      let folder = folderUri[0]?.fsPath ?? '';
-      if (process.platform === 'win32' && /^[a-z]:/.test(folder)) {
-        folder = folder.charAt(0).toUpperCase() + folder.slice(1);
-      }
-
+      const folder = normalizeDriveLetter(folderUri[0]?.fsPath ?? '');
       this._comm?.postDataReply(cmd, folder);
     }
   };

--- a/qt-core/src/webview/qml-trace/controller.ts
+++ b/qt-core/src/webview/qml-trace/controller.ts
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import { createLogger, getQtQmlApi } from 'qt-lib';
+import { createLogger, getQtQmlApi, normalizeDriveLetter } from 'qt-lib';
 import {
   Command,
   CommandId,
@@ -105,11 +105,7 @@ export class QmlTraceController {
 
     const folderUri = await vscode.window.showOpenDialog(options);
     if (folderUri && folderUri.length > 0) {
-      let folder = folderUri[0]?.fsPath ?? '';
-      if (process.platform === 'win32' && /^[a-z]:/.test(folder)) {
-        folder = folder.charAt(0).toUpperCase() + folder.slice(1);
-      }
-
+      const folder = normalizeDriveLetter(folderUri[0]?.fsPath ?? '');
       this._postReply(cmd, { folders: [folder] });
     }
   };

--- a/qt-core/test/suite/commands.test.mts
+++ b/qt-core/test/suite/commands.test.mts
@@ -5,6 +5,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import {
+  Home,
   isMultiWorkspace,
   QtAdditionalPath,
   AdditionalQtPathsName,
@@ -12,7 +13,6 @@ import {
   generateDefaultQtPathsName
 } from 'qt-lib';
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import {
   addQtPathToSettings,
@@ -373,7 +373,7 @@ describe('command: registerQt', () => {
 
     // Pick one candidate and pretend it exists
     const candidates = getDefaultQtRootCandidates();
-    const portable = path.join(os.homedir(), 'Qt');
+    const portable = path.join(Home, 'Qt');
     // Guard to ensure test stays aligned with production candidates
     expect(
       candidates.includes(portable),

--- a/qt-cpp/test/configure-build-helper.mts
+++ b/qt-cpp/test/configure-build-helper.mts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as cp from 'child_process';
-import { delay } from 'qt-lib';
+import { delay, IsMacOS, IsWindows, OSExeSuffix } from 'qt-lib';
 
 import {
   waitForVSCodeIdle,
@@ -89,9 +89,7 @@ type ConfigureResult = {
 export function materializeSnippetConfigForCurrentPlatform(
   base: vscode.DebugConfiguration
 ): vscode.DebugConfiguration {
-  const isWin = process.platform === 'win32';
-  const isMac = process.platform === 'darwin';
-  const platformKey = isWin ? 'windows' : isMac ? 'osx' : 'linux';
+  const platformKey = IsWindows ? 'windows' : IsMacOS ? 'osx' : 'linux';
 
   const platformOverrides = (base as any)[platformKey] as
     | Record<string, unknown>
@@ -133,7 +131,7 @@ function dumpConfigureOutput(
     const res = cp.spawnSync('cmake', ['--preset', presetName], {
       cwd: projectDir,
       encoding: 'utf-8',
-      shell: process.platform === 'win32'
+      shell: IsWindows
     });
     if (res.error) {
       console.log(
@@ -178,7 +176,7 @@ function dumpBuildOutput(logPrefix: string, buildDir: string): void {
   try {
     const res = cp.spawnSync('cmake', ['--build', buildDir], {
       encoding: 'utf-8',
-      shell: process.platform === 'win32'
+      shell: IsWindows
     });
     if (res.error) {
       console.log(
@@ -308,7 +306,6 @@ export async function configureAndBuildMinimalQtProject(
   // `cmake.useVsDeveloperEnvironment: 'always'`. The `architecture` field
   // uses the presets-spec "external" strategy: CMake ignores it, but CMake
   // Tools reads it to pick the environment's target architecture.
-  const isWin = process.platform === 'win32';
   const presets = {
     version: 3,
     configurePresets: [
@@ -317,7 +314,7 @@ export async function configureAndBuildMinimalQtProject(
         displayName: 'Qt Debug Configuration',
         description: 'Debug build using Qt with CMake Presets',
         binaryDir: buildDir,
-        ...(isWin
+        ...(IsWindows
           ? {
               generator: 'Ninja',
               architecture: { value: 'x64', strategy: 'external' }
@@ -326,7 +323,7 @@ export async function configureAndBuildMinimalQtProject(
         cacheVariables: {
           CMAKE_BUILD_TYPE: 'Debug',
           CMAKE_PREFIX_PATH: qtEnv.leaf,
-          ...(isWin
+          ...(IsWindows
             ? {
                 CMAKE_C_COMPILER: 'clang-cl',
                 CMAKE_CXX_COMPILER: 'clang-cl'
@@ -399,7 +396,7 @@ export async function configureAndBuildMinimalQtProject(
 
   // Ninja (single-config) is pinned on Windows, so the binary lands directly
   // in the build directory on every platform.
-  const bin = process.platform === 'win32' ? 'hello.exe' : 'hello';
+  const bin = 'hello' + OSExeSuffix;
   const outPath = path.join(buildDir, bin);
   dlog(`${logPrefix} Checking for binary at`, outPath);
 

--- a/qt-cpp/test/debug-helper.mts
+++ b/qt-cpp/test/debug-helper.mts
@@ -4,6 +4,8 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 
+import { IsLinux, IsMacOS, IsWindows } from 'qt-lib';
+
 /**
  * Debug-session utilities for qt-cpp NatVis integration tests.
  *
@@ -125,10 +127,7 @@ export function addBreakpoints(bps: vscode.SourceBreakpoint[]) {
  * @throws Error if required launch paths or the NatVis file cannot be resolved.
  */
 export async function makeCppDebugConfig(): Promise<vscode.DebugConfiguration> {
-  const isWin = process.platform === 'win32';
-  const isMac = process.platform === 'darwin';
-  const isLinux = process.platform === 'linux';
-  const miMode = process.env.MIMODE || (isMac ? 'lldb' : 'gdb');
+  const miMode = process.env.MIMODE || (IsMacOS ? 'lldb' : 'gdb');
 
   // Resolve what ${command:...} would have produced
   const program = await vscode.commands.executeCommand<string>(
@@ -151,9 +150,9 @@ export async function makeCppDebugConfig(): Promise<vscode.DebugConfiguration> {
   }
   const cfg: vscode.DebugConfiguration = {
     name: 'natvis-test-launch',
-    type: isWin ? 'cppvsdbg' : 'cppdbg',
+    type: IsWindows ? 'cppvsdbg' : 'cppdbg',
     request: 'launch',
-    ...(isWin ? {} : { MIMode: miMode }),
+    ...(IsWindows ? {} : { MIMode: miMode }),
     // Always the correct binary/dir for the *selected configuration* and *build type*
     program: program, //'${command:cmake.launchTargetPath}', // built binary
     cwd: cwd, //'${command:cmake.getLaunchTargetDirectory}', // correct working dir
@@ -166,11 +165,11 @@ export async function makeCppDebugConfig(): Promise<vscode.DebugConfiguration> {
   };
 
   // Non-Windows: set MI mode, and on Linux also force the debugger path.
-  if (!isWin) {
+  if (!IsWindows) {
     (cfg as any).MIMode = miMode;
 
     // On Ubuntu CI, cpptools can't infer the MI debugger, so we point it at gdb explicitly.
-    if (isLinux && !(cfg as any).miDebuggerPath) {
+    if (IsLinux && !(cfg as any).miDebuggerPath) {
       (cfg as any).miDebuggerPath = 'gdb';
     }
   }
@@ -366,7 +365,7 @@ export async function warmUpNatvisDisplay(
   session: vscode.DebugSession,
   frameId: number
 ): Promise<void> {
-  if (process.platform !== 'win32') return;
+  if (!IsWindows) return;
 
   const topLocals = await getLocals(session, frameId);
 
@@ -584,11 +583,9 @@ export function getQtCppSnippetDebugConfiguration(): vscode.DebugConfiguration {
     );
   }
 
-  const isWin = process.platform === 'win32';
-
   let snippet: DebugConfigurationSnippet | undefined;
 
-  if (isWin) {
+  if (IsWindows) {
     // Windows: use the Visual Studio debugger snippet
     snippet = allSnippets.find((s) => s.body?.type === 'cppvsdbg');
   } else {
@@ -614,7 +611,7 @@ export function getQtCppSnippetDebugConfiguration(): vscode.DebugConfiguration {
   if (!normalized.name) {
     normalized.name =
       snippet.label ??
-      (isWin ? 'Qt snippet (cppvsdbg)' : 'Qt snippet (cppdbg)');
+      (IsWindows ? 'Qt snippet (cppvsdbg)' : 'Qt snippet (cppdbg)');
   }
 
   return normalized;

--- a/qt-cpp/test/suite/build.test.mts
+++ b/qt-cpp/test/suite/build.test.mts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { delay } from 'qt-lib';
+import { delay, OSExeSuffix } from 'qt-lib';
 import {
   setupSandboxLifecycleHooks,
   waitForVSCodeIdle,
@@ -77,7 +77,7 @@ describe('build: minimal Qt project (index-build)', function () {
 
     await delay(400); // flush to disk
 
-    const bin = process.platform === 'win32' ? 'hello.exe' : 'hello';
+    const bin = 'hello' + OSExeSuffix;
     const outPath = path.join(buildDir, bin);
     console.log('Checking for binary at', outPath);
 

--- a/qt-cpp/test/suite/commands.test.mts
+++ b/qt-cpp/test/suite/commands.test.mts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 
-import { delay } from 'qt-lib';
+import { delay, IsWindows } from 'qt-lib';
 
 import {
   setupSandboxLifecycleHooks,
@@ -62,7 +62,7 @@ describe('command: scanForQtKits', () => {
   }
 
   it('calls for cmake scan for kits command, on Windows', async function () {
-    if (process.platform !== 'win32') {
+    if (!IsWindows) {
       this.skip(); // Only meaningful on Windows
     }
 

--- a/qt-cpp/test/suite/presets.test.mts
+++ b/qt-cpp/test/suite/presets.test.mts
@@ -11,7 +11,8 @@ import {
   delay,
   getCoreApi,
   CoreKey,
-  findQtPathsInInstallationPath
+  findQtPathsInInstallationPath,
+  IsWindows
 } from 'qt-lib';
 import {
   setupSandboxLifecycleHooks,
@@ -127,8 +128,7 @@ describe('presets: CMake Presets integration', function () {
     // Wait for build artifacts to be written to disk
     await delay(DISK_FLUSH_DELAY_MS);
 
-    const bin =
-      process.platform === 'win32' ? path.join('Debug', 'hello.exe') : 'hello';
+    const bin = IsWindows ? path.join('Debug', 'hello.exe') : 'hello';
     const outPath = path.join(buildDir, bin);
     console.log('Checking for binary at', outPath);
 

--- a/qt-lib/src/util.ts
+++ b/qt-lib/src/util.ts
@@ -67,6 +67,13 @@ export async function exists(filePath: string) {
   }
 }
 
+export function normalizeDriveLetter(fsPath: string): string {
+  if (IsWindows && /^[a-z]:/.test(fsPath)) {
+    return fsPath.charAt(0).toUpperCase() + fsPath.slice(1);
+  }
+  return fsPath;
+}
+
 export function askForKitSelection({
   message = 'No CMake kit selected. Please select a CMake kit.',
   buttonName = 'Select CMake Kit'

--- a/qt-lib/test/helper.mts
+++ b/qt-lib/test/helper.mts
@@ -4,9 +4,8 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as os from 'os';
 
-import { delay } from '../src/util.js';
+import { delay, IsMacOS, IsWindows, UserLocalDir } from '../src/util.js';
 
 /** Let VS Code flush microtasks (useful between command execution and assertions). */
 export async function waitForVSCodeIdle(): Promise<void> {
@@ -338,28 +337,16 @@ export function prepareStandardCMakeArgs(
   return args;
 }
 
-/** :
- *  - Windows:  %USERPROFILE%\AppData\Local\CMakeTools\cmake-tools-kits.json
- *  - Others (incl. macOS): ~/.local/share/CMakeTools/cmake-tools-kits.json
+/** Matches CMake Tools' kits file location (userLocalDir/CMakeTools):
+ *  - Windows:  %LOCALAPPDATA%\CMakeTools\cmake-tools-kits.json
+ *  - Others (incl. macOS): ($XDG_DATA_HOME or
+ *    ~/.local/share)/CMakeTools/cmake-tools-kits.json
  */
 function kitsPath(): string {
-  const home = os.homedir();
-  if (process.platform === 'win32') {
-    return path.join(
-      home,
-      'AppData',
-      'Local',
-      'CMakeTools',
-      'cmake-tools-kits.json'
-    );
+  if (!UserLocalDir) {
+    throw new Error('Cannot determine the user local data directory');
   }
-  return path.join(
-    home,
-    '.local',
-    'share',
-    'CMakeTools',
-    'cmake-tools-kits.json'
-  );
+  return path.join(UserLocalDir, 'CMakeTools', 'cmake-tools-kits.json');
 }
 
 type KitLike = { name?: string; label?: string };
@@ -395,12 +382,11 @@ function readKitsFromDisk(): KitLike[] {
 function pickKit(list: KitLike[]): string | undefined {
   if (!Array.isArray(list) || list.length === 0) return undefined;
 
-  const preferences: RegExp[] =
-    process.platform === 'darwin'
-      ? [/Clang.*arm64/i, /AppleClang/i, /Clang/i, /GCC/i]
-      : process.platform === 'win32'
-        ? [/MSVC|Visual Studio|Clang-cl/i, /Clang/i, /GCC|MinGW/i]
-        : [/GCC/i, /Clang/i];
+  const preferences: RegExp[] = IsMacOS
+    ? [/Clang.*arm64/i, /AppleClang/i, /Clang/i, /GCC/i]
+    : IsWindows
+      ? [/MSVC|Visual Studio|Clang-cl/i, /Clang/i, /GCC|MinGW/i]
+      : [/GCC/i, /Clang/i];
 
   for (const re of preferences) {
     const k = list.find((kk) => re.test(kk.name ?? kk.label ?? ''));

--- a/qt-qml/src/traceviewer/extractor.mts
+++ b/qt-qml/src/traceviewer/extractor.mts
@@ -7,6 +7,7 @@ import * as yauzl from 'yauzl';
 import * as vscode from 'vscode';
 import { Writable } from 'stream';
 
+import { IsWindows } from 'qt-lib';
 import { DownloadResult } from './downloader.mts';
 import { InstalledRelease } from './installation-manager.mts';
 
@@ -115,7 +116,7 @@ export async function unzipV2(
           reader.pipe(provider.stream);
 
           provider.stream.on('finish', () => {
-            if (process.platform !== 'win32') {
+            if (!IsWindows) {
               const mode = unixAttrs & 0o777;
               if (mode !== 0) {
                 fs.chmodSync(provider.fullPath, mode);

--- a/qt-qml/test/suite/installer.test.mts
+++ b/qt-qml/test/suite/installer.test.mts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import { spawnSync } from 'child_process';
 import * as vscode from 'vscode';
 
-import { OSExeSuffix } from 'qt-lib';
+import { OSExeSuffix, IsWindows } from 'qt-lib';
 import * as installer from '@/installer.mjs';
 import { VersionedInstallations } from '@/versioned-installations.mjs';
 
@@ -53,7 +53,7 @@ function installFakeBuild(
 // suitable executable can be provided on this machine (caller should skip).
 function installRunnableBuild(version: installer.InstallVersion): boolean {
   let content: string | Buffer;
-  if (process.platform === 'win32') {
+  if (IsWindows) {
     // A .exe must be a real binary; reuse the node.exe that runs the tests.
     const where = spawnSync('where', ['node'], { encoding: 'utf8' });
     const nodePath = where.stdout

--- a/qt-qml/test/suite/qml-debug.test.mts
+++ b/qt-qml/test/suite/qml-debug.test.mts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { delay } from 'qt-lib';
+import { delay, IsWindows } from 'qt-lib';
 import {
   setupSandboxLifecycleHooks,
   activateQtCore,
@@ -153,10 +153,9 @@ describe('QML Debugger integration', function () {
     await delay(DISK_FLUSH_DELAY_MS);
 
     // Check for binary
-    const bin =
-      process.platform === 'win32'
-        ? path.join('Debug', 'qml-debug-app.exe')
-        : 'qml-debug-app';
+    const bin = IsWindows
+      ? path.join('Debug', 'qml-debug-app.exe')
+      : 'qml-debug-app';
     const outPath = path.join(buildDir, bin);
     console.log('[qml-debug] Checking for binary at', outPath);
 


### PR DESCRIPTION
- **qt-lib, qt-core: Deduplicate the Windows drive-letter normalization**
- **qt-core, qt-qml: Use qt-lib platform constants**
- **Tests: Use qt-lib platform constants**
