### PR TITLE
Tests: Share the configure-preset retry across suites

### DIFF
--- a/qt-cpp/test/configure-build-helper.mts
+++ b/qt-cpp/test/configure-build-helper.mts
@@ -16,6 +16,7 @@ import {
   cmakeConfigForWorkspace,
   prepareCMakeQtEnvWithVersion,
   readCMakeCacheVar,
+  setConfigurePresetWithRetry,
   dlog
 } from './helper.mts';
 
@@ -26,8 +27,6 @@ import {
 // Test timing constants
 const FS_SETTLE_DELAY_MS = 500; // Wait for file system to settle after writing files
 const DISK_FLUSH_DELAY_MS = 400; // Wait for build artifacts to flush to disk
-const PRESET_APPLY_TIMEOUT_MS = 30_000; // Give up waiting for CMake Tools to apply the preset
-const PRESET_APPLY_RETRY_DELAY_MS = 500; // Pause between preset apply attempts
 
 // Name of the configure preset written by `configureAndBuildMinimalQtProject`.
 const CONFIGURE_PRESET_NAME = 'qt-debug';
@@ -356,38 +355,10 @@ export async function configureAndBuildMinimalQtProject(
   const errSpy = sandbox.spy(vscode.window, 'showErrorMessage');
 
   // ---- configure + build --------------------------------------------
-  // `cmake.setConfigurePreset` resolves the preset name against CMake Tools'
-  // in-memory presets model, which is only refreshed once its file watcher
-  // has reparsed the CMakePresets.json written above. If the reload has not
-  // happened yet (seen on macOS CI), the lookup fails and CMake Tools
-  // silently resets the selection to null instead of applying it — and the
-  // cmake.configure below then blocks forever on a preset quick pick nobody
-  // can answer. Retry until the active preset reads back correctly.
   dlog(`${logPrefix} Setting configure preset: ${CONFIGURE_PRESET_NAME}`);
-  const presetDeadline = Date.now() + PRESET_APPLY_TIMEOUT_MS;
-  for (;;) {
-    await vscode.commands.executeCommand(
-      'cmake.setConfigurePreset',
-      CONFIGURE_PRESET_NAME
-    );
-    const activePreset = await vscode.commands.executeCommand<string>(
-      'cmake.activeConfigurePresetName'
-    );
-    if (activePreset === CONFIGURE_PRESET_NAME) {
-      break;
-    }
-    if (Date.now() >= presetDeadline) {
-      throw new Error(
-        `${logPrefix} CMake Tools did not apply configure preset ` +
-          `'${CONFIGURE_PRESET_NAME}' within ${PRESET_APPLY_TIMEOUT_MS}ms ` +
-          `(active preset: '${activePreset}')`
-      );
-    }
-    dlog(
-      `${logPrefix} Configure preset not applied yet (active: '${activePreset}'), retrying...`
-    );
-    await delay(PRESET_APPLY_RETRY_DELAY_MS);
-  }
+  await setConfigurePresetWithRetry(CONFIGURE_PRESET_NAME, (msg) =>
+    dlog(`${logPrefix} ${msg}`)
+  );
   await waitForVSCodeIdle();
 
   dlog(`${logPrefix} Running cmake.configure...`);

--- a/qt-cpp/test/helper.mts
+++ b/qt-cpp/test/helper.mts
@@ -17,7 +17,8 @@ export {
   cmakeConfigForWorkspace,
   readCMakeCacheVar,
   prepareStandardCMakeArgs,
-  selectAndApplyKit
+  selectAndApplyKit,
+  setConfigurePresetWithRetry
 } from '../../qt-lib/test/helper.mjs';
 
 // ---------------------------------------------------------------------------

--- a/qt-cpp/test/suite/presets.test.mts
+++ b/qt-cpp/test/suite/presets.test.mts
@@ -22,7 +22,8 @@ import {
   getWorkspaceFolderOrThrow,
   cleanBuildDir,
   readCMakeCacheVar,
-  cmakeConfigForWorkspace
+  cmakeConfigForWorkspace,
+  setConfigurePresetWithRetry
 } from '../helper.mts';
 
 // Test timing constants
@@ -99,10 +100,7 @@ describe('presets: CMake Presets integration', function () {
 
     // Set the configure preset using the correct CMake Tools command
     console.log('Setting configure preset: qt-debug');
-    await vscode.commands.executeCommand(
-      'cmake.setConfigurePreset',
-      'qt-debug'
-    );
+    await setConfigurePresetWithRetry('qt-debug', (msg) => console.log(msg));
     await waitForVSCodeIdle();
 
     console.log('Running cmake.configure with presets...');

--- a/qt-lib/test/helper.mts
+++ b/qt-lib/test/helper.mts
@@ -292,6 +292,54 @@ export function cmakeConfigForWorkspace(ws: vscode.WorkspaceFolder) {
   return new CMakeConfigurator(ws);
 }
 
+const PRESET_APPLY_TIMEOUT_MS = 30_000; // Give up waiting for CMake Tools to apply the preset
+const PRESET_APPLY_RETRY_DELAY_MS = 500; // Pause between preset apply attempts
+
+/**
+ * Sets the CMake Tools configure preset and verifies it was applied.
+ *
+ * `cmake.setConfigurePreset` resolves the preset name against CMake Tools'
+ * in-memory presets model, which is only refreshed once its file watcher
+ * has reparsed a freshly written CMakePresets.json. If the reload has not
+ * happened yet (seen on macOS and Windows CI), the lookup fails and CMake
+ * Tools silently resets the selection to null instead of applying it — and
+ * a subsequent `cmake.configure` blocks forever on a preset quick pick
+ * nobody can answer. Retry until the active preset reads back correctly.
+ *
+ * @param presetName - Name of the configure preset to apply.
+ * @param log - Optional sink for retry diagnostics (e.g. a test's `dlog`).
+ */
+export async function setConfigurePresetWithRetry(
+  presetName: string,
+  log: (message: string) => void = () => {
+    /* silent by default */
+  }
+): Promise<void> {
+  const deadline = Date.now() + PRESET_APPLY_TIMEOUT_MS;
+  for (;;) {
+    await vscode.commands.executeCommand(
+      'cmake.setConfigurePreset',
+      presetName
+    );
+    const activePreset = await vscode.commands.executeCommand<string>(
+      'cmake.activeConfigurePresetName'
+    );
+    if (activePreset === presetName) {
+      break;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `CMake Tools did not apply configure preset '${presetName}' ` +
+          `within ${PRESET_APPLY_TIMEOUT_MS}ms (active preset: '${activePreset}')`
+      );
+    }
+    log(
+      `Configure preset not applied yet (active: '${activePreset}'), retrying...`
+    );
+    await delay(PRESET_APPLY_RETRY_DELAY_MS);
+  }
+}
+
 /**
  * Reads a specific variable value from a CMake build directory's `CMakeCache.txt` file.
  *

--- a/qt-qml/test/helper.mts
+++ b/qt-qml/test/helper.mts
@@ -18,7 +18,8 @@ export {
   readCMakeCacheVar,
   prepareStandardCMakeArgs,
   selectAndApplyKit,
-  CMakeConfigurator
+  CMakeConfigurator,
+  setConfigurePresetWithRetry
 } from '../../qt-lib/test/helper.mjs';
 
 /**

--- a/qt-qml/test/suite/qml-debug.test.mts
+++ b/qt-qml/test/suite/qml-debug.test.mts
@@ -17,7 +17,8 @@ import {
   cleanBuildDir,
   cmakeConfigForWorkspace,
   waitForVSCodeIdle,
-  CMakeConfigurator
+  CMakeConfigurator,
+  setConfigurePresetWithRetry
 } from '../helper.mts';
 import {
   prepareQmlBreakpointsFromMarkers,
@@ -130,9 +131,8 @@ describe('QML Debugger integration', function () {
 
     // Set the configure preset
     console.log('[qml-debug] Setting configure preset: qml-debug');
-    await vscode.commands.executeCommand(
-      'cmake.setConfigurePreset',
-      'qml-debug'
+    await setConfigurePresetWithRetry('qml-debug', (msg) =>
+      console.log('[qml-debug]', msg)
     );
     await waitForVSCodeIdle();
 


### PR DESCRIPTION
Extract the retry from 2070f7eb into setConfigurePresetWithRetry() in
qt-lib/test/helper.mts and use it at all preset call sites. The qt-qml
qml-debug suite lacked the retry and hung on Windows CI when CMake Tools
had not yet reloaded the freshly written CMakePresets.json.
