### PR TITLE
Package: Disable extensions in untrusted workspaces

### DIFF
--- a/qt-core/package.json
+++ b/qt-core/package.json
@@ -36,6 +36,12 @@
     "onWebviewPanel:ViewTypeWelcomePage"
   ],
   "main": "./out/extension.js",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": false,
+      "description": "%qt-core.untrustedWorkspaces.description%"
+    }
+  },
   "contributes": {
     "configurationDefaults": {
       "workbench.editorAssociations": {

--- a/qt-core/package.nls.json
+++ b/qt-core/package.nls.json
@@ -1,4 +1,5 @@
 {
+  "qt-core.untrustedWorkspaces.description": "Qt Core runs Qt tools such as qmake/qtpaths and Qt Widgets Designer as external programs, using paths taken from workspace settings. It stays disabled until you trust this workspace.",
   "qt-core.command.documentationHomepage.title": "Documentation: Open homepage",
   "qt-core.command.documentationSearchManually.title": "Documentation: Search",
   "qt-core.command.documentationSearchForCurrentWord.title": "Documentation: Search for the current word",

--- a/qt-cpp/package.json
+++ b/qt-cpp/package.json
@@ -61,6 +61,12 @@
   ],
   "main": "./out/extension.js",
   "l10n": "./l10n",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": false,
+      "description": "%qt-cpp.untrustedWorkspaces.description%"
+    }
+  },
   "contributes": {
     "configuration": {
       "title": "Qt C++ Configuration",

--- a/qt-cpp/package.nls.json
+++ b/qt-cpp/package.nls.json
@@ -1,4 +1,5 @@
 {
+  "qt-cpp.untrustedWorkspaces.description": "Qt C++ configures and runs CMake and Qt build tooling for this project. It stays disabled until you trust this workspace.",
   "qt-cpp.command.scanForQtKits.title": "Scan for Qt kits",
   "qt-cpp.command.dummyregisterQt.title": "Dummy register Qt",
   "qt-cpp.debugger.cppdbg.snippet.label": "Qt: Debug with cppdbg",

--- a/qt-python/package.json
+++ b/qt-python/package.json
@@ -37,6 +37,12 @@
   ],
   "main": "./out/extension.js",
   "l10n": "./l10n",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": false,
+      "description": "%qt-python.untrustedWorkspaces.description%"
+    }
+  },
   "contributes": {
     "configuration": {
       "title": "Qt Python Configuration",

--- a/qt-python/package.nls.json
+++ b/qt-python/package.nls.json
@@ -1,4 +1,5 @@
 {
+  "qt-python.untrustedWorkspaces.description": "Qt Python runs Qt for Python build tooling for this project. It stays disabled until you trust this workspace.",
   "qt-python.command.installPySide6.title": "Install PySide6",
   "qt-python.command.createUvEnv.title": "Create virtual environment with uv",
   "qt-python.debug.launch.label": "Qt: PySide: Launch",

--- a/qt-qml/package.json
+++ b/qt-qml/package.json
@@ -36,6 +36,12 @@
   ],
   "main": "./out/extension.js",
   "l10n": "./l10n",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": false,
+      "description": "%qt-qml.untrustedWorkspaces.description%"
+    }
+  },
   "contributes": {
     "commands": [
       {

--- a/qt-qml/package.nls.json
+++ b/qt-qml/package.nls.json
@@ -1,4 +1,5 @@
 {
+  "qt-qml.untrustedWorkspaces.description": "Qt QML runs QML tooling such as the QML Language Server and profiler as external programs, using paths taken from workspace settings. It stays disabled until you trust this workspace.",
   "qt-qml.command.restartQmlls.title": "Restart QML language server",
   "qt-qml.command.checkQmllsUpdate.title": "Check for QML language server update",
   "qt-qml.command.downloadQmlls.title": "Download the most recent QML language server",


### PR DESCRIPTION
Set capabilities.untrustedWorkspaces.supported to false in the qt-core,
qt-cpp, qt-qml and qt-python manifests, with a localized Workspace Trust
description. The extensions stay disabled until the user grants trust.

Task-number: https://qt-project.atlassian.net/browse/VSCODEEXT-328
