### PR TITLE
qt-qml: Verify qmlls download against its SHA256 digest

### DIFF
--- a/qt-qml/src/installer.mts
+++ b/qt-qml/src/installer.mts
@@ -20,6 +20,7 @@ import {
 } from 'qt-lib';
 import * as unzipper from '@/unzipper.js';
 import * as downloader from '@/downloader.js';
+import { sha256OfFile, digestMatches } from '@/integrity.js';
 import { setDoNotAskForDownloadingQmlls } from '@/qmlls.mjs';
 import {
   VersionedInstallations,
@@ -168,6 +169,9 @@ interface Asset {
   size: number;
   browser_download_url: string;
   created_at: string;
+  // SHA256 of the asset ("sha256:<hex>"), shipped by the release manifest and
+  // used to verify the download before it is unzipped, chmod'd, or run.
+  digest?: string;
 }
 
 export interface AssetWithTag extends Asset {
@@ -299,6 +303,22 @@ export async function install(asset: AssetWithTag) {
       // another instance installing the same version, theirs is used.
       const stagingDir = installations.createStagingDir();
       try {
+        // Integrity gate: verify the downloaded bytes against the SHA256 digest
+        // the release manifest ships, before we unzip, chmod, or run anything.
+        // Fail closed if the digest is missing or does not match.
+        if (!asset.digest) {
+          throw new Error(
+            `Refusing to install ${asset.name}: the release manifest did not provide a SHA256 digest to verify the download.`
+          );
+        }
+        const actualDigest = await sha256OfFile(tmpPath);
+        if (!digestMatches(asset.digest, actualDigest)) {
+          throw new Error(
+            `Integrity check failed for ${asset.name}: the download does not match the expected SHA256 digest.`
+          );
+        }
+        logger.info(`Integrity check passed for: ${asset.name}`);
+
         logger.info(`Unzipping to: ${stagingDir}`);
         await unzipWithProgress(tmpPath, stagingDir);
         logger.info(`Unzipping finished: ${stagingDir}`);

--- a/qt-qml/src/integrity.ts
+++ b/qt-qml/src/integrity.ts
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as fs from 'fs';
+import { createHash } from 'crypto';
+
+// SHA256 of a file as a lowercase hex string, computed by streaming so large
+// downloads are not loaded into memory at once.
+export async function sha256OfFile(filePath: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const hash = createHash('sha256');
+    const stream = fs.createReadStream(filePath);
+    stream.on('data', (chunk) => hash.update(chunk as Buffer));
+    stream.on('end', () => {
+      resolve(hash.digest('hex'));
+    });
+    stream.on('error', reject);
+  });
+}
+
+// Compare a manifest-supplied digest against an actual SHA256 hex string.
+// The expected value may be prefixed ("sha256:<hex>") or bare hex. Returns
+// false for any missing, malformed, or non-matching input so callers can fail
+// closed.
+export function digestMatches(
+  expected: string | undefined,
+  actualHex: string
+): boolean {
+  if (!expected) {
+    return false;
+  }
+  const want = expected
+    .replace(/^sha256:/i, '')
+    .trim()
+    .toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(want)) {
+    return false;
+  }
+  return want === actualHex.trim().toLowerCase();
+}

--- a/qt-qml/test/suite/integrity.test.mts
+++ b/qt-qml/test/suite/integrity.test.mts
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createHash } from 'crypto';
+
+import { digestMatches, sha256OfFile } from '@/integrity.js';
+
+const sha256 = (data: string) =>
+  createHash('sha256').update(Buffer.from(data)).digest('hex');
+
+suite('Download integrity (R3)', () => {
+  test('accepts a matching sha256:-prefixed digest', () => {
+    const hex = sha256('hello');
+    expect(digestMatches(`sha256:${hex}`, hex)).to.equal(true);
+  });
+
+  test('accepts a bare-hex digest case-insensitively', () => {
+    const hex = sha256('hello');
+    expect(digestMatches(hex.toUpperCase(), hex)).to.equal(true);
+  });
+
+  test('rejects a mismatched digest', () => {
+    expect(
+      digestMatches(`sha256:${sha256('hello')}`, sha256('hell0'))
+    ).to.equal(false);
+  });
+
+  test('fails closed on missing or malformed digests', () => {
+    const hex = sha256('x');
+    expect(digestMatches(undefined, hex)).to.equal(false);
+    expect(digestMatches('', hex)).to.equal(false);
+    expect(digestMatches('sha256:not-hex', hex)).to.equal(false);
+    expect(digestMatches('sha256:abc', hex)).to.equal(false); // too short
+  });
+
+  test('sha256OfFile matches the file contents hash', async () => {
+    const content = 'the quick brown fox';
+    const p = path.join(os.tmpdir(), `qmlls-integrity-${process.pid}.bin`);
+    fs.writeFileSync(p, Buffer.from(content));
+    try {
+      expect(await sha256OfFile(p)).to.equal(sha256(content));
+    } finally {
+      fs.rmSync(p, { force: true });
+    }
+  });
+});


### PR DESCRIPTION
Check the downloaded qmlls archive against the per-asset SHA256 digest the
release manifest already ships, before it is unzipped, chmod'd, or run. Fail
closed when the digest is missing or does not match, so a substituted binary
from a compromised mirror, a TLS proxy, or a poisoned manifest cannot be
installed.

Task-number: https://qt-project.atlassian.net/browse/VSCODEEXT-326
