### PR TITLE
qt-lib: qt-qml: Contain archive extraction to the target directory

### DIFF
--- a/qt-lib/src/index.ts
+++ b/qt-lib/src/index.ts
@@ -14,5 +14,6 @@ export * from './test-helper';
 export * from './test-constants';
 export * from './file-finder';
 export * from './qrc-parser';
+export * from './path-containment';
 export * from './qml-api';
 export * from './msvc';

--- a/qt-lib/src/path-containment.ts
+++ b/qt-lib/src/path-containment.ts
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Throw if `candidate` would escape `root` once the symlinks in its existing
+ * prefix are resolved, and otherwise return the resolved absolute path.
+ *
+ * `candidate` need not exist yet: an archive entry is validated before it is
+ * written, so the check realpaths the deepest ancestor that does exist. That
+ * defeats a symlink planted earlier in the same extraction which would redirect
+ * a later write outside `root`, as well as `..` traversal and absolute paths. A
+ * lexical `startsWith` check cannot see through such symlinks; realpath can.
+ *
+ * `root` must already exist on disk.
+ */
+export function assertInside(root: string, candidate: string): string {
+  const realRoot = fs.realpathSync(root);
+  const target = path.resolve(realRoot, candidate);
+
+  let existing = target;
+  while (!fs.existsSync(existing)) {
+    const parent = path.dirname(existing);
+    if (parent === existing) {
+      break;
+    }
+    existing = parent;
+  }
+  const realExisting = fs.realpathSync(existing);
+
+  const rel = path.relative(realRoot, realExisting);
+  if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
+    throw new Error(`Refusing path outside the extraction root: ${candidate}`);
+  }
+  return target;
+}

--- a/qt-qml/src/installer.mts
+++ b/qt-qml/src/installer.mts
@@ -16,7 +16,8 @@ import {
   IsWindows,
   IsMacOS,
   IsLinux,
-  IsArm64
+  IsArm64,
+  assertInside
 } from 'qt-lib';
 import * as unzipper from '@/unzipper.js';
 import * as downloader from '@/downloader.js';
@@ -458,6 +459,7 @@ async function unzipWithProgress(zipPath: string, destDir: string) {
     const unzipStreamProvider = (entry: unzipper.Entry) => {
       const name = entry.fileName;
       const dest = path.join(destDir, name);
+      assertInside(destDir, dest);
 
       fs.mkdirSync(path.dirname(dest), { recursive: true });
       progress.report({ message: name });

--- a/qt-qml/src/traceviewer/extractor.mts
+++ b/qt-qml/src/traceviewer/extractor.mts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import { Writable } from 'stream';
 
 import { IsWindows, assertInside } from 'qt-lib';
+import { ExtractionBudget } from '@/unzipper.js';
 import { DownloadResult } from './downloader.mts';
 import { InstalledRelease } from './installation-manager.mts';
 
@@ -69,6 +70,7 @@ export async function unzipV2(
   streamProvider: (entry: yauzl.Entry) => StreamProviderResult
 ) {
   return new Promise<void>((resolve, reject) => {
+    const budget = new ExtractionBudget();
     const callback = (error: Error | null, zipFile: yauzl.ZipFile) => {
       if (error) {
         reject(error);
@@ -77,6 +79,13 @@ export async function unzipV2(
 
       zipFile.readEntry();
       zipFile.on('entry', (entry: yauzl.Entry) => {
+        try {
+          budget.charge(entry);
+        } catch (err) {
+          reject(err as Error);
+          return;
+        }
+
         const unixAttrs = entry.externalFileAttributes >> 16;
         const isSymlink = (unixAttrs & UNIX_FILE_TYPE_MASK) === UNIX_SYMLINK;
 

--- a/qt-qml/src/traceviewer/extractor.mts
+++ b/qt-qml/src/traceviewer/extractor.mts
@@ -7,7 +7,7 @@ import * as yauzl from 'yauzl';
 import * as vscode from 'vscode';
 import { Writable } from 'stream';
 
-import { IsWindows } from 'qt-lib';
+import { IsWindows, assertInside } from 'qt-lib';
 import { DownloadResult } from './downloader.mts';
 import { InstalledRelease } from './installation-manager.mts';
 
@@ -26,6 +26,7 @@ export async function extractWithProgress(
     const unzipStreamProvider = (entry: Entry) => {
       const name = entry.fileName;
       const fullPath = path.join(release.filesDir, name);
+      assertInside(release.filesDir, fullPath);
 
       if (entry.fileName.endsWith('/')) {
         fs.mkdirSync(fullPath, { recursive: true });
@@ -37,6 +38,7 @@ export async function extractWithProgress(
     };
 
     fs.rmSync(release.filesDir, { recursive: true, force: true });
+    fs.mkdirSync(release.filesDir, { recursive: true });
     await unzipV2(
       downloadResult.downloadedFilePath,
       release.filesDir,
@@ -57,6 +59,9 @@ type StreamProviderResult = {
 
 const UNIX_SYMLINK = 0o120000;
 const UNIX_FILE_TYPE_MASK = 0o170000;
+// A symlink target is a path; cap the bytes we accumulate for it so a crafted
+// archive cannot drive the extractor to OOM through the symlink-target read.
+const MaxSymlinkTargetBytes = 4096;
 
 export async function unzipV2(
   inputPath: string,
@@ -81,15 +86,42 @@ export async function unzipV2(
               reject(e);
               return;
             }
-            let target = '';
+            const chunks: Buffer[] = [];
+            let targetLength = 0;
+            let aborted = false;
             reader.on('data', (chunk: Buffer) => {
-              target += chunk.toString();
+              if (aborted) {
+                return;
+              }
+              targetLength += chunk.length;
+              if (targetLength > MaxSymlinkTargetBytes) {
+                aborted = true;
+                reader.destroy();
+                reject(
+                  new Error('Archive symlink target exceeds the maximum length')
+                );
+                return;
+              }
+              chunks.push(chunk);
             });
             reader.on('end', () => {
+              if (aborted) {
+                return;
+              }
               try {
+                const rawTarget = Buffer.concat(chunks).toString().trim();
                 const linkPath = path.join(baseDir, entry.fileName);
+                // The link's own location must stay inside the extraction root,
+                // and so must whatever the link resolves to, or a later entry
+                // could write through it to an arbitrary location.
+                assertInside(baseDir, linkPath);
+                const resolvedTarget = path.resolve(
+                  path.dirname(linkPath),
+                  rawTarget
+                );
+                assertInside(baseDir, resolvedTarget);
                 fs.mkdirSync(path.dirname(linkPath), { recursive: true });
-                fs.symlinkSync(target.trim(), linkPath);
+                fs.symlinkSync(rawTarget, linkPath);
               } catch (err) {
                 reject(err as Error);
                 return;
@@ -101,7 +133,13 @@ export async function unzipV2(
           return;
         }
 
-        const provider = streamProvider(entry);
+        let provider: StreamProviderResult;
+        try {
+          provider = streamProvider(entry);
+        } catch (err) {
+          reject(err as Error);
+          return;
+        }
         if (provider === null) {
           zipFile.readEntry();
           return;

--- a/qt-qml/src/traceviewer/runner.mts
+++ b/qt-qml/src/traceviewer/runner.mts
@@ -118,11 +118,8 @@ export class QmlTraceViewerRunner {
       }
     });
 
-    const out = await outPromise;
-    const err = await errPromise;
-    void err;
-
-    return out;
+    await outPromise;
+    await errPromise;
   }
 
   private _clearProcAndFire() {
@@ -235,31 +232,46 @@ async function parseJsonOutput(uri: vscode.Uri, text: string) {
 type Stream = NodeJS.ReadableStream;
 type Callback = ((line: string) => void) | undefined;
 
+// A single JSON-RPC line from the viewer is small. A runaway or compromised
+// viewer process could emit one endless line and grow the leftover buffer
+// without bound, so cap it and drop the oversized line instead of keeping it.
+const MaxLineBytes = 1024 * 1024; // 1 MiB
+
 async function streamToLines(stream: Stream | null, callback: Callback) {
   if (stream === null) {
     return;
   }
 
   let leftover = '';
-  const lines: string[] = [];
+  let discardingLongLine = false;
 
   for await (const chunk of stream) {
     const text = leftover + chunk.toString();
     const parts = text.split('\n');
     leftover = parts.pop() ?? '';
 
+    if (discardingLongLine) {
+      if (parts.length === 0) {
+        // Still inside the oversized line; keep dropping it.
+        leftover = '';
+        continue;
+      }
+      // The first newline ends the oversized line; drop what belongs to it.
+      parts.shift();
+      discardingLongLine = false;
+    }
+
     for (const line of parts) {
-      const trimmed = line.trim();
-      lines.push(trimmed);
-      callback?.(trimmed);
+      callback?.(line.trim());
+    }
+
+    if (leftover.length > MaxLineBytes) {
+      leftover = '';
+      discardingLongLine = true;
     }
   }
 
   if (leftover.trim()) {
-    const trimmed = leftover.trim();
-    lines.push(trimmed);
-    callback?.(trimmed);
+    callback?.(leftover.trim());
   }
-
-  return lines;
 }

--- a/qt-qml/src/unzipper.ts
+++ b/qt-qml/src/unzipper.ts
@@ -6,6 +6,50 @@ import { Writable } from 'stream';
 
 export type Entry = yauzl.Entry;
 
+// Bounds for what a single archive may extract. A crafted archive (zip bomb)
+// can declare millions of entries or expand a few compressed bytes into
+// gigabytes and exhaust disk or memory before any path check runs, so breach
+// aborts the extraction. The caps are generous multiples of the real qmlls
+// and trace viewer packages. yauzl verifies the declared sizes against the
+// actual inflated bytes (validateEntrySizes defaults to true), so a central
+// directory that understates a size is caught at stream time.
+const MaxEntryCount = 10000;
+const MaxTotalUncompressedBytes = 2 * 1024 * 1024 * 1024; // 2 GiB
+const MaxCompressionRatio = 100;
+// Fixed deflate overhead makes tiny entries report extreme ratios, so only
+// entries large enough to matter are ratio checked.
+const RatioCheckMinBytes = 1024 * 1024; // 1 MiB
+
+export class ExtractionBudget {
+  private _entryCount = 0;
+  private _totalUncompressedBytes = 0;
+
+  charge(entry: yauzl.Entry) {
+    this._entryCount++;
+    if (this._entryCount > MaxEntryCount) {
+      throw new Error(
+        `Archive contains more than ${MaxEntryCount.toString()} entries`
+      );
+    }
+
+    this._totalUncompressedBytes += entry.uncompressedSize;
+    if (this._totalUncompressedBytes > MaxTotalUncompressedBytes) {
+      throw new Error(
+        `Archive expands beyond ${MaxTotalUncompressedBytes.toString()} bytes`
+      );
+    }
+
+    if (
+      entry.uncompressedSize > RatioCheckMinBytes &&
+      entry.uncompressedSize > entry.compressedSize * MaxCompressionRatio
+    ) {
+      throw new Error(
+        `Archive entry has a suspicious compression ratio: ${entry.fileName}`
+      );
+    }
+  }
+}
+
 export async function unzip(
   inputPath: string,
   streamProvider: (entry: yauzl.Entry) => Writable | null
@@ -20,6 +64,7 @@ export async function unzip(
     let pendingWrites = 0;
     let allEntriesRead = false;
     let settled = false;
+    const budget = new ExtractionBudget();
 
     const fail = (error: Error) => {
       if (settled) {
@@ -46,6 +91,7 @@ export async function unzip(
       zipFile.on('entry', (entry: yauzl.Entry) => {
         let writer: Writable | null;
         try {
+          budget.charge(entry);
           writer = streamProvider(entry);
         } catch (err) {
           fail(err as Error);

--- a/qt-qml/src/unzipper.ts
+++ b/qt-qml/src/unzipper.ts
@@ -44,7 +44,13 @@ export async function unzip(
 
       zipFile.readEntry();
       zipFile.on('entry', (entry: yauzl.Entry) => {
-        const writer = streamProvider(entry);
+        let writer: Writable | null;
+        try {
+          writer = streamProvider(entry);
+        } catch (err) {
+          fail(err as Error);
+          return;
+        }
         if (writer === null) {
           zipFile.readEntry();
           return;

--- a/qt-qml/test/suite/path-containment.test.mts
+++ b/qt-qml/test/suite/path-containment.test.mts
@@ -1,0 +1,62 @@
+// Copyright (C) 2026 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { assertInside } from 'qt-lib';
+
+suite('Archive extraction containment (R4)', () => {
+  let root: string;
+  let outside: string;
+
+  setup(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'extract-root-'));
+    outside = fs.mkdtempSync(path.join(os.tmpdir(), 'outside-'));
+  });
+
+  teardown(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+
+  test('allows a not-yet-existing path inside the root', () => {
+    expect(() =>
+      assertInside(root, path.join(root, 'sub/file.txt'))
+    ).to.not.throw();
+  });
+
+  test('rejects an absolute path outside the root', () => {
+    expect(() => assertInside(root, path.join(outside, 'x'))).to.throw();
+  });
+
+  test('rejects .. traversal out of the root', () => {
+    expect(() => assertInside(root, path.join(root, '../escape'))).to.throw();
+  });
+
+  test('rejects a write through a planted symlink that escapes the root', () => {
+    // The PL-002 primitive: a symlink inside the root pointing outside, then a
+    // write through it. Realpath sees through the link; a lexical check would not.
+    fs.symlinkSync(outside, path.join(root, 'evil'));
+    expect(() =>
+      assertInside(root, path.join(root, 'evil', 'payload.plist'))
+    ).to.throw();
+  });
+
+  test('rejects a symlink target that resolves outside the root', () => {
+    const linkPath = path.join(root, 'link');
+    const resolvedTarget = path.resolve(
+      path.dirname(linkPath),
+      '../../../../etc'
+    );
+    expect(() => assertInside(root, resolvedTarget)).to.throw();
+  });
+
+  test('allows a symlink target that stays inside the root', () => {
+    const linkPath = path.join(root, 'link');
+    const resolvedTarget = path.resolve(path.dirname(linkPath), 'sub/inside');
+    expect(() => assertInside(root, resolvedTarget)).to.not.throw();
+  });
+});


### PR DESCRIPTION
Add a shared assertInside() helper that resolves symlinks with realpath and
rejects any archive entry whose real destination falls outside the extraction
root, then apply it in both unzip stacks: the qmlls installer and the trace
viewer extractor.

The trace viewer extractor previously created a symlink straight from archive
bytes, so a crafted archive could plant a symlink pointing outside the root and
then write through it into a persistence location. Validate both the symlink
location and its resolved target before creating the link, guard every regular
file destination before opening it, and cap the symlink target read so a
crafted target cannot exhaust memory.

Task-number: https://qt-project.atlassian.net/browse/VSCODEEXT-324
