### PR TITLE
qt-qml: Validate every download redirect hop

### DIFF
--- a/qt-qml/src/downloader.ts
+++ b/qt-qml/src/downloader.ts
@@ -6,13 +6,34 @@ import * as fs from 'fs';
 import * as http from 'http';
 import * as https from 'https';
 
+// The download URL comes from a remote release manifest and every redirect
+// hop comes from a remote server, so each of them is untrusted input. Pin
+// the whole chain to https and to hosts Qt publishes releases through, or a
+// tampered manifest or redirect could send the request anywhere.
+const AllowedDownloadHosts = ['github.com', 'githubusercontent.com', 'qt.io'];
+
+export function checkedDownloadUrl(url: string | URL, base?: URL): URL {
+  const parsed = new URL(url, base);
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`Refusing non-https download URL: ${parsed.toString()}`);
+  }
+  const host = parsed.hostname;
+  const allowed = AllowedDownloadHosts.some(
+    (domain) => host === domain || host.endsWith(`.${domain}`)
+  );
+  if (!allowed) {
+    throw new Error(`Refusing download from unexpected host: ${host}`);
+  }
+  return parsed;
+}
+
 export async function download(
   url: string,
   destPath: string,
   token?: vscode.CancellationToken,
   reportCallback?: (progress: number, max: number) => void
 ) {
-  let downloadUrl = url;
+  let downloadUrl = checkedDownloadUrl(url);
   const MaxRedirects = 10;
   const controller = new AbortController();
   token?.onCancellationRequested(() => {
@@ -20,22 +41,21 @@ export async function download(
   });
 
   for (let i = 0; i < MaxRedirects; ++i) {
-    if (!downloadUrl) {
-      throw Error('Invalid download URL');
-    }
-
-    const res = await getHttps(downloadUrl, controller);
+    const res = await getHttps(downloadUrl.toString(), controller);
     if (!res.statusCode) {
       throw Error(`Invalid status code ${res.statusCode?.toString() ?? ''}`);
     }
 
     if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-      downloadUrl = res.headers.location;
+      res.resume();
+      downloadUrl = checkedDownloadUrl(res.headers.location, downloadUrl);
       continue;
     }
 
     return downloadOctetStream(res, destPath, token, reportCallback);
   }
+
+  throw new Error('Download exceeded the maximum number of redirects');
 }
 
 async function downloadOctetStream(

--- a/qt-qml/src/traceviewer/downloader.mts
+++ b/qt-qml/src/traceviewer/downloader.mts
@@ -102,8 +102,38 @@ function createDownloadFilePath() {
   return path.join(dir, fileName);
 }
 
+// download.qt.io redirects file downloads to a changing set of third-party
+// mirrors, so the hosts cannot be pinned here. Follow redirects manually
+// instead of letting fetch do it, so every hop can be forced to stay on
+// https and a redirect cannot downgrade the transfer to cleartext.
+const MaxRedirects = 10;
+
+async function fetchHttpsOnly(url: string, init?: RequestInit) {
+  let current = new URL(url);
+  for (let i = 0; i < MaxRedirects; ++i) {
+    if (current.protocol !== 'https:') {
+      throw new Error(`Refusing non-https download URL: ${current.toString()}`);
+    }
+
+    const res = await fetch(current, { ...init, redirect: 'manual' });
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get('location');
+      if (!location) {
+        throw new Error(`Redirect without a location: ${String(res.status)}`);
+      }
+      await res.body?.cancel();
+      current = new URL(location, current);
+      continue;
+    }
+
+    return res;
+  }
+
+  throw new Error('Download exceeded the maximum number of redirects');
+}
+
 async function fetchAndCheck(url: string, init?: RequestInit) {
-  const res = await fetch(url, init);
+  const res = await fetchHttpsOnly(url, init);
   if (!res.ok) {
     throw new Error(`Invalid status code: ${res.statusText}`);
   }


### PR DESCRIPTION
The qmlls downloader followed up to 10 redirects to any host and any
scheme, and the URL it starts from comes from the remote release
manifest. Validate the initial URL and every redirect target against an
allowlist of Qt release hosts (github.com, githubusercontent.com,
qt.io) and require https on every hop. Resolve relative locations
against the current URL and fail when the redirect budget is exhausted
instead of silently returning without a download.

The trace viewer download cannot pin hosts because download.qt.io
redirects to a changing set of third party mirrors, so follow its
redirects manually with a hop cap and require https on every hop so a
redirect cannot downgrade the transfer to cleartext.

Task-number: https://qt-project.atlassian.net/browse/VSCODEEXT-326
