### PR TITLE
qt-core: qt-cpp: qt-qml: Handle async webview and parser failures

### DIFF
--- a/qt-core/src/webview/courses/dispatcher.ts
+++ b/qt-core/src/webview/courses/dispatcher.ts
@@ -36,7 +36,7 @@ export class CoursesDispatcher {
     this._disposables = [
       this._comm,
       this._comm.onDidReceiveMessage((m) => {
-        this.dispatch(m);
+        void this.dispatch(m);
       })
     ];
   }
@@ -46,7 +46,7 @@ export class CoursesDispatcher {
     this._disposables.length = 0;
   }
 
-  public dispatch(cmd: unknown) {
+  public async dispatch(cmd: unknown) {
     if (!IsCommand(cmd)) {
       return;
     }
@@ -58,7 +58,7 @@ export class CoursesDispatcher {
     }
 
     try {
-      void handler(cmd);
+      await handler(cmd);
     } catch (e) {
       logger.error(`Cannot handle command '${String(cmd.id)}': ${String(e)}`);
     }

--- a/qt-core/src/webview/ex-browser/dispatcher.ts
+++ b/qt-core/src/webview/ex-browser/dispatcher.ts
@@ -71,7 +71,7 @@ export class ExBrowserDispatcher {
     this._disposables = [
       this._comm,
       this._comm.onDidReceiveMessage((m) => {
-        this.dispatch(m);
+        void this.dispatch(m);
       })
     ];
   }
@@ -83,7 +83,7 @@ export class ExBrowserDispatcher {
     this._disposables.length = 0;
   }
 
-  public dispatch(cmd: unknown) {
+  public async dispatch(cmd: unknown) {
     if (!IsCommand(cmd)) {
       return;
     }
@@ -95,7 +95,7 @@ export class ExBrowserDispatcher {
     }
 
     try {
-      void handler(cmd);
+      await handler(cmd);
     } catch (e) {
       logger.error(`Cannot handle command '${String(cmd.id)}': ${String(e)}`);
     }

--- a/qt-core/src/webview/new-item/dispatcher.ts
+++ b/qt-core/src/webview/new-item/dispatcher.ts
@@ -65,7 +65,7 @@ export class NewItemDispatcher {
     this._context = context;
   }
 
-  public dispatch(cmd: unknown) {
+  public async dispatch(cmd: unknown) {
     if (!this._panel || !IsCommand(cmd)) {
       return;
     }
@@ -77,7 +77,7 @@ export class NewItemDispatcher {
     }
 
     try {
-      void handler(cmd);
+      await handler(cmd);
     } catch (e) {
       logger.error(
         `Error while handling command '${String(cmd.id)}': ${String(e)}`

--- a/qt-core/src/webview/new-item/panel.ts
+++ b/qt-core/src/webview/new-item/panel.ts
@@ -68,7 +68,7 @@ export class NewItemPanel {
       panel.onDidDispose(this.dispose.bind(this)),
       this._comm,
       this._comm.onDidReceiveMessage((m) => {
-        this._dispatcher.dispatch(m);
+        void this._dispatcher.dispatch(m);
       })
     ];
   }

--- a/qt-core/src/webview/welcome/dispatcher.ts
+++ b/qt-core/src/webview/welcome/dispatcher.ts
@@ -38,7 +38,7 @@ export class WelcomePageDispatcher {
     this._disposables = [
       this._comm,
       this._comm.onDidReceiveMessage((m) => {
-        this.dispatch(m);
+        void this.dispatch(m);
       })
     ];
   }
@@ -48,7 +48,7 @@ export class WelcomePageDispatcher {
     this._disposables.length = 0;
   }
 
-  public dispatch(cmd: unknown) {
+  public async dispatch(cmd: unknown) {
     if (!IsCommand(cmd)) {
       return;
     }
@@ -60,7 +60,7 @@ export class WelcomePageDispatcher {
     }
 
     try {
-      void handler(cmd);
+      await handler(cmd);
     } catch (e) {
       logger.error(`Cannot handle command '${String(cmd.id)}': ${String(e)}`);
     }

--- a/qt-cpp/src/kit-manager.ts
+++ b/qt-cpp/src/kit-manager.ts
@@ -499,9 +499,14 @@ export class KitManager {
       return undefined;
     }
     const cmakeKitsFileContent = await fs.readFile(cmakeKitsFile, 'utf8');
-    let currentKits: Kit[] = [];
-    currentKits = JSON.parse(cmakeKitsFileContent) as Kit[];
-    return currentKits;
+    try {
+      return JSON.parse(cmakeKitsFileContent) as Kit[];
+    } catch (error) {
+      const fileName = path.basename(cmakeKitsFile);
+      const message = isError(error) ? error.message : String(error);
+      logger.error(`Malformed JSON in ${fileName}:`, message);
+      return undefined;
+    }
   }
 
   private static async loadCMakeKitsFileJSON(cmakeKitsFile: string) {

--- a/qt-qml/src/traceviewer/runner.mts
+++ b/qt-qml/src/traceviewer/runner.mts
@@ -30,7 +30,9 @@ export class QmlTraceViewerRunner {
     };
     this._onStdout = (l) => {
       logger.text(' ' + l).info();
-      void parseJsonOutput(this._uri, l);
+      parseJsonOutput(this._uri, l).catch((e: unknown) => {
+        logger.text(`Cannot handle viewer output: ${String(e)}`).error();
+      });
     };
   }
 
@@ -175,13 +177,23 @@ function asTrimmedString(value: unknown): string {
 }
 
 async function parseJsonOutput(uri: vscode.Uri, text: string) {
-  const obj = JSON.parse(text) as Record<string, unknown>;
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    // Ordinary diagnostic output, not a JSON-RPC message. It is already
+    // logged by the caller, so it is not an error here.
+    return;
+  }
   const version = asTrimmedString(obj.jsonrpc);
   const method = asTrimmedString(obj.method).toLowerCase();
   if (version !== '2.0' || method.length === 0) {
-    throw new Error(
-      `Invalid JSON-RPC: version = ${version}, method = ${method}`
-    );
+    logger
+      .text('Ignoring non JSON-RPC output')
+      .data('version', version)
+      .data('method', method)
+      .warn();
+    return;
   }
 
   if (method === 'traceeventselected') {


### PR DESCRIPTION
The four webview dispatchers ran async command handlers as void inside
a synchronous try/catch, so a rejected handler escaped the catch and
became an unhandled rejection instead of a logged error. Await the
handlers, as the qrc-editor controller already does.

Wrap the trace viewer stdout JSON.parse so ordinary diagnostic lines
are ignored instead of throwing, warn on non JSON-RPC objects instead
of throwing, and surface failures of the async continuation at the
call site. Guard the cmake kits file JSON.parse locally so a malformed
file logs and returns undefined regardless of the caller.

Fixes: [VSCODEEXT-335](https://qt-project.atlassian.net/browse/VSCODEEXT-335)
