### PR TITLE
qt-lib: qt-core: qt-qml: Contain qrc file paths

### DIFF
--- a/qt-core/src/webview/qrc-editor/controller.ts
+++ b/qt-core/src/webview/qrc-editor/controller.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import { createLogger } from 'qt-lib';
+import { createLogger, isInsideReal } from 'qt-lib';
 import { WebviewChannel } from '@/webview/channel';
 import {
   Command,
@@ -88,6 +88,7 @@ export class QrcEditorController {
       logger.error(
         `Error while handling command '${String(cmd.id)}': ${String(e)}`
       );
+      this._comm.postErrorReply(cmd, String(e));
     }
   };
 
@@ -103,11 +104,16 @@ export class QrcEditorController {
       return;
     }
 
-    const paths = await extractOrAskAbsPaths(cmd.payload, node.qrcUri);
+    // Contain before walking: the paths are webview supplied, so an
+    // out-of-tree path must not be traversed at all, and symlinks are
+    // resolved so <qrcDir>/link cannot smuggle an outside tree in.
+    const paths = (await extractOrAskAbsPaths(cmd.payload, node.qrcUri)).filter(
+      (p) => isInsideReal(node.qrcDir, p)
+    );
     const fileIndexes = (
       await Promise.all(
         paths.map(async (p) =>
-          collectAllFiles(p).then((found) => node.addFiles(found))
+          collectAllFiles(p, node.qrcDir).then((found) => node.addFiles(found))
         )
       )
     ).flat();
@@ -340,26 +346,81 @@ function toInteger(value: unknown, defaultValue = 0): number {
   return safe;
 }
 
-async function collectAllFiles(dir: string) {
-  const s = await fs.stat(dir);
+const MaxWalkDepth = 32;
+const MaxWalkEntries = 10000;
+
+// Bounded, symlink aware replacement for the previous unbounded walk,
+// where a symlink cycle or a huge tree hung the editor thread before any
+// containment ran. A directory is only descended when its realpath stays
+// inside `root` and was not visited yet, so every plain file it yields is
+// provably contained; symlinked files are kept only when their target
+// resolves inside `root`. Breaching the depth or entry budget throws
+// instead of returning a partial result.
+async function collectAllFiles(entry: string, root: string) {
+  const s = await fs.stat(entry);
   if (s.isFile()) {
-    return [dir];
+    return isInsideReal(root, entry) ? [entry] : [];
   }
 
-  let found: string[] = [];
-  const list = await fs.readdir(dir);
+  const found: string[] = [];
+  const visited = new Set<string>();
 
-  for (const file of list) {
-    const filePath = path.join(dir, file);
-    const stat = await fs.stat(filePath);
-
-    if (stat.isDirectory()) {
-      found = found.concat(await collectAllFiles(filePath));
-    } else {
-      found.push(filePath);
+  const push = (filePath: string) => {
+    if (found.length >= MaxWalkEntries) {
+      throw new Error(
+        `More than ${MaxWalkEntries.toString()} files under: ${entry}`
+      );
     }
-  }
+    found.push(filePath);
+  };
 
+  const walk = async (dir: string, depth: number) => {
+    if (depth > MaxWalkDepth) {
+      throw new Error(
+        `Directory tree deeper than ${MaxWalkDepth.toString()}: ${dir}`
+      );
+    }
+
+    let real: string;
+    try {
+      real = await fs.realpath(dir);
+    } catch {
+      return;
+    }
+    if (visited.has(real) || !isInsideReal(root, real)) {
+      return;
+    }
+    visited.add(real);
+
+    for (const dirent of await fs.readdir(dir, { withFileTypes: true })) {
+      const filePath = path.join(dir, dirent.name);
+      // Some filesystems do not report dirent types; fall back to lstat.
+      const type =
+        dirent.isFile() || dirent.isDirectory() || dirent.isSymbolicLink()
+          ? dirent
+          : await fs.lstat(filePath);
+
+      if (type.isDirectory()) {
+        await walk(filePath, depth + 1);
+      } else if (type.isFile()) {
+        push(filePath);
+      } else if (type.isSymbolicLink()) {
+        let target;
+        try {
+          target = await fs.stat(filePath);
+        } catch {
+          continue;
+        }
+        if (target.isDirectory()) {
+          await walk(filePath, depth + 1);
+        } else if (target.isFile() && isInsideReal(root, filePath)) {
+          push(filePath);
+        }
+      }
+    }
+  };
+
+  await walk(entry, 0);
   return found;
 }
 

--- a/qt-core/src/webview/qrc-editor/node.ts
+++ b/qt-core/src/webview/qrc-editor/node.ts
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
+import { isInsideReal } from 'qt-lib';
 import { EXTENSION_ID } from '@/constants';
 import {
   RccTag,
@@ -59,7 +60,10 @@ export class QrcNode {
     const added: FileTag[] = [];
 
     absFilePaths
-      .filter((p) => p.startsWith(this.qrcDir))
+      // Realpath containment, not a prefix check: siblings like
+      // <qrcDir>-evil and symlinks resolving outside the qrc directory
+      // must not become entries.
+      .filter((p) => isInsideReal(this.qrcDir, p))
       .forEach((p) => {
         const text = normalizeFilePath(this.qrcDir, p);
         if (!existingPaths.includes(text)) {
@@ -173,7 +177,7 @@ export class QrcNode {
     this.qrcDir = path.dirname(doc.uri.fsPath);
     this.qrcUri = doc.uri;
     this.fileUri = this.file
-      ? vscode.Uri.file(path.join(this.qrcDir, this.file.text))
+      ? checkedFileUri(doc.uri, this.qrcDir, this.file.text)
       : undefined;
   }
 
@@ -215,6 +219,18 @@ export class QrcNode {
 function normalizeFilePath(qrcDir: string, absPath: string) {
   const rel = path.relative(qrcDir, absPath);
   return rel.replace(/\\/g, '/');
+}
+
+// A `<file>` entry from the parsed document is untrusted text; it must not
+// map to a file outside the workspace folder (or, without one, the qrc
+// directory), or the thumbnail and open/reveal actions would read through
+// it. Must not throw: this runs in the QrcNode constructor and a throw
+// would block every command on the node, including removing the entry.
+function checkedFileUri(qrcUri: vscode.Uri, qrcDir: string, text: string) {
+  const root =
+    vscode.workspace.getWorkspaceFolder(qrcUri)?.uri.fsPath ?? qrcDir;
+  const joined = path.join(qrcDir, text);
+  return isInsideReal(root, joined) ? vscode.Uri.file(joined) : undefined;
 }
 
 function insertAfterOrPush<T>(array: T[], index: number, item: T): number {

--- a/qt-lib/src/file-finder.ts
+++ b/qt-lib/src/file-finder.ts
@@ -4,7 +4,10 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 
+import { createLogger } from './logger';
 import { QRCParser } from './qrc-parser';
+
+const logger = createLogger('file-finder');
 
 export class FileFinder {
   private readonly _qrcParser: QRCParser;
@@ -46,9 +49,21 @@ export class FileFinder {
       const additionalQrcFiles = await vscode.workspace.findFiles(pattern);
       allQrcFiles.push(...additionalQrcFiles);
     }
+    const extraRoots = [
+      ...(vscode.workspace.workspaceFolders?.map((f) => f.uri.fsPath) ?? []),
+      ...additionalFolders
+    ];
     // parse all qrc files asynchrounously
     const parsePromises = allQrcFiles.map((file) =>
-      this._qrcParser.parseQRCFile(file.fsPath)
+      this._qrcParser.parseQRCFile(file.fsPath, false, {
+        extraRoots,
+        onViolation: (entry, resolvedPath) => {
+          logger.warn(
+            `Dropping qrc entry outside the allowed roots: ${entry} -> ` +
+              `${resolvedPath} (${file.fsPath})`
+          );
+        }
+      })
     );
     const parsedQrcFiles = await Promise.all(parsePromises);
     this._cache.clear();

--- a/qt-lib/src/index.ts
+++ b/qt-lib/src/index.ts
@@ -14,5 +14,6 @@ export * from './test-helper';
 export * from './test-constants';
 export * from './file-finder';
 export * from './qrc-parser';
+export * from './path-containment';
 export * from './qml-api';
 export * from './msvc';

--- a/qt-lib/src/path-containment.ts
+++ b/qt-lib/src/path-containment.ts
@@ -31,8 +31,48 @@ export function assertInside(root: string, candidate: string): string {
   const realExisting = fs.realpathSync(existing);
 
   const rel = path.relative(realRoot, realExisting);
-  if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
-    throw new Error(`Refusing path outside the extraction root: ${candidate}`);
+  if (isEscapingRelation(rel)) {
+    throw new Error(`Refusing path outside ${root}: ${candidate}`);
   }
   return target;
+}
+
+/**
+ * Lexical containment check: true if `candidate` stays under `root` after
+ * path resolution, without touching the filesystem. A relative `candidate`
+ * is resolved against `root`, matching `assertInside`.
+ *
+ * Symlinks are NOT resolved, so this must not guard a filesystem read or
+ * write on its own; use `assertInside`/`isInsideReal` at such sinks. It is
+ * the right check when the root may not exist on disk, and unlike a bare
+ * `startsWith` it cannot be fooled by sibling prefixes (`/opt/vcpkg` vs
+ * `/opt/vcpkg-evil`).
+ */
+export function isInside(root: string, candidate: string): boolean {
+  const resolvedRoot = path.resolve(root);
+  const rel = path.relative(
+    resolvedRoot,
+    path.resolve(resolvedRoot, candidate)
+  );
+  return !isEscapingRelation(rel);
+}
+
+/**
+ * Boolean form of `assertInside`: true if `candidate` stays under `root`
+ * once symlinks in its existing prefix are resolved. Also returns false
+ * when `root` itself does not exist.
+ */
+export function isInsideReal(root: string, candidate: string): boolean {
+  try {
+    assertInside(root, candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isEscapingRelation(rel: string): boolean {
+  return (
+    rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)
+  );
 }

--- a/qt-lib/src/path-containment.ts
+++ b/qt-lib/src/path-containment.ts
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Throw if `candidate` would escape `root` once the symlinks in its existing
+ * prefix are resolved, and otherwise return the resolved absolute path.
+ *
+ * `candidate` need not exist yet: an archive entry is validated before it is
+ * written, so the check realpaths the deepest ancestor that does exist. That
+ * defeats a symlink planted earlier in the same extraction which would redirect
+ * a later write outside `root`, as well as `..` traversal and absolute paths. A
+ * lexical `startsWith` check cannot see through such symlinks; realpath can.
+ *
+ * `root` must already exist on disk.
+ */
+export function assertInside(root: string, candidate: string): string {
+  const realRoot = fs.realpathSync(root);
+  const target = path.resolve(realRoot, candidate);
+
+  let existing = target;
+  while (!fs.existsSync(existing)) {
+    const parent = path.dirname(existing);
+    if (parent === existing) {
+      break;
+    }
+    existing = parent;
+  }
+  const realExisting = fs.realpathSync(existing);
+
+  const rel = path.relative(realRoot, realExisting);
+  if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
+    throw new Error(`Refusing path outside the extraction root: ${candidate}`);
+  }
+  return target;
+}

--- a/qt-lib/src/qrc-parser.ts
+++ b/qt-lib/src/qrc-parser.ts
@@ -5,6 +5,14 @@ import { XMLParser } from 'fast-xml-parser';
 import * as fs from 'fs';
 import * as path from 'path';
 
+export interface QRCContainmentOptions {
+  // Roots besides the .qrc file's own directory that entries may resolve
+  // into, typically the workspace folders and the build directories.
+  extraRoots?: string[];
+  // Called for each entry dropped because it resolves outside every root.
+  onViolation?: (entry: string, resolvedPath: string) => void;
+}
+
 // Define the structure for the QRC XML
 interface QRCFile {
   '@_alias': string | undefined; // The alias for the file
@@ -34,11 +42,16 @@ export class QRCParser {
     });
   }
 
-  parseQRCFile(filePath: string, includeAllFiles = false) {
+  parseQRCFile(
+    filePath: string,
+    includeAllFiles = false,
+    options?: QRCContainmentOptions
+  ) {
     if (!fs.existsSync(filePath)) {
       throw new Error(`Cannot find file: ${filePath}`);
     }
-    const cacheKey = `${filePath}:${includeAllFiles ? 'all' : 'qml-js'}`;
+    const roots = (options?.extraRoots ?? []).join('|');
+    const cacheKey = `${filePath}:${includeAllFiles ? 'all' : 'qml-js'}:${roots}`;
     const cachedContent = this._cache.get(cacheKey);
     if (cachedContent) {
       return cachedContent;
@@ -47,7 +60,8 @@ export class QRCParser {
     const fileMapping = this.parseQRC(
       xmlContent,
       path.dirname(filePath),
-      includeAllFiles
+      includeAllFiles,
+      options
     );
     if (!fileMapping) {
       return undefined;
@@ -56,7 +70,12 @@ export class QRCParser {
     return fileMapping;
   }
 
-  parseQRC(xmlContent: string, qrcDir: string, includeAllFiles = false) {
+  parseQRC(
+    xmlContent: string,
+    qrcDir: string,
+    includeAllFiles = false,
+    options?: QRCContainmentOptions
+  ) {
     try {
       // Parse the XML content into the defined structure
       const jsonObj = this.parser.parse(xmlContent) as QRCParsed; // Type assertion to QRCParsed
@@ -73,6 +92,14 @@ export class QRCParser {
 
       // Initialize a Map to store file paths and corresponding aliases
       const resourceMap = new Map<string, string>();
+
+      // A crafted .qrc must not map resources onto files outside the
+      // project: entries may only resolve into the .qrc's own directory or
+      // one of the extra roots (workspace folders, build directories).
+      const isContained = createContainmentChecker([
+        qrcDir,
+        ...(options?.extraRoots ?? [])
+      ]);
 
       // Loop through each <qresource> and add its files to the map
       resourcesArray.forEach((resource) => {
@@ -96,9 +123,17 @@ export class QRCParser {
             return;
           }
 
+          const resolved = path.isAbsolute(text)
+            ? text
+            : path.join(qrcDir, text);
+          if (!isContained(resolved)) {
+            options?.onViolation?.(text, resolved);
+            return;
+          }
+
           resourceMap.set(
             path.join(prefix, file['@_alias'] ?? text).replace(/\\/g, '/'),
-            path.isAbsolute(text) ? text : path.join(qrcDir, text)
+            resolved
           );
         });
       });
@@ -108,4 +143,70 @@ export class QRCParser {
       throw new Error(`Cannot parse QRC file: ${error as string}`);
     }
   }
+}
+
+// Returns a containment check over the union of `roots`, resolving symlinks
+// like assertInside but amortized for many candidates: each root is
+// realpathed once and directory realpaths are memoized, since entries
+// cluster in few directories. A candidate that does not exist is resolved
+// through its deepest existing ancestor, so not-yet-built files inside a
+// root still pass. Roots that do not exist cannot contain anything.
+function createContainmentChecker(roots: string[]) {
+  const realRoots: string[] = [];
+  for (const root of roots) {
+    try {
+      realRoots.push(fs.realpathSync.native(root));
+    } catch {
+      // skip missing roots
+    }
+  }
+
+  const dirCache = new Map<string, string | undefined>();
+  const resolveDir = (dir: string): string | undefined => {
+    if (dirCache.has(dir)) {
+      return dirCache.get(dir);
+    }
+    let real: string | undefined;
+    try {
+      real = fs.realpathSync.native(dir);
+    } catch {
+      const parent = path.dirname(dir);
+      if (parent !== dir) {
+        const realParent = resolveDir(parent);
+        real =
+          realParent === undefined
+            ? undefined
+            : path.join(realParent, path.basename(dir));
+      }
+    }
+    dirCache.set(dir, real);
+    return real;
+  };
+
+  const inside = (rootReal: string, candidateReal: string) => {
+    const rel = path.relative(rootReal, candidateReal);
+    return !(
+      rel === '..' ||
+      rel.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(rel)
+    );
+  };
+
+  return (candidate: string): boolean => {
+    let real: string | undefined;
+    try {
+      real = fs.realpathSync.native(candidate);
+    } catch {
+      const realParent = resolveDir(path.dirname(candidate));
+      real =
+        realParent === undefined
+          ? undefined
+          : path.join(realParent, path.basename(candidate));
+    }
+    if (real === undefined) {
+      return false;
+    }
+    const resolved = real;
+    return realRoots.some((root) => inside(root, resolved));
+  };
 }

--- a/qt-lib/src/util.ts
+++ b/qt-lib/src/util.ts
@@ -9,6 +9,7 @@ import * as fsSync from 'fs';
 import * as async from 'async';
 
 import { QtInfo } from './core-api';
+import { isInside } from './path-containment';
 import { telemetry } from './telemetry';
 
 export const Home = userHome();
@@ -218,7 +219,7 @@ export function inVCPKGRoot(p: string) {
   if (!vcpkgRoot) {
     return false;
   }
-  return p.startsWith(vcpkgRoot);
+  return isInside(vcpkgRoot, p);
 }
 
 export function getVCPKGRoot() {

--- a/qt-qml/esbuild.mjs
+++ b/qt-qml/esbuild.mjs
@@ -15,6 +15,8 @@ await runEsbuild({
     './test/suite/extension.test.mts',
     './test/suite/command.test.mts',
     './test/suite/installer.test.mts',
+    './test/suite/path-containment.test.mts',
+    './test/suite/qrc-parser.test.mts',
     './test/runTest.qml-debug.mts',
     './test/runTestHelper.mts',
     './test/suite/index-qml-debug.mts',

--- a/qt-qml/src/installer.mts
+++ b/qt-qml/src/installer.mts
@@ -16,7 +16,8 @@ import {
   IsWindows,
   IsMacOS,
   IsLinux,
-  IsArm64
+  IsArm64,
+  assertInside
 } from 'qt-lib';
 import * as unzipper from '@/unzipper.js';
 import * as downloader from '@/downloader.js';
@@ -458,6 +459,7 @@ async function unzipWithProgress(zipPath: string, destDir: string) {
     const unzipStreamProvider = (entry: unzipper.Entry) => {
       const name = entry.fileName;
       const dest = path.join(destDir, name);
+      assertInside(destDir, dest);
 
       fs.mkdirSync(path.dirname(dest), { recursive: true });
       progress.report({ message: name });

--- a/qt-qml/src/preview/qrc-resource-finder.mts
+++ b/qt-qml/src/preview/qrc-resource-finder.mts
@@ -122,9 +122,21 @@ export class QrcResourceFinder {
    */
   private processQrcFile(qrcFilePath: string) {
     try {
+      const extraRoots = [
+        ...(vscode.workspace.workspaceFolders?.map((f) => f.uri.fsPath) ?? []),
+        ...this._buildDirs
+      ];
       // Parse with includeAllFiles=true to get all resources (images, conf files, etc.)
       const fileMapping: Map<string, string> | undefined =
-        this._qrcParser.parseQRCFile(qrcFilePath, true);
+        this._qrcParser.parseQRCFile(qrcFilePath, true, {
+          extraRoots,
+          onViolation: (entry, resolvedPath) => {
+            logger.warn(
+              `Dropping qrc entry outside the allowed roots: ${entry} -> ` +
+                `${resolvedPath} (${qrcFilePath})`
+            );
+          }
+        });
       if (!fileMapping) {
         return;
       }

--- a/qt-qml/src/traceviewer/extractor.mts
+++ b/qt-qml/src/traceviewer/extractor.mts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import { Writable } from 'stream';
 
 import { IsWindows, assertInside } from 'qt-lib';
+import { ExtractionBudget } from '@/unzipper.js';
 import { DownloadResult } from './downloader.mts';
 import { InstalledRelease } from './installation-manager.mts';
 
@@ -69,6 +70,7 @@ export async function unzipV2(
   streamProvider: (entry: yauzl.Entry) => StreamProviderResult
 ) {
   return new Promise<void>((resolve, reject) => {
+    const budget = new ExtractionBudget();
     const callback = (error: Error | null, zipFile: yauzl.ZipFile) => {
       if (error) {
         reject(error);
@@ -77,6 +79,13 @@ export async function unzipV2(
 
       zipFile.readEntry();
       zipFile.on('entry', (entry: yauzl.Entry) => {
+        try {
+          budget.charge(entry);
+        } catch (err) {
+          reject(err as Error);
+          return;
+        }
+
         const unixAttrs = entry.externalFileAttributes >> 16;
         const isSymlink = (unixAttrs & UNIX_FILE_TYPE_MASK) === UNIX_SYMLINK;
 

--- a/qt-qml/src/traceviewer/extractor.mts
+++ b/qt-qml/src/traceviewer/extractor.mts
@@ -7,7 +7,7 @@ import * as yauzl from 'yauzl';
 import * as vscode from 'vscode';
 import { Writable } from 'stream';
 
-import { IsWindows } from 'qt-lib';
+import { IsWindows, assertInside } from 'qt-lib';
 import { DownloadResult } from './downloader.mts';
 import { InstalledRelease } from './installation-manager.mts';
 
@@ -26,6 +26,7 @@ export async function extractWithProgress(
     const unzipStreamProvider = (entry: Entry) => {
       const name = entry.fileName;
       const fullPath = path.join(release.filesDir, name);
+      assertInside(release.filesDir, fullPath);
 
       if (entry.fileName.endsWith('/')) {
         fs.mkdirSync(fullPath, { recursive: true });
@@ -37,6 +38,7 @@ export async function extractWithProgress(
     };
 
     fs.rmSync(release.filesDir, { recursive: true, force: true });
+    fs.mkdirSync(release.filesDir, { recursive: true });
     await unzipV2(
       downloadResult.downloadedFilePath,
       release.filesDir,
@@ -57,6 +59,9 @@ type StreamProviderResult = {
 
 const UNIX_SYMLINK = 0o120000;
 const UNIX_FILE_TYPE_MASK = 0o170000;
+// A symlink target is a path; cap the bytes we accumulate for it so a crafted
+// archive cannot drive the extractor to OOM through the symlink-target read.
+const MaxSymlinkTargetBytes = 4096;
 
 export async function unzipV2(
   inputPath: string,
@@ -81,15 +86,42 @@ export async function unzipV2(
               reject(e);
               return;
             }
-            let target = '';
+            const chunks: Buffer[] = [];
+            let targetLength = 0;
+            let aborted = false;
             reader.on('data', (chunk: Buffer) => {
-              target += chunk.toString();
+              if (aborted) {
+                return;
+              }
+              targetLength += chunk.length;
+              if (targetLength > MaxSymlinkTargetBytes) {
+                aborted = true;
+                reader.destroy();
+                reject(
+                  new Error('Archive symlink target exceeds the maximum length')
+                );
+                return;
+              }
+              chunks.push(chunk);
             });
             reader.on('end', () => {
+              if (aborted) {
+                return;
+              }
               try {
+                const rawTarget = Buffer.concat(chunks).toString().trim();
                 const linkPath = path.join(baseDir, entry.fileName);
+                // The link's own location must stay inside the extraction root,
+                // and so must whatever the link resolves to, or a later entry
+                // could write through it to an arbitrary location.
+                assertInside(baseDir, linkPath);
+                const resolvedTarget = path.resolve(
+                  path.dirname(linkPath),
+                  rawTarget
+                );
+                assertInside(baseDir, resolvedTarget);
                 fs.mkdirSync(path.dirname(linkPath), { recursive: true });
-                fs.symlinkSync(target.trim(), linkPath);
+                fs.symlinkSync(rawTarget, linkPath);
               } catch (err) {
                 reject(err as Error);
                 return;
@@ -101,7 +133,13 @@ export async function unzipV2(
           return;
         }
 
-        const provider = streamProvider(entry);
+        let provider: StreamProviderResult;
+        try {
+          provider = streamProvider(entry);
+        } catch (err) {
+          reject(err as Error);
+          return;
+        }
         if (provider === null) {
           zipFile.readEntry();
           return;

--- a/qt-qml/src/traceviewer/runner.mts
+++ b/qt-qml/src/traceviewer/runner.mts
@@ -118,11 +118,8 @@ export class QmlTraceViewerRunner {
       }
     });
 
-    const out = await outPromise;
-    const err = await errPromise;
-    void err;
-
-    return out;
+    await outPromise;
+    await errPromise;
   }
 
   private _clearProcAndFire() {
@@ -235,31 +232,46 @@ async function parseJsonOutput(uri: vscode.Uri, text: string) {
 type Stream = NodeJS.ReadableStream;
 type Callback = ((line: string) => void) | undefined;
 
+// A single JSON-RPC line from the viewer is small. A runaway or compromised
+// viewer process could emit one endless line and grow the leftover buffer
+// without bound, so cap it and drop the oversized line instead of keeping it.
+const MaxLineBytes = 1024 * 1024; // 1 MiB
+
 async function streamToLines(stream: Stream | null, callback: Callback) {
   if (stream === null) {
     return;
   }
 
   let leftover = '';
-  const lines: string[] = [];
+  let discardingLongLine = false;
 
   for await (const chunk of stream) {
     const text = leftover + chunk.toString();
     const parts = text.split('\n');
     leftover = parts.pop() ?? '';
 
+    if (discardingLongLine) {
+      if (parts.length === 0) {
+        // Still inside the oversized line; keep dropping it.
+        leftover = '';
+        continue;
+      }
+      // The first newline ends the oversized line; drop what belongs to it.
+      parts.shift();
+      discardingLongLine = false;
+    }
+
     for (const line of parts) {
-      const trimmed = line.trim();
-      lines.push(trimmed);
-      callback?.(trimmed);
+      callback?.(line.trim());
+    }
+
+    if (leftover.length > MaxLineBytes) {
+      leftover = '';
+      discardingLongLine = true;
     }
   }
 
   if (leftover.trim()) {
-    const trimmed = leftover.trim();
-    lines.push(trimmed);
-    callback?.(trimmed);
+    callback?.(leftover.trim());
   }
-
-  return lines;
 }

--- a/qt-qml/src/unzipper.ts
+++ b/qt-qml/src/unzipper.ts
@@ -6,6 +6,50 @@ import { Writable } from 'stream';
 
 export type Entry = yauzl.Entry;
 
+// Bounds for what a single archive may extract. A crafted archive (zip bomb)
+// can declare millions of entries or expand a few compressed bytes into
+// gigabytes and exhaust disk or memory before any path check runs, so breach
+// aborts the extraction. The caps are generous multiples of the real qmlls
+// and trace viewer packages. yauzl verifies the declared sizes against the
+// actual inflated bytes (validateEntrySizes defaults to true), so a central
+// directory that understates a size is caught at stream time.
+const MaxEntryCount = 10000;
+const MaxTotalUncompressedBytes = 2 * 1024 * 1024 * 1024; // 2 GiB
+const MaxCompressionRatio = 100;
+// Fixed deflate overhead makes tiny entries report extreme ratios, so only
+// entries large enough to matter are ratio checked.
+const RatioCheckMinBytes = 1024 * 1024; // 1 MiB
+
+export class ExtractionBudget {
+  private _entryCount = 0;
+  private _totalUncompressedBytes = 0;
+
+  charge(entry: yauzl.Entry) {
+    this._entryCount++;
+    if (this._entryCount > MaxEntryCount) {
+      throw new Error(
+        `Archive contains more than ${MaxEntryCount.toString()} entries`
+      );
+    }
+
+    this._totalUncompressedBytes += entry.uncompressedSize;
+    if (this._totalUncompressedBytes > MaxTotalUncompressedBytes) {
+      throw new Error(
+        `Archive expands beyond ${MaxTotalUncompressedBytes.toString()} bytes`
+      );
+    }
+
+    if (
+      entry.uncompressedSize > RatioCheckMinBytes &&
+      entry.uncompressedSize > entry.compressedSize * MaxCompressionRatio
+    ) {
+      throw new Error(
+        `Archive entry has a suspicious compression ratio: ${entry.fileName}`
+      );
+    }
+  }
+}
+
 export async function unzip(
   inputPath: string,
   streamProvider: (entry: yauzl.Entry) => Writable | null
@@ -20,6 +64,7 @@ export async function unzip(
     let pendingWrites = 0;
     let allEntriesRead = false;
     let settled = false;
+    const budget = new ExtractionBudget();
 
     const fail = (error: Error) => {
       if (settled) {
@@ -46,6 +91,7 @@ export async function unzip(
       zipFile.on('entry', (entry: yauzl.Entry) => {
         let writer: Writable | null;
         try {
+          budget.charge(entry);
           writer = streamProvider(entry);
         } catch (err) {
           fail(err as Error);

--- a/qt-qml/src/unzipper.ts
+++ b/qt-qml/src/unzipper.ts
@@ -44,7 +44,13 @@ export async function unzip(
 
       zipFile.readEntry();
       zipFile.on('entry', (entry: yauzl.Entry) => {
-        const writer = streamProvider(entry);
+        let writer: Writable | null;
+        try {
+          writer = streamProvider(entry);
+        } catch (err) {
+          fail(err as Error);
+          return;
+        }
         if (writer === null) {
           zipFile.readEntry();
           return;

--- a/qt-qml/test/suite/index.mts
+++ b/qt-qml/test/suite/index.mts
@@ -15,7 +15,7 @@ export function run(): Promise<void> {
   const testsRoot = path.resolve(__dirname);
   return new Promise((c, e) => {
     const testFiles = new glob.Glob(
-      '{extension,command,installer,versioned-installations}.test.js',
+      '{extension,command,installer,versioned-installations,path-containment,qrc-parser}.test.js',
       {
         cwd: testsRoot
       }

--- a/qt-qml/test/suite/path-containment.test.mts
+++ b/qt-qml/test/suite/path-containment.test.mts
@@ -1,0 +1,62 @@
+// Copyright (C) 2026 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { assertInside } from 'qt-lib';
+
+suite('Archive extraction containment (R4)', () => {
+  let root: string;
+  let outside: string;
+
+  setup(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'extract-root-'));
+    outside = fs.mkdtempSync(path.join(os.tmpdir(), 'outside-'));
+  });
+
+  teardown(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+
+  test('allows a not-yet-existing path inside the root', () => {
+    expect(() =>
+      assertInside(root, path.join(root, 'sub/file.txt'))
+    ).to.not.throw();
+  });
+
+  test('rejects an absolute path outside the root', () => {
+    expect(() => assertInside(root, path.join(outside, 'x'))).to.throw();
+  });
+
+  test('rejects .. traversal out of the root', () => {
+    expect(() => assertInside(root, path.join(root, '../escape'))).to.throw();
+  });
+
+  test('rejects a write through a planted symlink that escapes the root', () => {
+    // The PL-002 primitive: a symlink inside the root pointing outside, then a
+    // write through it. Realpath sees through the link; a lexical check would not.
+    fs.symlinkSync(outside, path.join(root, 'evil'));
+    expect(() =>
+      assertInside(root, path.join(root, 'evil', 'payload.plist'))
+    ).to.throw();
+  });
+
+  test('rejects a symlink target that resolves outside the root', () => {
+    const linkPath = path.join(root, 'link');
+    const resolvedTarget = path.resolve(
+      path.dirname(linkPath),
+      '../../../../etc'
+    );
+    expect(() => assertInside(root, resolvedTarget)).to.throw();
+  });
+
+  test('allows a symlink target that stays inside the root', () => {
+    const linkPath = path.join(root, 'link');
+    const resolvedTarget = path.resolve(path.dirname(linkPath), 'sub/inside');
+    expect(() => assertInside(root, resolvedTarget)).to.not.throw();
+  });
+});

--- a/qt-qml/test/suite/path-containment.test.mts
+++ b/qt-qml/test/suite/path-containment.test.mts
@@ -6,7 +6,16 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { assertInside } from 'qt-lib';
+import { assertInside, isInside, isInsideReal } from 'qt-lib';
+
+function trySymlink(target: string, linkPath: string) {
+  try {
+    fs.symlinkSync(target, linkPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 suite('Archive extraction containment (R4)', () => {
   let root: string;
@@ -36,10 +45,12 @@ suite('Archive extraction containment (R4)', () => {
     expect(() => assertInside(root, path.join(root, '../escape'))).to.throw();
   });
 
-  test('rejects a write through a planted symlink that escapes the root', () => {
+  test('rejects a write through a planted symlink that escapes the root', function () {
     // The PL-002 primitive: a symlink inside the root pointing outside, then a
     // write through it. Realpath sees through the link; a lexical check would not.
-    fs.symlinkSync(outside, path.join(root, 'evil'));
+    if (!trySymlink(outside, path.join(root, 'evil'))) {
+      this.skip();
+    }
     expect(() =>
       assertInside(root, path.join(root, 'evil', 'payload.plist'))
     ).to.throw();
@@ -58,5 +69,62 @@ suite('Archive extraction containment (R4)', () => {
     const linkPath = path.join(root, 'link');
     const resolvedTarget = path.resolve(path.dirname(linkPath), 'sub/inside');
     expect(() => assertInside(root, resolvedTarget)).to.not.throw();
+  });
+});
+
+suite('Path containment helpers (R7)', () => {
+  let root: string;
+  let outside: string;
+
+  setup(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'contain-root-'));
+    outside = fs.mkdtempSync(path.join(os.tmpdir(), 'contain-outside-'));
+  });
+
+  teardown(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+
+  test('isInside rejects a sibling directory sharing the root prefix', () => {
+    expect(isInside('/opt/vcpkg', '/opt/vcpkg-evil/x')).to.equal(false);
+    expect(isInside('/opt/vcpkg', '/opt/vcpkg/installed')).to.equal(true);
+  });
+
+  test('isInside accepts the root itself', () => {
+    expect(isInside('/opt/vcpkg', '/opt/vcpkg')).to.equal(true);
+  });
+
+  test('isInside rejects .. traversal and absolute escapes', () => {
+    expect(isInside('/opt/vcpkg', '/opt/vcpkg/a/../../etc')).to.equal(false);
+    expect(isInside('/opt/vcpkg', '/etc/passwd')).to.equal(false);
+  });
+
+  test('isInside resolves a relative candidate against the root', () => {
+    expect(isInside('/opt/vcpkg', 'sub/file')).to.equal(true);
+    expect(isInside('/opt/vcpkg', '../other')).to.equal(false);
+  });
+
+  test('isInside works without the root existing on disk', () => {
+    const missing = path.join(root, 'missing-root');
+    expect(isInside(missing, path.join(missing, 'a'))).to.equal(true);
+  });
+
+  test('isInsideReal fails closed when the root is missing', () => {
+    const missing = path.join(root, 'missing-root');
+    expect(isInsideReal(missing, path.join(missing, 'a'))).to.equal(false);
+  });
+
+  test('isInsideReal sees through an escaping leaf symlink', function () {
+    const secret = path.join(outside, 'secret');
+    fs.writeFileSync(secret, '');
+    if (!trySymlink(secret, path.join(root, 'link'))) {
+      this.skip();
+    }
+    expect(isInsideReal(root, path.join(root, 'link'))).to.equal(false);
+  });
+
+  test('isInsideReal allows a not-yet-existing path inside the root', () => {
+    expect(isInsideReal(root, path.join(root, 'new/file'))).to.equal(true);
   });
 });

--- a/qt-qml/test/suite/qrc-parser.test.mts
+++ b/qt-qml/test/suite/qrc-parser.test.mts
@@ -1,0 +1,118 @@
+// Copyright (C) 2026 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { QRCParser } from 'qt-lib';
+
+function qrcXml(entries: string[]) {
+  const files = entries.map((e) => `<file>${e}</file>`).join('');
+  return `<RCC><qresource prefix="/">${files}</qresource></RCC>`;
+}
+
+function trySymlink(target: string, linkPath: string) {
+  try {
+    fs.symlinkSync(target, linkPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+suite('QRC parser containment (R7)', () => {
+  let qrcDir: string;
+  let outside: string;
+
+  setup(() => {
+    qrcDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qrc-dir-'));
+    outside = fs.mkdtempSync(path.join(os.tmpdir(), 'qrc-outside-'));
+  });
+
+  teardown(() => {
+    fs.rmSync(qrcDir, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+
+  test('keeps a relative entry inside the qrc directory', () => {
+    const map = new QRCParser().parseQRC(qrcXml(['Main.qml']), qrcDir);
+    expect(map?.get('/Main.qml')).to.equal(path.join(qrcDir, 'Main.qml'));
+  });
+
+  test('keeps a not-yet-existing entry inside the qrc directory', () => {
+    const map = new QRCParser().parseQRC(qrcXml(['sub/New.qml']), qrcDir);
+    expect(map?.get('/sub/New.qml')).to.equal(path.join(qrcDir, 'sub/New.qml'));
+  });
+
+  test('drops a .. traversal entry and reports it', () => {
+    const dropped: string[] = [];
+    const map = new QRCParser().parseQRC(
+      qrcXml(['../../escape.qml', 'Ok.qml']),
+      qrcDir,
+      false,
+      { onViolation: (entry) => dropped.push(entry) }
+    );
+    expect(map?.has('/Ok.qml')).to.equal(true);
+    expect([...(map?.keys() ?? [])]).to.have.lengthOf(1);
+    expect(dropped).to.deep.equal(['../../escape.qml']);
+  });
+
+  test('drops an absolute entry outside every root', () => {
+    const target = path.join(outside, 'secret.qml');
+    const map = new QRCParser().parseQRC(qrcXml([target]), qrcDir);
+    expect(map?.size ?? 0).to.equal(0);
+  });
+
+  test('keeps an absolute entry inside an extra root', () => {
+    const target = path.join(outside, 'Generated.qml');
+    fs.writeFileSync(target, '');
+    const map = new QRCParser().parseQRC(qrcXml([target]), qrcDir, false, {
+      extraRoots: [outside]
+    });
+    expect(map?.size).to.equal(1);
+    expect([...(map?.values() ?? [])]).to.deep.equal([target]);
+  });
+
+  test('drops an in-tree symlink resolving outside every root', function () {
+    const secret = path.join(outside, 'secret.qml');
+    fs.writeFileSync(secret, '');
+    if (!trySymlink(secret, path.join(qrcDir, 'Link.qml'))) {
+      this.skip();
+    }
+    const map = new QRCParser().parseQRC(qrcXml(['Link.qml']), qrcDir);
+    expect(map?.size ?? 0).to.equal(0);
+  });
+
+  test('accepts entries through a symlinked root', function () {
+    // A workspace folder path may itself be a symlink while generated qrc
+    // files reference the physical path; roots are realpathed so both
+    // spellings must pass.
+    const linkRoot = path.join(outside, 'ws-link');
+    if (!trySymlink(qrcDir, linkRoot)) {
+      this.skip();
+    }
+    const target = path.join(fs.realpathSync(qrcDir), 'App.qml');
+    fs.writeFileSync(target, '');
+    const map = new QRCParser().parseQRC(qrcXml([target]), qrcDir, false, {
+      extraRoots: [linkRoot]
+    });
+    expect(map?.size).to.equal(1);
+  });
+
+  test('caches per root set in parseQRCFile', () => {
+    const parser = new QRCParser();
+    const generated = path.join(outside, 'Gen.qml');
+    fs.writeFileSync(generated, '');
+    const qrcPath = path.join(qrcDir, 'res.qrc');
+    fs.writeFileSync(qrcPath, qrcXml([generated]));
+
+    const withoutRoot = parser.parseQRCFile(qrcPath);
+    const withRoot = parser.parseQRCFile(qrcPath, false, {
+      extraRoots: [outside]
+    });
+    expect(withoutRoot?.size ?? 0).to.equal(0);
+    expect(withRoot?.size).to.equal(1);
+  });
+});


### PR DESCRIPTION
A .qrc file from the workspace could point at files outside the
project, for example /etc/passwd or ../../secret, and the extension
would read them for the QML preview, thumbnails, and the open action.
Entries are now only accepted when they resolve, symlinks included,
into the .qrc directory, the workspace folders, or the build
directories. The qrc editor's file walk is also bounded so a symlink
loop or a huge tree can no longer hang the extension.

Commits
- [qt-lib: Fix separator blind vcpkg root check](https://github.com/OrkunTokdemir/vscodeext/commit/da9c99c6d33dc69a2fadee8b08182d8b8800de07)
- [qt-lib: qt-core: qt-qml: Contain qrc file paths](https://github.com/OrkunTokdemir/vscodeext/commit/7a275fdefa75f65a8f1ae285c6b5bdfed6514844)
- [qt-core: Bound the qrc editor file walk](https://github.com/OrkunTokdemir/vscodeext/commit/f30bbfd296eafd3718f7379373631865bd9b42e2)

Fixes: [VSCODEEXT-331](https://qt-project.atlassian.net/browse/VSCODEEXT-331)
Fixes: [VSCODEEXT-332](https://qt-project.atlassian.net/browse/VSCODEEXT-332)