### PR TITLE
qt-cpp: Warm up NatVis display before the snippet test reads Locals

### DIFF
--- a/qt-cpp/test/suite/natvis.test.mts
+++ b/qt-cpp/test/suite/natvis.test.mts
@@ -218,6 +218,10 @@ describe('Debugging using Qt debug snippets (Qt: Debug with …)', function () {
 
       const stop = stops[0]!;
       const frameId = stop.frameId!;
+      // On cppvsdbg the NatVis DisplayString is evaluated lazily: a cold
+      // Locals read right after the stop can return empty value strings.
+      // Warm it up first, like the golden test does.
+      await warmUpNatvisDisplay(session, frameId);
       const locals = await getLocals(session, frameId);
       dlog(
         '[snippet-test] Locals at top frame:',


### PR DESCRIPTION
On Windows/cppvsdbg the first Locals read after a breakpoint stop can return an empty DisplayString value; the display is fine for a user. The cold read worked by margin only, and the latest natvis growth ate that margin on Qt 6.10. The golden test already warms up the display before sampling (0716837); do the same in the snippet test.

## Description

<!-- Describe what this pull request changes and why. -->

## Related issue

<!-- Link the issue this PR addresses, e.g. VSCODEEXT-123, or remove this section. -->

## Type of change

<!-- Put an "x" in the boxes that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] My changes follow the code style of this project (`npm run ci-lint:all` passes).
- [ ] I have tested my changes locally. ([ ] Windows, [ ] Linux, [] MacOS)
- [ ] I have updated the documentation where necessary.
