### PR TITLE
Improve managed qmlls installation reliability by enabling integrity tests, avoiding redundant blocking executable probes, tolerating slow first launches, and clearing stale managed-version state.

### DIFF
--- a/qt-qml/esbuild.mjs
+++ b/qt-qml/esbuild.mjs
@@ -15,6 +15,7 @@ await runEsbuild({
     './test/suite/extension.test.mts',
     './test/suite/command.test.mts',
     './test/suite/installer.test.mts',
+    './test/suite/integrity.test.mts',
     './test/runTest.qml-debug.mts',
     './test/runTestHelper.mts',
     './test/suite/index-qml-debug.mts',

--- a/qt-qml/src/installer.mts
+++ b/qt-qml/src/installer.mts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { spawnSync } from 'child_process';
+import { spawn } from 'child_process';
 
 import {
   OSExeSuffix,
@@ -181,8 +181,7 @@ export interface AssetWithTag extends Asset {
 export enum AssetStatus {
   Outdated,
   UpToDate,
-  NotInstalled,
-  Broken
+  NotInstalled
 }
 interface CheckResult {
   message: string;
@@ -191,19 +190,44 @@ interface CheckResult {
 
 const RunnableProbeTimeoutMs = 2000;
 
-function isRunnable(exePath: string): boolean {
-  const res = spawnSync(exePath, ['--help'], {
-    timeout: RunnableProbeTimeoutMs
+/**
+ * Smoke-test a freshly unpacked qmlls before it is committed as a version.
+ * Runs asynchronously, so a slow first start never blocks the extension
+ * host. A process that is still running when the probe expires counts as
+ * runnable: the image loaded and executed, which is what this asks. Only a
+ * failure to spawn or a non-zero exit means the artifact is unusable, and
+ * both of those are immediate.
+ *
+ * `args` and `timeoutMs` exist so the probe's classification can be tested
+ * against a known executable; production always uses the defaults.
+ */
+export async function isRunnable(
+  exePath: string,
+  args: string[] = ['--help'],
+  timeoutMs = RunnableProbeTimeoutMs
+): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    // No pipes: nothing here reads the child's output, and a child that
+    // fills the pipe buffer would block until the probe expires instead of
+    // exiting. Buffer capacity is platform-dependent and smallest on Windows.
+    const child = spawn(exePath, args, { stdio: 'ignore' });
+    const timer = setTimeout(() => {
+      child.kill();
+      resolve(true);
+    }, timeoutMs);
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      // Says which of the two failures happened: refused by the OS (an
+      // unnotarized binary under Gatekeeper, a missing exec bit) reads very
+      // differently from a binary that ran and rejected --help.
+      logger.warn(`qmlls probe could not start ${exePath}: ${String(error)}`);
+      resolve(false);
+    });
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      resolve(code === 0);
+    });
   });
-  // A timeout means the process loaded and was still running when it was
-  // killed, which is what this check asks. Only a failure to spawn or a
-  // non-zero exit means the install is unusable. A freshly written exe can
-  // need seconds for its first run while a virus scanner reads it, and
-  // reporting that as broken re-downloads a perfectly good install.
-  if ((res.error as NodeJS.ErrnoException | undefined)?.code === 'ETIMEDOUT') {
-    return true;
-  }
-  return res.status === 0;
 }
 
 function versionOf(asset: AssetWithTag): InstallVersion {
@@ -242,14 +266,6 @@ export function checkStatusAgainst(asset: AssetWithTag): CheckResult {
     };
   }
 
-  // check if executable
-  if (!isRunnable(exePath)) {
-    return {
-      message: 'Found, but not executable',
-      status: AssetStatus.Broken
-    };
-  }
-
   return {
     message: `Already Up-to-date, tag = ${asset.tag_name}`,
     status: AssetStatus.UpToDate
@@ -283,11 +299,7 @@ export async function install(asset: AssetWithTag) {
       // tag and upload time) already; then only the manifest needs to be
       // published.
       const version = versionOf(asset);
-      const existingExe = path.join(
-        installations.versionDirPath(version),
-        QmllsExeName
-      );
-      if (installations.hasVersion(version) && isRunnable(existingExe)) {
+      if (installations.hasVersion(version)) {
         logger.info(
           `${asset.tag_name} (uploaded ${asset.created_at}) is already installed, publishing it`
         );
@@ -339,7 +351,7 @@ export async function install(asset: AssetWithTag) {
         logger.info(`Setting executable permission for: ${stagedExe}`);
         fs.chmodSync(stagedExe, 0o755);
         logger.info(`Executable permission set for: ${stagedExe}`);
-        if (!isRunnable(stagedExe)) {
+        if (!(await isRunnable(stagedExe))) {
           logger.error(`Staged qmlls is not runnable: ${stagedExe}`);
           throw new Error(`${stagedExe} is not runnable`);
         }

--- a/qt-qml/src/installer.mts
+++ b/qt-qml/src/installer.mts
@@ -189,8 +189,20 @@ interface CheckResult {
   status: AssetStatus;
 }
 
+const RunnableProbeTimeoutMs = 2000;
+
 function isRunnable(exePath: string): boolean {
-  const res = spawnSync(exePath, ['--help'], { timeout: 1000 });
+  const res = spawnSync(exePath, ['--help'], {
+    timeout: RunnableProbeTimeoutMs
+  });
+  // A timeout means the process loaded and was still running when it was
+  // killed, which is what this check asks. Only a failure to spawn or a
+  // non-zero exit means the install is unusable. A freshly written exe can
+  // need seconds for its first run while a virus scanner reads it, and
+  // reporting that as broken re-downloads a perfectly good install.
+  if ((res.error as NodeJS.ErrnoException | undefined)?.code === 'ETIMEDOUT') {
+    return true;
+  }
   return res.status === 0;
 }
 

--- a/qt-qml/src/qmlls.mts
+++ b/qt-qml/src/qmlls.mts
@@ -259,7 +259,8 @@ export class Qmlls {
 
   /**
    * The identity of the managed qmlls install the language clients are
-   * running from or adopting. Used by the manifest watcher to tell a version
+   * running from or adopting, and undefined whenever they are not running a
+   * managed install at all. Used by the manifest watcher to tell a version
    * published by another VS Code instance apart from our own install. The
    * upload time is part of the identity: a build re-published under the same
    * tag must still trigger a restart.
@@ -326,10 +327,16 @@ export class Qmlls {
     if (!configs.get<boolean>('enabled', false)) {
       telemetry.sendConfig('QmllsDisabled');
       logger.info('QML Language Server is disabled in the settings');
+      Qmlls.runningInstalledVersion = undefined;
       return;
     }
 
     try {
+      // Only the managed install below adopts a version again. Clearing it
+      // here keeps a custom exe, a Qt kit fallback, or a failed start from
+      // leaving the previously adopted identity behind, which would make the
+      // manifest watcher restart clients that are not running that install.
+      Qmlls.runningInstalledVersion = undefined;
       if (configs.get<string>('customExePath')) {
         const customPath = configs.get<string>('customExePath') ?? '';
         const resolvedCustomPath = resolveConfiguration(customPath);

--- a/qt-qml/test/suite/index.mts
+++ b/qt-qml/test/suite/index.mts
@@ -15,7 +15,7 @@ export function run(): Promise<void> {
   const testsRoot = path.resolve(__dirname);
   return new Promise((c, e) => {
     const testFiles = new glob.Glob(
-      '{extension,command,installer,versioned-installations}.test.js',
+      '{extension,command,installer,integrity,versioned-installations}.test.js',
       {
         cwd: testsRoot
       }

--- a/qt-qml/test/suite/installer.test.mts
+++ b/qt-qml/test/suite/installer.test.mts
@@ -5,10 +5,9 @@ import { expect } from 'chai';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { spawnSync } from 'child_process';
 import * as vscode from 'vscode';
 
-import { OSExeSuffix, IsWindows } from 'qt-lib';
+import { OSExeSuffix } from 'qt-lib';
 import * as installer from '@/installer.mjs';
 import { VersionedInstallations } from '@/versioned-installations.mjs';
 
@@ -31,8 +30,8 @@ function makeAsset(
 
 // Installs a fake build into the versioned store the installer operates on
 // and publishes it as current, like a finished install() would. The exe is
-// not runnable; only tests that must reach the health check need
-// installRunnableBuild() instead.
+// not runnable, which no longer matters: a committed version directory is
+// complete by construction, so checkStatusAgainst does not execute it.
 function installFakeBuild(
   version: installer.InstallVersion,
   content: string | Buffer = 'not a real executable'
@@ -48,29 +47,59 @@ function installFakeBuild(
   return path.join(versionDir, QmllsExeName);
 }
 
-// Installs a fake build whose exe exits 0 for `qmlls --help`, so
-// checkStatusAgainst can reach the UpToDate verdict. Returns false when no
-// suitable executable can be provided on this machine (caller should skip).
-function installRunnableBuild(version: installer.InstallVersion): boolean {
-  let content: string | Buffer;
-  if (IsWindows) {
-    // A .exe must be a real binary; reuse the node.exe that runs the tests.
-    const where = spawnSync('where', ['node'], { encoding: 'utf8' });
-    const nodePath = where.stdout
-      ?.split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(Boolean);
-    if (where.status !== 0 || !nodePath) {
-      return false;
-    }
-    content = fs.readFileSync(nodePath);
-  } else {
-    content = '#!/bin/sh\nexit 0\n';
-  }
-  const exePath = installFakeBuild(version, content);
-  fs.chmodSync(exePath, 0o755);
-  return true;
-}
+describe('installer: qmlls runnable probe', () => {
+  const nodeExe = process.execPath;
+
+  it('accepts an executable that exits zero', async () => {
+    expect(
+      await installer.isRunnable(nodeExe, ['-e', 'process.exit(0)'])
+    ).to.equal(true);
+  });
+
+  it('rejects an executable that exits non-zero', async () => {
+    expect(
+      await installer.isRunnable(nodeExe, ['-e', 'process.exit(3)'])
+    ).to.equal(false);
+  });
+
+  it('rejects an executable that cannot be started', async () => {
+    const missing = path.join(
+      os.tmpdir(),
+      `qmlls-does-not-exist-${String(process.pid)}${OSExeSuffix}`
+    );
+
+    expect(await installer.isRunnable(missing)).to.equal(false);
+  });
+
+  it('accepts an executable still running when the probe expires', async () => {
+    const startedAt = Date.now();
+
+    const runnable = await installer.isRunnable(
+      nodeExe,
+      ['-e', 'setTimeout(() => undefined, 60000)'],
+      200
+    );
+
+    expect(runnable).to.equal(true);
+    expect(Date.now() - startedAt).to.be.lessThan(2000);
+  });
+
+  it('does not stall on an executable that outwrites the pipe buffer', async () => {
+    const startedAt = Date.now();
+
+    const runnable = await installer.isRunnable(
+      nodeExe,
+      ['-e', 'process.stdout.write("x".repeat(200000))'],
+      2000
+    );
+
+    // Nothing drains the child's output, so with piped stdio the child blocks
+    // once the buffer fills and only the timeout ends the probe. Finishing
+    // well before it is what proves the output is discarded instead.
+    expect(runnable).to.equal(true);
+    expect(Date.now() - startedAt).to.be.lessThan(1500);
+  });
+});
 
 describe('installer: qmlls update detection', () => {
   let tmpDir: string;
@@ -120,15 +149,11 @@ describe('installer: qmlls update detection', () => {
     expect(result.status).to.equal(installer.AssetStatus.Outdated);
   });
 
-  it('recognizes the published build as up to date when tag and upload time match', function () {
-    if (
-      !installRunnableBuild({
-        tag: BASE_ASSET.tag_name,
-        createdAt: BASE_ASSET.created_at
-      })
-    ) {
-      this.skip();
-    }
+  it('recognizes the published build as up to date when tag and upload time match', () => {
+    installFakeBuild({
+      tag: BASE_ASSET.tag_name,
+      createdAt: BASE_ASSET.created_at
+    });
 
     const result = installer.checkStatusAgainst(makeAsset());
 

--- a/qt-qml/test/suite/integrity.test.mts
+++ b/qt-qml/test/suite/integrity.test.mts
@@ -12,24 +12,24 @@ import { digestMatches, sha256OfFile } from '@/integrity.js';
 const sha256 = (data: string) =>
   createHash('sha256').update(Buffer.from(data)).digest('hex');
 
-suite('Download integrity (R3)', () => {
-  test('accepts a matching sha256:-prefixed digest', () => {
+describe('Download integrity (R3)', () => {
+  it('accepts a matching sha256:-prefixed digest', () => {
     const hex = sha256('hello');
     expect(digestMatches(`sha256:${hex}`, hex)).to.equal(true);
   });
 
-  test('accepts a bare-hex digest case-insensitively', () => {
+  it('accepts a bare-hex digest case-insensitively', () => {
     const hex = sha256('hello');
     expect(digestMatches(hex.toUpperCase(), hex)).to.equal(true);
   });
 
-  test('rejects a mismatched digest', () => {
+  it('rejects a mismatched digest', () => {
     expect(
       digestMatches(`sha256:${sha256('hello')}`, sha256('hell0'))
     ).to.equal(false);
   });
 
-  test('fails closed on missing or malformed digests', () => {
+  it('fails closed on missing or malformed digests', () => {
     const hex = sha256('x');
     expect(digestMatches(undefined, hex)).to.equal(false);
     expect(digestMatches('', hex)).to.equal(false);
@@ -37,7 +37,7 @@ suite('Download integrity (R3)', () => {
     expect(digestMatches('sha256:abc', hex)).to.equal(false); // too short
   });
 
-  test('sha256OfFile matches the file contents hash', async () => {
+  it('sha256OfFile matches the file contents hash', async () => {
     const content = 'the quick brown fox';
     const p = path.join(os.tmpdir(), `qmlls-integrity-${process.pid}.bin`);
     fs.writeFileSync(p, Buffer.from(content));


### PR DESCRIPTION
## Description

Four independent fixes to the qmlls download and install path, all against code
already on `dev`. They are ordered so each one stands on its own: the test
wiring first, then the probe fixes, then an unrelated `qmlls.mts` fix.

**Run the download integrity tests.** The tests that came with the SHA256
download gate never executed. Three separate lists decide whether a test file
runs and `integrity.test.mts` was in none of them: esbuild's `testEntryPoints`
never compiled it, the suite runner's glob never picked it up, and it used
Mocha's TDD interface (`suite`/`test`) while the runner is configured for BDD,
so it would have thrown on load had it been included. Added to both lists and
converted to `describe`/`it` like every other suite in the package.

**Do not treat a slow qmlls probe as a broken install.** `isRunnable()` ran
`qmlls --help` and required exit code 0 within one second, so a timeout was
read as a broken install. A timeout only means the process was still running
when it was killed - the image loaded and executed, which is what the check
asks. The first run of a freshly written executable can take seconds while a
virus scanner reads it, which is exactly the state of a just-unzipped qmlls.
The false verdict re-downloads a good install, and aborts the install outright
when the staged executable is probed. `ETIMEDOUT` now counts as runnable and
the budget is two seconds, so the timeout only bounds how long the probe takes.

**Check the qmlls download instead of executing the install.** Three different
questions were being answered by one blocking `qmlls --help`: whether the
download arrived intact, whether a committed version is still usable, and
whether qmlls runs on this machine. Download integrity is established by the
SHA256 gate, so nothing needs to re-check it. A committed version directory is
complete by construction - installs are staged and moved into place with one
atomic rename - so `checkStatusAgainst()` and the reuse path no longer execute
it; `hasVersion()` already checks the executable is there. With that, no state
reaches the `Broken` verdict any more and it is removed. The remaining smoke
test on a freshly unpacked executable is kept, because that artifact is the one
that has never been validated, but it now runs asynchronously so a slow first
start cannot block the extension host.

**Forget the adopted qmlls version when none is running.**
`Qmlls.runningInstalledVersion` tells the manifest watcher which managed install
the language clients run, so a version published by another window can be told
apart from our own. It was only ever set, never cleared: a custom exe path, a Qt
kit fallback, or a failed start left a previously adopted identity behind, and
the watcher then restarted language servers that were never running that
install.

### Behaviour changes worth reviewing

- `AssetStatus.Broken` is removed - no code path can reach it once the execute
  probes are gone.
- `checkStatusAgainst()` and the "already installed by another window" path no
  longer execute qmlls. On Unix this drops an executable-bit check that used to
  exist there; `chmod 0o755` still runs immediately before the atomic rename,
  and a real failure surfaces at language-server start with the Qt kit fallback.
- `isRunnable()` is now async and exported, with `args` and `timeoutMs`
  parameters so its classification can be tested. Production uses the defaults.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] My changes follow the code style of this project (`npm run ci-lint:all` passes).
- [x] I have tested my changes locally. ([x] Windows, [ ] Linux, [ ] MacOS)
- [x] I have updated the documentation where necessary. (no user-facing docs affected)