### PR TITLE
qt-cpp: update NatVis golden expectations to the current natvis and MIEngine

### DIFF
--- a/qt-cpp/test/debug-golden-entries.mts
+++ b/qt-cpp/test/debug-golden-entries.mts
@@ -48,12 +48,6 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     name: 'coreTypes.qDate',
     type: 'QDate',
     value: '2024-06-15',
-    knownProblem: {
-      darwin:
-        'LLDB fails to evaluate QDate intrinsics (year(), month(), day()) and prints evaluation errors instead of the formatted date.',
-      linux:
-        'GDB fails to evaluate QDate intrinsics (year(), month(), day()) and prints evaluation errors instead of the formatted date.'
-    },
     children: [
       { name: '[year]', value: '2024' },
       { name: '[month]', value: '6' },
@@ -531,12 +525,6 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     name: 'coreTypes.qUrl',
     type: 'QUrl',
     value: 'https://user:pass@github.com/narnaud/natvis4qt?ref=main#section1',
-    knownProblem: {
-      darwin:
-        'LLDB cannot evaluate the pointer-arithmetic intrinsics used to access scheme()/host()/path() relying on MSVC-specific.',
-      linux:
-        'GDB cannot evaluate the pointer-arithmetic intrinsics used to access scheme()/host()/path() relying on MSVC-specific.'
-    },
     children: [
       { name: '[scheme]', value: 'https' },
       { name: '[username]', value: 'user' },
@@ -1115,8 +1103,6 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     type: 'QCborMap',
     value: 'empty',
     knownProblem: {
-      darwin:
-        'QCborMap NatVis relies on Qt6Cored.dll intrinsics; cbor() cannot be evaluated, so the "empty" DisplayString is not shown.',
       linux:
         'QCborMap NatVis relies on Qt6Cored.dll intrinsics; cbor() cannot be evaluated, so the "empty" DisplayString is not shown.'
     },
@@ -1161,9 +1147,7 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: 'undefined',
     knownProblem: {
       darwin:
-        'NatVis formatting is currently unreliable under LLDB; value collapses to {...}.',
-      linux:
-        'NatVis formatting is currently unreliable under GDB; value collapses to "undefined".'
+        'NatVis formatting is currently unreliable under LLDB; value collapses to {...}.'
     },
     children: [{ name: '[expect_none]', value: '' }]
   },
@@ -1353,10 +1337,6 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     type: 'QVariant',
     value: '42',
     knownProblem: {
-      darwin:
-        "QVariant NatVis evaluation fails under LLDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'.",
-      linux:
-        "QVariant NatVis evaluation fails under GDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'.",
       win32:
         'Qt debug info (PDB files) is now available. cl (MSVC) evaluates QVariant correctly; ' +
         'with a clang-cl binary vsdbg cannot evaluate the typeId() intrinsic ' +
@@ -1369,10 +1349,6 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     type: 'QVariant',
     value: 'variant-string',
     knownProblem: {
-      darwin:
-        "QVariant NatVis evaluation fails under LLDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'.",
-      linux:
-        "QVariant NatVis evaluation fails under GDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'.",
       win32:
         'Qt debug info (PDB files) is now available. cl (MSVC) evaluates QVariant correctly; ' +
         'with a clang-cl binary vsdbg cannot evaluate the typeId() intrinsic ' +
@@ -1385,10 +1361,6 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     type: 'QVariant',
     value: 'true',
     knownProblem: {
-      darwin:
-        "QVariant NatVis evaluation fails under LLDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'.",
-      linux:
-        "QVariant NatVis evaluation fails under GDB: rule calls typeId() but the debugger reports 'use of undeclared identifier typeId'.",
       win32:
         'Qt debug info (PDB files) is now available. cl (MSVC) evaluates QVariant correctly; ' +
         'with a clang-cl binary vsdbg cannot evaluate the typeId() intrinsic ' +
@@ -1481,12 +1453,6 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     name: 'coreStateTypes.qAtomicPtrNull',
     type: 'QBasicAtomicPointer<int>',
     value: 'empty',
-    knownProblem: {
-      darwin:
-        'QBasicAtomicPointer<*> NatVis is not applied under LLDB; value falls back to {...} instead of {_q_value}/empty.',
-      linux:
-        'QBasicAtomicPointer<*> NatVis is not applied under GDB; value falls back to "" instead of {_q_value}/empty.'
-    },
     children: [{ name: '[expect_none]' }]
   },
   {
@@ -1622,14 +1588,6 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     name: 'guiTypes.qPixmap',
     type: 'QPixmap',
     value: 'empty',
-    knownProblem: {
-      darwin:
-        'QPixmap NatVis uses Qt6Gui.dll-qualified intrinsics; LLDB cannot resolve them ' +
-        'so neither the DisplayString nor children are materialized.',
-      linux:
-        'QPixmap NatVis uses Qt6Gui.dll-qualified intrinsics; GDB cannot resolve them ' +
-        'so neither the DisplayString nor children are materialized.'
-    },
     children: [
       {
         // [type] is a <Synthetic> that hardcodes "UINT8" without reading any memory,
@@ -1720,12 +1678,6 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     name: 'guiTypes.qVector2D',
     type: 'QVector2D',
     value: '{ x = 1, y = 2 }',
-    knownProblem: {
-      darwin:
-        'LLDB does not reliably apply the QVector2D NatVis DisplayString on macOS.',
-      linux:
-        'GDB does not reliably apply the QVector2D NatVis DisplayString on Linux.'
-    },
     children: [
       {
         name: '[x]',
@@ -1749,12 +1701,6 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     name: 'guiTypes.qVector3D',
     type: 'QVector3D',
     value: '{ x = 1, y = 2, z = 3 }',
-    knownProblem: {
-      darwin:
-        'LLDB does not reliably apply the QVector3D NatVis DisplayString on macOS.',
-      linux:
-        'GDB does not reliably apply the QVector3D NatVis DisplayString on Linux.'
-    },
     children: [
       {
         name: '[x]',
@@ -1786,12 +1732,6 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     name: 'guiTypes.qVector4D',
     type: 'QVector4D',
     value: '{ x = 1, y = 2, z = 3, w = 4 }',
-    knownProblem: {
-      darwin:
-        'LLDB does not reliably apply the QVector4D NatVis DisplayString on macOS.',
-      linux:
-        'GDB does not reliably apply the QVector4D NatVis DisplayString on Linux.'
-    },
     children: [
       {
         name: '[x]',

--- a/qt-cpp/test/debug-golden-entries.mts
+++ b/qt-cpp/test/debug-golden-entries.mts
@@ -471,54 +471,10 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     type: 'QTime',
     value: '{ milliseconds = 45296000 }',
     children: [
-      {
-        name: '[hours]',
-        value: '12',
-        knownProblem: {
-          darwin:
-            'LLDB fails to evaluate QTime intrinsic hour(); ' +
-            'reports "use of undeclared identifier \'hour\'".',
-          linux:
-            'GDB fails to evaluate QTime intrinsic hour(); ' +
-            'reports "use of undeclared identifier \'hour\'".'
-        }
-      },
-      {
-        name: '[minutes]',
-        value: '34',
-        knownProblem: {
-          darwin:
-            'LLDB fails to evaluate QTime intrinsic minute(); ' +
-            'reports "use of undeclared identifier \'minute\'".',
-          linux:
-            'GDB fails to evaluate QTime intrinsic minute(); ' +
-            'reports "use of undeclared identifier \'minute\'".'
-        }
-      },
-      {
-        name: '[seconds]',
-        value: '56',
-        knownProblem: {
-          darwin:
-            'LLDB fails to evaluate QTime intrinsic second(); ' +
-            'reports "use of undeclared identifier \'second\'".',
-          linux:
-            'GDB fails to evaluate QTime intrinsic second(); ' +
-            'reports "use of undeclared identifier \'second\'".'
-        }
-      },
-      {
-        name: '[milliseconds]',
-        value: '0',
-        knownProblem: {
-          darwin:
-            'LLDB fails to evaluate QTime intrinsic millisecond(); ' +
-            'reports "use of undeclared identifier \'millisecond\'".',
-          linux:
-            'GDB fails to evaluate QTime intrinsic millisecond(); ' +
-            'reports "use of undeclared identifier \'millisecond\'".'
-        }
-      }
+      { name: '[hours]', value: '12' },
+      { name: '[minutes]', value: '34' },
+      { name: '[seconds]', value: '56' },
+      { name: '[milliseconds]', value: '0' }
     ]
   },
   {
@@ -616,10 +572,6 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
         name: '[0]',
         value: '123',
         knownProblem: {
-          darwin:
-            'QVariant NatVis evaluation fails under LLDB. QList expands but element DisplayString becomes an evaluator error.',
-          linux:
-            'QVariant NatVis evaluation fails under GDB. QList expands but element DisplayString becomes an evaluator error.',
           win32:
             'QVariant elements are rendered as their internal storage ' +
             '(d/data/shared/_forAlignment...) instead of the contained scalar value.'
@@ -629,10 +581,6 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
         name: '[1]',
         value: 'hello',
         knownProblem: {
-          darwin:
-            'QVariant NatVis evaluation fails under LLDB. QList expands but element DisplayString becomes an evaluator error.',
-          linux:
-            'QVariant NatVis evaluation fails under GDB. QList expands but element DisplayString becomes an evaluator error.',
           win32:
             'QVariant elements are rendered as their internal storage ' +
             '(d/data/shared/_forAlignment...) instead of the contained scalar value.'
@@ -1679,22 +1627,8 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     type: 'QVector2D',
     value: '{ x = 1, y = 2 }',
     children: [
-      {
-        name: '[x]',
-        value: '1',
-        knownProblem: {
-          darwin: 'QVector2D NatVis children are not materialized under LLDB.',
-          linux: 'QVector2D NatVis children are not materialized under GDB.'
-        }
-      },
-      {
-        name: '[y]',
-        value: '2',
-        knownProblem: {
-          darwin: 'QVector2D NatVis children are not materialized under LLDB.',
-          linux: 'QVector2D NatVis children are not materialized under GDB.'
-        }
-      }
+      { name: '[x]', value: '1' },
+      { name: '[y]', value: '2' }
     ]
   },
   {
@@ -1702,30 +1636,9 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     type: 'QVector3D',
     value: '{ x = 1, y = 2, z = 3 }',
     children: [
-      {
-        name: '[x]',
-        value: '1',
-        knownProblem: {
-          darwin: 'QVector3D NatVis children are not materialized under LLDB.',
-          linux: 'QVector3D NatVis children are not materialized under GDB.'
-        }
-      },
-      {
-        name: '[y]',
-        value: '2',
-        knownProblem: {
-          darwin: 'QVector3D NatVis children are not materialized under LLDB.',
-          linux: 'QVector3D NatVis children are not materialized under GDB.'
-        }
-      },
-      {
-        name: '[z]',
-        value: '3',
-        knownProblem: {
-          darwin: 'QVector3D NatVis children are not materialized under LLDB.',
-          linux: 'QVector3D NatVis children are not materialized under GDB.'
-        }
-      }
+      { name: '[x]', value: '1' },
+      { name: '[y]', value: '2' },
+      { name: '[z]', value: '3' }
     ]
   },
   {
@@ -1733,38 +1646,10 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     type: 'QVector4D',
     value: '{ x = 1, y = 2, z = 3, w = 4 }',
     children: [
-      {
-        name: '[x]',
-        value: '1',
-        knownProblem: {
-          darwin: 'QVector4D NatVis children are not materialized under LLDB.',
-          linux: 'QVector4D NatVis children are not materialized under GDB.'
-        }
-      },
-      {
-        name: '[y]',
-        value: '2',
-        knownProblem: {
-          darwin: 'QVector4D NatVis children are not materialized under LLDB.',
-          linux: 'QVector4D NatVis children are not materialized under GDB.'
-        }
-      },
-      {
-        name: '[z]',
-        value: '3',
-        knownProblem: {
-          darwin: 'QVector4D NatVis children are not materialized under LLDB.',
-          linux: 'QVector4D NatVis children are not materialized under GDB.'
-        }
-      },
-      {
-        name: '[w]',
-        value: '4',
-        knownProblem: {
-          darwin: 'QVector4D NatVis children are not materialized under LLDB.',
-          linux: 'QVector4D NatVis children are not materialized under GDB.'
-        }
-      }
+      { name: '[x]', value: '1' },
+      { name: '[y]', value: '2' },
+      { name: '[z]', value: '3' },
+      { name: '[w]', value: '4' }
     ]
   },
   {

--- a/qt-cpp/test/debug-golden-entries.mts
+++ b/qt-cpp/test/debug-golden-entries.mts
@@ -60,13 +60,15 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: 'QDateTime(Brunei placeholder)',
     knownProblem: {
       darwin:
-        'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
+        'The engine inlines nested NatVis intrinsics textually, so the ' +
+        'QDateTime calendar math expands until it overflows the lldb-mi ' +
+        'command buffer and evaluation fails. Per-intrinsic evaluation is ' +
+        'the pending engine fix.',
       linux:
-        'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
+        'The engine inlines nested NatVis intrinsics textually, so the ' +
+        'QDateTime calendar math expands until it overflows the gdb/mi ' +
+        'command buffer and evaluation fails. Per-intrinsic evaluation is ' +
+        'the pending engine fix.',
       win32:
         'Qt debug info (PDB files) is now available, but DisplayString evaluation still fails ' +
         'and the debugger falls back to a raw "{d={...}}" representation. ' +
@@ -81,13 +83,15 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: 'QDateTime(Default placeholder)',
     knownProblem: {
       darwin:
-        'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
+        'The engine inlines nested NatVis intrinsics textually, so the ' +
+        'QDateTime calendar math expands until it overflows the lldb-mi ' +
+        'command buffer and evaluation fails. Per-intrinsic evaluation is ' +
+        'the pending engine fix.',
       linux:
-        'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
+        'The engine inlines nested NatVis intrinsics textually, so the ' +
+        'QDateTime calendar math expands until it overflows the gdb/mi ' +
+        'command buffer and evaluation fails. Per-intrinsic evaluation is ' +
+        'the pending engine fix.',
       win32:
         'Qt debug info (PDB files) is now available, but DisplayString evaluation still fails ' +
         'and the debugger falls back to a raw "{d={...}}" representation. ' +
@@ -102,13 +106,15 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: 'QDateTime(Marquesas placeholder)',
     knownProblem: {
       darwin:
-        'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
+        'The engine inlines nested NatVis intrinsics textually, so the ' +
+        'QDateTime calendar math expands until it overflows the lldb-mi ' +
+        'command buffer and evaluation fails. Per-intrinsic evaluation is ' +
+        'the pending engine fix.',
       linux:
-        'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
+        'The engine inlines nested NatVis intrinsics textually, so the ' +
+        'QDateTime calendar math expands until it overflows the gdb/mi ' +
+        'command buffer and evaluation fails. Per-intrinsic evaluation is ' +
+        'the pending engine fix.',
       win32:
         'Qt debug info (PDB files) is now available, but DisplayString evaluation still fails ' +
         'and the debugger falls back to a raw "{d={...}}" representation. ' +
@@ -123,13 +129,15 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: 'QDateTime(TimeSecOffset placeholder)',
     knownProblem: {
       darwin:
-        'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
+        'The engine inlines nested NatVis intrinsics textually, so the ' +
+        'QDateTime calendar math expands until it overflows the lldb-mi ' +
+        'command buffer and evaluation fails. Per-intrinsic evaluation is ' +
+        'the pending engine fix.',
       linux:
-        'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
+        'The engine inlines nested NatVis intrinsics textually, so the ' +
+        'QDateTime calendar math expands until it overflows the gdb/mi ' +
+        'command buffer and evaluation fails. Per-intrinsic evaluation is ' +
+        'the pending engine fix.',
       win32:
         'Qt debug info (PDB files) is now available, but DisplayString evaluation still fails ' +
         'and the debugger falls back to a raw "{d={...}}" representation. ' +
@@ -145,8 +153,10 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     knownProblem: {
       all:
         'qDateTimeShouldFail is intentionally constructed with an invalid/timezone setup to ' +
-        'exercise QDateTime NatVis error-path behaviour. However, because QDateTime NatVis is ' +
-        'currently broken globally, we cannot yet assert its DisplayString or error formatting.'
+        'exercise QDateTime NatVis error-path behaviour. However, QDateTime NatVis still fails ' +
+        'on every CI configuration (textually inlined intrinsics overflow the MI command buffer ' +
+        'on macOS/Linux; vsdbg falls back to raw output on Windows), so we cannot yet assert ' +
+        'its DisplayString or error formatting.'
     }
   },
   {
@@ -155,13 +165,15 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: 'QDateTime(SouthPole placeholder)',
     knownProblem: {
       darwin:
-        'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
+        'The engine inlines nested NatVis intrinsics textually, so the ' +
+        'QDateTime calendar math expands until it overflows the lldb-mi ' +
+        'command buffer and evaluation fails. Per-intrinsic evaluation is ' +
+        'the pending engine fix.',
       linux:
-        'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
+        'The engine inlines nested NatVis intrinsics textually, so the ' +
+        'QDateTime calendar math expands until it overflows the gdb/mi ' +
+        'command buffer and evaluation fails. Per-intrinsic evaluation is ' +
+        'the pending engine fix.',
       win32:
         'Qt debug info (PDB files) is now available, but DisplayString evaluation still fails ' +
         'and the debugger falls back to a raw "{d={...}}" representation. ' +
@@ -176,13 +188,15 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: 'QDateTime(TimeUtc placeholder)',
     knownProblem: {
       darwin:
-        'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
+        'The engine inlines nested NatVis intrinsics textually, so the ' +
+        'QDateTime calendar math expands until it overflows the lldb-mi ' +
+        'command buffer and evaluation fails. Per-intrinsic evaluation is ' +
+        'the pending engine fix.',
       linux:
-        'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
+        'The engine inlines nested NatVis intrinsics textually, so the ' +
+        'QDateTime calendar math expands until it overflows the gdb/mi ' +
+        'command buffer and evaluation fails. Per-intrinsic evaluation is ' +
+        'the pending engine fix.',
       win32:
         'Qt debug info (PDB files) is now available, but DisplayString evaluation still fails ' +
         'and the debugger falls back to a raw "{d={...}}" representation. ' +
@@ -197,13 +211,15 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     value: 'QDateTime(Yukon placeholder)',
     knownProblem: {
       darwin:
-        'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so LLDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
+        'The engine inlines nested NatVis intrinsics textually, so the ' +
+        'QDateTime calendar math expands until it overflows the lldb-mi ' +
+        'command buffer and evaluation fails. Per-intrinsic evaluation is ' +
+        'the pending engine fix.',
       linux:
-        'NatVis expressions reference Windows-only private symbols ' +
-        '(e.g. Qt6Cored.dll!QDateTimePrivate), so GDB cannot evaluate the intrinsics ' +
-        '(priv(), status(), year(), month(), day(), RecZone views), producing long evaluation errors.',
+        'The engine inlines nested NatVis intrinsics textually, so the ' +
+        'QDateTime calendar math expands until it overflows the gdb/mi ' +
+        'command buffer and evaluation fails. Per-intrinsic evaluation is ' +
+        'the pending engine fix.',
       win32:
         'Qt debug info (PDB files) is now available, but DisplayString evaluation still fails ' +
         'and the debugger falls back to a raw "{d={...}}" representation. ' +

--- a/qt-cpp/test/debug-golden-entries.mts
+++ b/qt-cpp/test/debug-golden-entries.mts
@@ -1669,6 +1669,28 @@ const GOLDEN_ENTRY_DEFS: readonly GoldenEntryInput[] = [
     ]
   },
   {
+    name: 'guiTypes.qColorRgb',
+    type: 'QColor',
+    value: 'rgb(255, 0, 0)',
+    children: [
+      { name: '[alpha]', value: '255' },
+      { name: '[red]', value: '255' },
+      { name: '[green]', value: '0' },
+      { name: '[blue]', value: '0' }
+    ]
+  },
+  {
+    name: 'guiTypes.qColorRgba',
+    type: 'QColor',
+    value: 'rgba(10, 20, 30, 128)',
+    children: [
+      { name: '[alpha]', value: '128' },
+      { name: '[red]', value: '10' },
+      { name: '[green]', value: '20' },
+      { name: '[blue]', value: '30' }
+    ]
+  },
+  {
     name: 'guiTypes.qMatrix4x4',
     type: 'QMatrix4x4',
     value: '{ m11 = 2, m12 = 0, m13 = 0, m14 = 1, ... }',

--- a/qt-cpp/test/projectFolderNatvis/gui_types.h
+++ b/qt-cpp/test/projectFolderNatvis/gui_types.h
@@ -33,6 +33,10 @@ struct GuiTypes
     QVector3D qVector3D;
     QVector4D qVector4D;
 
+    // colors
+    QColor qColorRgb;
+    QColor qColorRgba;
+
     GuiTypes();
 };
 
@@ -53,6 +57,8 @@ inline GuiTypes::GuiTypes()
     , qVector2D(1.0f, 2.0f)
     , qVector3D(1.0f, 2.0f, 3.0f)
     , qVector4D(1.0f, 2.0f, 3.0f, 4.0f)
+    , qColorRgb(255, 0, 0)
+    , qColorRgba(10, 20, 30, 128)
 {
     // Image: make it non-trivial.
     qImageArgb32.fill(qRgba(10, 20, 30, 255));


### PR DESCRIPTION
Many knownProblem markers predate the natvis rework in debugging_helpers
(056aa28) and the MIEngine fixes in current cpptools; those rows now pass
and report KP*, i.e. their assertions are disabled for no reason.

- Drop the stale root and child markers on macOS/Linux; each row becomes
  a hard assertion again.
- Refresh the QDateTime knownProblem texts to the actual failure
  mechanism (inlined intrinsics overflow the MI command buffer).
- Add QColor golden coverage.

Every removal was verified as KP* on both Qt 6.9.2 and 6.10.1. Result:
zero FAIL and zero KP* on all three OS at both versions, except the
QPolygon item markers on Linux (kept: that formatting flickers). win32
markers are untouched.
