### PR TITLE
qt-core, webview: Add busy indicator when loading examples

### DIFF
--- a/qt-core/webview-ui/src/apps/ex-browser/main/ExMainView.svelte
+++ b/qt-core/webview-ui/src/apps/ex-browser/main/ExMainView.svelte
@@ -6,6 +6,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 <script lang="ts">
   import { type ExCategory } from '@shared/ex-browser';
   import EmptyState from '@/comps/EmptyState.svelte';
+  import LoadingMask from '@/comps/LoadingMask.svelte';
   import { exBrowser as texts } from '@/apps/texts';
 
   import './ExMainView.css';
@@ -28,6 +29,8 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
       .filter((e) => e.examples.length !== 0);
   });
 
+  const showBusyIndicator = $derived(ui.task.busy || (ui.state === 'starting'));
+
   function findExamples(category?: ExCategory) {
     if (category?.type === 'general') {
       const name = category?.name.trim() ?? '';
@@ -40,7 +43,11 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 <div data-area='main' class="flex-1 min-w-0 flex flex-col">
   {#if all.length === 0}
-    {@render emptyStateInfo()}
+    {#if showBusyIndicator}
+      {@render busyIndicator()}
+    {:else}
+      {@render emptyStateInfo()}
+    {/if}
   {:else}
     {#each all as { category, examples } (category)}
       {#if category.type === 'general' && examples.length !== 0}
@@ -70,4 +77,14 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
       {l}<br />
     {/each}
   </EmptyState>
+{/snippet}
+
+{#snippet busyIndicator()}
+  <LoadingMask
+    busy={true}
+    error={ui.task.error}
+    forceHidden={ui.task.isDebouncing}
+    busyText={texts.loading.busy}
+    closeText={texts.loading.close}
+  />
 {/snippet}

--- a/qt-core/webview-ui/src/apps/ex-browser/popovers/ExCatalogQtVersions.svelte
+++ b/qt-core/webview-ui/src/apps/ex-browser/popovers/ExCatalogQtVersions.svelte
@@ -29,6 +29,7 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
       onclick={async () => {
         if (!loading) {
           loading = true;
+          ui.popovers.catalog.visible = false;
           await viewlogic.selectPackage(p);
           loading = false;
         }

--- a/qt-core/webview-ui/src/apps/ex-browser/states.svelte.ts
+++ b/qt-core/webview-ui/src/apps/ex-browser/states.svelte.ts
@@ -9,6 +9,7 @@ import {
 } from '@shared/ex-browser';
 
 import * as NewItemForm from '@/comps/NewItemForm.logic.svelte';
+import { TaskBusyRunner } from '@/comps/TaskBusyRunner.svelte';
 import * as VscodeThemeMonitor from '@/comps/VscodeThemeMonitor.svelte';
 
 export type ViewMode = 'grid' | 'list';
@@ -21,6 +22,8 @@ export const data = $state({
 });
 
 export const ui = $state({
+  state: 'starting' as 'starting' | 'running' | 'error',
+  task: new TaskBusyRunner(),
   grid: undefined as HTMLDivElement | undefined,
   list: undefined as HTMLDivElement | undefined,
   theme: VscodeThemeMonitor.createController(),

--- a/qt-core/webview-ui/src/apps/ex-browser/viewlogic.svelte.ts
+++ b/qt-core/webview-ui/src/apps/ex-browser/viewlogic.svelte.ts
@@ -22,19 +22,25 @@ import { CommandId, isErrorResponse } from '@shared/message';
 import { data, ui } from './states.svelte';
 
 export async function onAppMount() {
-  ui.sidebar.newProject.input.onEvent(onNewProjectFormEvent);
-  ui.sidebar.newProject.input.onValidate(validateNewProjectForm);
-  ui.theme.monitor.start();
+  try {
+    ui.sidebar.newProject.input.onEvent(onNewProjectFormEvent);
+    ui.sidebar.newProject.input.onValidate(validateNewProjectForm);
+    ui.theme.monitor.start();
 
-  await loadConfigs();
-  await loadPackages();
+    await loadConfigs();
+    await loadPackages();
 
-  if (data.packages[0]) {
-    await selectPackage(data.packages[0]);
+    if (data.packages[0]) {
+      await selectPackage(data.packages[0]);
+    }
+
+    setEventListenerEnabled(true);
+    ui.filter.searchInputEl?.focus();
+    ui.state = 'running';
+  } catch (e) {
+    ui.state = 'error';
+    throw e;
   }
-
-  setEventListenerEnabled(true);
-  ui.filter.searchInputEl?.focus();
 }
 
 export async function onAppDestroy() {
@@ -235,29 +241,33 @@ async function loadPackages() {
 }
 
 async function loadExamples(reason: 'selectPackage' | '' = '') {
-  const r = await vscode.post(CommandId.ExBrowserGetExamples, {
-    query: createFilterQuery(ui.filter.searchInput, ui.filter.tags),
-    category: $state.snapshot(ui.filter.category)
-  });
-
-  if (Array.isArray(r) && r.every(isExEntry)) {
-    data.examples = r;
-  }
-
-  if (reason === 'selectPackage') {
-    selectExample(undefined);
-    return;
-  }
-
-  if (ui.selected.example) {
-    const hit = data.examples.find((e) => {
-      return _.isEqual(ui.selected.example, e);
+  const task = async () => {
+    const r = await vscode.post(CommandId.ExBrowserGetExamples, {
+      query: createFilterQuery(ui.filter.searchInput, ui.filter.tags),
+      category: $state.snapshot(ui.filter.category)
     });
 
-    if (!hit) {
+    if (Array.isArray(r) && r.every(isExEntry)) {
+      data.examples = r;
+    }
+
+    if (reason === 'selectPackage') {
       selectExample(undefined);
+      return;
+    }
+
+    if (ui.selected.example) {
+      const hit = data.examples.find((e) => {
+        return _.isEqual(ui.selected.example, e);
+      });
+
+      if (!hit) {
+        selectExample(undefined);
+      }
     }
   }
+
+  await ui.task.run(task, { debounceTime_ms: 0 });
 }
 
 function findCategoryByName(name: string) {

--- a/qt-core/webview-ui/src/apps/texts.ts
+++ b/qt-core/webview-ui/src/apps/texts.ts
@@ -230,6 +230,11 @@ export const exBrowser = {
   searchBox: {
     defaultPlaceholder: 'Search in examples...',
     placeholder: (category: string) => `Search in '${category}'`
+  },
+
+  loading: {
+    busy: 'Loading...',
+    close: 'Close'
   }
 }
 

--- a/qt-core/webview-ui/src/comps/TaskBusyRunner.svelte.ts
+++ b/qt-core/webview-ui/src/comps/TaskBusyRunner.svelte.ts
@@ -9,7 +9,7 @@ export class TaskBusyRunner {
   private _busy = $state(false);
   private _error = $state(undefined as unknown);
   private _isDebouncing = $state(false);
-  private _pendingTimer = $state(null as NodeJS.Timeout | null);
+  private _pendingTimer = $state(null as ReturnType<typeof setTimeout> | null);
 
   get busy() {
     return this._busy;

--- a/qt-core/webview-ui/src/styles/components/others.css
+++ b/qt-core/webview-ui/src/styles/components/others.css
@@ -56,3 +56,14 @@ SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
   white-space: normal;
   word-break: break-word;
 }
+
+.qt-spinner {
+  color: transparent;
+  fill: var(--qt-accent-blue);
+}
+
+.qt-spinner-text {
+  color: var(--qt-text-default);
+  background: none;
+  font-size: var(--qt-font-m);
+}


### PR DESCRIPTION
For better UX, the example browser now shows a proper loading animation instead of displaying error text while examples load.

Task-number: [VSCODEEXT-351](https://qt-project.atlassian.net/browse/VSCODEEXT-351)
