### PR TITLE
qt-qml: Download the trace viewer from the latest official release

### DIFF
--- a/qt-qml/esbuild.mjs
+++ b/qt-qml/esbuild.mjs
@@ -16,6 +16,7 @@ await runEsbuild({
     './test/suite/command.test.mts',
     './test/suite/installer.test.mts',
     './test/suite/integrity.test.mts',
+    './test/suite/traceviewer.test.mts',
     './test/runTest.qml-debug.mts',
     './test/runTestHelper.mts',
     './test/suite/index-qml-debug.mts',

--- a/qt-qml/src/traceviewer/constants.mts
+++ b/qt-qml/src/traceviewer/constants.mts
@@ -1,21 +1,58 @@
 // Copyright (C) 2026 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
-import { IsMacOS } from 'qt-lib';
+import { IsLinux, IsMacOS, IsWindows } from 'qt-lib';
 import { EXTENSION_ID } from '@/constants.js';
 
 // Note
 // official: <host>/official_releases/qtcreator/latest/installer_source;
-// snapshot: <host>/snapshots/qtcreator/21.0/21.0.0-beta1/installer_source/latest
+// snapshot: <host>/snapshots/qtcreator/<ver>/<ver-full>/installer_source/latest
 export const DOWNLOAD_HOST = 'https://download.qt.io';
 export const DOWNLOAD_DIR_BASE =
-  '/snapshots/qtcreator/21.0/21.0.0-beta1/installer_source/latest';
+  '/official_releases/qtcreator/latest/installer_source';
 export const DOWNLOAD_CONTENT_TYPE = 'application/zip';
-export const DOWNLOAD_FILE = IsMacOS
-  ? 'qmltraceviewer-signed.zip'
-  : 'qmltraceviewer.zip';
 
-export const EXE_NAME = 'qmltraceviewer';
+export interface PackageCandidate {
+  // package file name below <download-dir>/<os>_<arch>/
+  file: string;
+  // executable path relative to the extracted package
+  exeRelPath: string;
+}
+
+// The tool was renamed from "qmltraceviewer" (up to Qt Creator 20) to
+// "qtprofiler" (Qt Creator 21 and later), which renamed both the package
+// and the executable inside it. Candidates are tried in order, newest name
+// first, so the download keeps working with whichever release "latest"
+// serves. Drop the old name once Qt Creator 21 is the oldest release here.
+export const PACKAGE_CANDIDATES: PackageCandidate[] = IsMacOS
+  ? [
+      {
+        file: 'qtprofiler-signed.zip',
+        exeRelPath: 'Qt Profiler.app/Contents/MacOS/Qt Profiler'
+      },
+      {
+        file: 'qmltraceviewer-signed.zip',
+        exeRelPath: 'qmltraceviewer.app/Contents/MacOS/qmltraceviewer'
+      }
+    ]
+  : IsWindows
+    ? [
+        { file: 'qtprofiler.zip', exeRelPath: 'bin\\qtprofiler.exe' },
+        { file: 'qmltraceviewer.zip', exeRelPath: 'bin\\qmltraceviewer.exe' }
+      ]
+    : IsLinux
+      ? [
+          {
+            file: 'qtprofiler.zip',
+            exeRelPath: 'libexec/qtcreator/qtprofiler'
+          },
+          {
+            file: 'qmltraceviewer.zip',
+            exeRelPath: 'libexec/qtcreator/qmltraceviewer'
+          }
+        ]
+      : [];
+
 export const INSTALL_DIR_NAME = 'qmltraceviewer';
 export const INSTALL_INFO_FILE = 'installation.json';
 export const RELEASE_INFO_FILE = 'release.json';

--- a/qt-qml/src/traceviewer/downloader.mts
+++ b/qt-qml/src/traceviewer/downloader.mts
@@ -11,9 +11,11 @@ import { pipeline } from 'node:stream/promises';
 
 import { IsMacOS, IsLinux, IsWindows, Isx64, IsArm64 } from 'qt-lib';
 import { Progress, ProgressUpdater } from './helpers/progress.mts';
+import { createWrappedLogger } from './helpers/logger-wrapper.ts';
 import * as consts from './constants.mts';
 
 type WebStream = import('node:stream/web').ReadableStream;
+const logger = createWrappedLogger('traceviewer-downloader');
 
 export interface DownloadResult {
   result: 'downloaded' | 'up-to-date';
@@ -24,8 +26,9 @@ export interface DownloadResult {
 }
 
 export async function downloadWithProgress(latestId: string | undefined) {
-  const sourceUrl = resolvePackageUrl();
+  const sourceUrls = resolvePackageUrls();
   const downloadedFilePath = createDownloadFilePath();
+  let sourceUrl = '';
   let id = '';
   let isUpToDate = false;
 
@@ -42,7 +45,8 @@ export async function downloadWithProgress(latestId: string | undefined) {
       abortController.abort();
     });
 
-    const res = await fetchAndCheck(sourceUrl, abortOptions);
+    const { url, res } = await fetchFirstAvailable(sourceUrls, abortOptions);
+    sourceUrl = url;
     id = createIdFromHeaders(res.headers);
     if (latestId && latestId === id) {
       isUpToDate = true;
@@ -78,7 +82,7 @@ export async function downloadWithProgress(latestId: string | undefined) {
 }
 
 // helpers
-function resolvePackageUrl() {
+export function resolvePackageUrls() {
   const os_ = IsMacOS ? 'mac' : IsWindows ? 'windows' : IsLinux ? 'linux' : '';
   const arch = Isx64 || IsMacOS ? 'x64' : IsArm64 ? 'arm64' : '';
   if (!os_ || !arch) {
@@ -86,12 +90,44 @@ function resolvePackageUrl() {
   }
 
   const base = vscode.Uri.parse(consts.DOWNLOAD_HOST);
-  return vscode.Uri.joinPath(
-    base,
-    consts.DOWNLOAD_DIR_BASE,
-    `${os_}_${arch}`,
-    consts.DOWNLOAD_FILE
-  ).toString();
+  return consts.PACKAGE_CANDIDATES.map((candidate) =>
+    vscode.Uri.joinPath(
+      base,
+      consts.DOWNLOAD_DIR_BASE,
+      `${os_}_${arch}`,
+      candidate.file
+    ).toString()
+  );
+}
+
+export async function fetchFirstAvailable(
+  urls: string[],
+  init?: RequestInit,
+  fetchFn: (
+    url: string,
+    init?: RequestInit
+  ) => Promise<Response> = fetchAndCheck
+) {
+  const failures: string[] = [];
+  for (const url of urls) {
+    try {
+      return { url, res: await fetchFn(url, init) };
+    } catch (e) {
+      if (init?.signal?.aborted) {
+        throw e;
+      }
+
+      const message = e instanceof Error ? e.message : String(e);
+      failures.push(`${url}: ${message}`);
+      logger
+        .text('Package candidate is not available')
+        .data('url', url)
+        .data('error', message)
+        .warn();
+    }
+  }
+
+  throw new Error(`All download candidates failed: ${failures.join('; ')}`);
 }
 
 function createDownloadFilePath() {
@@ -134,19 +170,24 @@ async function fetchHttpsOnly(url: string, init?: RequestInit) {
 
 async function fetchAndCheck(url: string, init?: RequestInit) {
   const res = await fetchHttpsOnly(url, init);
+  const fail = async (message: string) => {
+    await res.body?.cancel();
+    return new Error(message);
+  };
+
   if (!res.ok) {
-    throw new Error(`Invalid status code: ${res.statusText}`);
+    throw await fail(`Invalid status code: ${res.statusText}`);
   }
 
   const contentType = res.headers.get('content-type');
   if (contentType !== consts.DOWNLOAD_CONTENT_TYPE) {
-    throw new Error(`Invalid content type: ${contentType ?? '-'}`);
+    throw await fail(`Invalid content type: ${contentType ?? '-'}`);
   }
 
   const contentLength = res.headers.get('content-length');
   const maxBytes = Number.parseInt(contentLength ?? '0');
   if (maxBytes <= 0) {
-    throw new Error(`Invalid content length: ${String(maxBytes)}`);
+    throw await fail(`Invalid content length: ${String(maxBytes)}`);
   }
 
   return res;

--- a/qt-qml/src/traceviewer/downloader.mts
+++ b/qt-qml/src/traceviewer/downloader.mts
@@ -110,10 +110,14 @@ export async function fetchFirstAvailable(
 ) {
   const failures: string[] = [];
   for (const url of urls) {
+    logger.text('Trying package candidate').data('url', url).info();
     try {
-      return { url, res: await fetchFn(url, init) };
+      const res = await fetchFn(url, init);
+      logger.text('Package candidate is available').data('url', url).info();
+      return { url, res };
     } catch (e) {
       if (init?.signal?.aborted) {
+        logger.text('Download cancelled').data('url', url).info();
         throw e;
       }
 

--- a/qt-qml/src/traceviewer/installation-manager.mts
+++ b/qt-qml/src/traceviewer/installation-manager.mts
@@ -6,7 +6,6 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { spawn } from 'child_process';
 
-import { IsMacOS, IsLinux, IsWindows, OSExeSuffix } from 'qt-lib';
 import { fsDir } from './helpers/fs-utils.ts';
 import { createWrappedLogger } from './helpers/logger-wrapper.ts';
 import * as consts from './constants.mts';
@@ -96,12 +95,16 @@ export class InstalledRelease {
   }
 
   get execPath() {
-    const subdir = findExeDir();
-    if (subdir === '') {
+    const candidates = consts.PACKAGE_CANDIDATES.map((candidate) =>
+      path.join(this.filesDir, candidate.exeRelPath)
+    );
+
+    const first = candidates[0];
+    if (!first) {
       throw new Error('Cannot determine binary path for the current platform');
     }
 
-    return path.join(this.filesDir, subdir, consts.EXE_NAME + OSExeSuffix);
+    return candidates.find((exe) => fs.existsSync(exe)) ?? first;
   }
 
   public async save(downloadSrc: string) {
@@ -123,7 +126,7 @@ export class InstalledRelease {
       path.dirname(execPath)
     );
 
-    // expected output: "QmlTraceViewer 19.0.82"
+    // expected output: "QmlTraceViewer 20.0.0" or "QtProfiler 21.0.0"
     const output = stdout.trim().split(' ');
     return output[1] ?? '';
   }
@@ -181,18 +184,6 @@ function resolveInstallBaseDir(context: Context) {
 
 function resolveInstallInfoFilePath(context: Context) {
   return path.join(resolveInstallBaseDir(context), consts.INSTALL_INFO_FILE);
-}
-
-function findExeDir() {
-  if (IsMacOS) {
-    return 'qmltraceviewer.app/Contents/MacOS';
-  }
-
-  if (IsLinux) {
-    return 'libexec/qtcreator';
-  }
-
-  return IsWindows ? 'bin' : '';
 }
 
 async function spawnAsync(

--- a/qt-qml/src/traceviewer/installation-manager.mts
+++ b/qt-qml/src/traceviewer/installation-manager.mts
@@ -104,7 +104,18 @@ export class InstalledRelease {
       throw new Error('Cannot determine binary path for the current platform');
     }
 
-    return candidates.find((exe) => fs.existsSync(exe)) ?? first;
+    const found = candidates.find((exe) => fs.existsSync(exe));
+    if (found) {
+      logger.text('Resolved executable').data('path', found).debug();
+      return found;
+    }
+
+    logger
+      .text('No executable on disk, defaulting to the newest layout')
+      .data('path', first)
+      .debug();
+
+    return first;
   }
 
   public async save(downloadSrc: string) {

--- a/qt-qml/test/suite/index.mts
+++ b/qt-qml/test/suite/index.mts
@@ -15,7 +15,7 @@ export function run(): Promise<void> {
   const testsRoot = path.resolve(__dirname);
   return new Promise((c, e) => {
     const testFiles = new glob.Glob(
-      '{extension,command,installer,integrity,versioned-installations}.test.js',
+      '{extension,command,installer,integrity,traceviewer,versioned-installations}.test.js',
       {
         cwd: testsRoot
       }

--- a/qt-qml/test/suite/traceviewer.test.mts
+++ b/qt-qml/test/suite/traceviewer.test.mts
@@ -1,0 +1,168 @@
+// Copyright (C) 2026 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import * as consts from '@/traceviewer/constants.mjs';
+import {
+  fetchFirstAvailable,
+  resolvePackageUrls
+} from '@/traceviewer/downloader.mjs';
+import { InstalledRelease } from '@/traceviewer/installation-manager.mjs';
+
+const OFFICIAL_LATEST =
+  'https://download.qt.io/official_releases/qtcreator/latest/installer_source/';
+
+const okResponse = () => ({ ok: true }) as unknown as Response;
+
+describe('Trace viewer package fallback', () => {
+  it('resolves every package URL from the official latest release dir', () => {
+    const urls = resolvePackageUrls();
+    expect(urls.length).to.be.greaterThan(1);
+    for (const url of urls) {
+      expect(url.startsWith(OFFICIAL_LATEST)).to.equal(true);
+      expect(url).to.match(/\/(linux|mac|windows)_(x64|arm64)\/[^/]+\.zip$/);
+    }
+  });
+
+  it('tries the qtprofiler package before the qmltraceviewer package', () => {
+    const urls = resolvePackageUrls();
+    expect(path.basename(urls[0] ?? '')).to.contain('qtprofiler');
+    expect(path.basename(urls[1] ?? '')).to.contain('qmltraceviewer');
+  });
+
+  it('matches the published package layout for this platform', () => {
+    const layouts: Record<string, consts.PackageCandidate[]> = {
+      darwin: [
+        {
+          file: 'qtprofiler-signed.zip',
+          exeRelPath: 'Qt Profiler.app/Contents/MacOS/Qt Profiler'
+        },
+        {
+          file: 'qmltraceviewer-signed.zip',
+          exeRelPath: 'qmltraceviewer.app/Contents/MacOS/qmltraceviewer'
+        }
+      ],
+      win32: [
+        {
+          file: 'qtprofiler.zip',
+          exeRelPath: path.join('bin', 'qtprofiler.exe')
+        },
+        {
+          file: 'qmltraceviewer.zip',
+          exeRelPath: path.join('bin', 'qmltraceviewer.exe')
+        }
+      ],
+      linux: [
+        {
+          file: 'qtprofiler.zip',
+          exeRelPath: 'libexec/qtcreator/qtprofiler'
+        },
+        {
+          file: 'qmltraceviewer.zip',
+          exeRelPath: 'libexec/qtcreator/qmltraceviewer'
+        }
+      ]
+    };
+
+    const expected = layouts[process.platform];
+    if (!expected) {
+      return;
+    }
+    expect(consts.PACKAGE_CANDIDATES).to.deep.equal(expected);
+  });
+
+  it('falls back to the next package when the first download fails', async () => {
+    const calls: string[] = [];
+    const fetchFn = (url: string) => {
+      calls.push(url);
+      if (calls.length === 1) {
+        return Promise.reject(new Error('Invalid status code: Not Found'));
+      }
+      return Promise.resolve(okResponse());
+    };
+
+    const r = await fetchFirstAvailable(
+      ['first', 'second'],
+      undefined,
+      fetchFn
+    );
+    expect(r.url).to.equal('second');
+    expect(calls).to.deep.equal(['first', 'second']);
+  });
+
+  it('reports every attempted URL when all downloads fail', async () => {
+    const fetchFn = (url: string) =>
+      Promise.reject(new Error(`no ${url} here`));
+
+    try {
+      await fetchFirstAvailable(['first', 'second'], undefined, fetchFn);
+      expect.fail('fetchFirstAvailable should have thrown');
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      expect(message).to.contain('first');
+      expect(message).to.contain('second');
+    }
+  });
+
+  it('stops trying candidates once the download is cancelled', async () => {
+    const abortController = new AbortController();
+    let calls = 0;
+    const fetchFn = () => {
+      calls++;
+      abortController.abort();
+      return Promise.reject(new Error('aborted'));
+    };
+
+    try {
+      await fetchFirstAvailable(
+        ['first', 'second'],
+        { signal: abortController.signal },
+        fetchFn
+      );
+      expect.fail('fetchFirstAvailable should have thrown');
+    } catch (e) {
+      expect(e).to.be.instanceOf(Error);
+    }
+    expect(calls).to.equal(1);
+  });
+
+  describe('executable resolution', () => {
+    let baseDir: string;
+    let release: InstalledRelease;
+    let candidates: string[];
+
+    const createExe = (exePath: string) => {
+      fs.mkdirSync(path.dirname(exePath), { recursive: true });
+      fs.writeFileSync(exePath, 'not a real executable');
+    };
+
+    beforeEach(() => {
+      baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'traceviewer-test-'));
+      release = new InstalledRelease(baseDir, '1');
+      candidates = consts.PACKAGE_CANDIDATES.map((c) =>
+        path.join(release.filesDir, c.exeRelPath)
+      );
+    });
+
+    afterEach(() => {
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    it('resolves the executable of an old qmltraceviewer package', () => {
+      const oldExe = candidates[1] ?? '';
+      createExe(oldExe);
+      expect(release.execPath).to.equal(oldExe);
+    });
+
+    it('prefers the qtprofiler executable when both are present', () => {
+      for (const exe of candidates) {
+        createExe(exe);
+      }
+      expect(release.execPath).to.equal(candidates[0]);
+    });
+  });
+});


### PR DESCRIPTION
The trace viewer download pinned the 21.0.0-beta1 snapshot directory,
which disappears with every new Qt Creator release, and the package in
it was renamed from qmltraceviewer.zip to qtprofiler.zip, so the
download failed with a 404.

Resolve the package from official_releases/qtcreator/latest instead and
try both package generations in order, qtprofiler first and
qmltraceviewer as the fallback, until one of them downloads. The
executable is resolved the same way, since the rename also moved the
binary. On macOS it moved from qmltraceviewer.app/Contents/MacOS/
qmltraceviewer to "Qt Profiler.app/Contents/MacOS/Qt Profiler", on
Linux and Windows only the file name changed. A failed candidate is
logged and its response body cancelled, because the qtprofiler name
returns 404 on every download until Qt Creator 21 is released.

Fixes: [VSCODEEXT-354](https://qt-project.atlassian.net/browse/VSCODEEXT-354)
