### PR TITLE
qt-lib, workflow: Suppress sending telemetry during testing and development

### DIFF
--- a/.github/workflows/qt-tests.yml
+++ b/.github/workflows/qt-tests.yml
@@ -58,6 +58,8 @@ jobs:
       DBUS_SESSION_BUS_ADDRESS: "disabled:"
       NO_AT_BRIDGE: "1"
       TEST_SUITE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_suite || 'all' }}
+      QT_SUPPRESS_TELEMETRY: "1"
+      QT_LOG_SUPPRESSED_TELEMETRY: "1"
 
     steps:
       # Check out your branch code into the runner

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,11 @@
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}/qt-core"],
       "outFiles": ["${workspaceFolder}/qt-core/out/**/*.js"],
-      "preLaunchTask": "npm qt-core watch + vite:start"
+      "preLaunchTask": "npm qt-core watch + vite:start",
+      "env": {
+        "QT_SUPPRESS_TELEMETRY": "1",
+        "QT_LOG_SUPPRESSED_TELEMETRY": "1"
+      }
     },
     {
       "name": "Run qt-cpp",
@@ -19,7 +23,11 @@
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}/qt-cpp"],
       "outFiles": ["${workspaceFolder}/qt-cpp/out/**/*.js"],
-      "preLaunchTask": "npm qt-cpp watch"
+      "preLaunchTask": "npm qt-cpp watch",
+      "env": {
+        "QT_SUPPRESS_TELEMETRY": "1",
+        "QT_LOG_SUPPRESSED_TELEMETRY": "1"
+      }
     },
     {
       "name": "Run qt-qml",
@@ -27,7 +35,11 @@
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}/qt-qml"],
       "outFiles": ["${workspaceFolder}/qt-qml/out/**/*.js"],
-      "preLaunchTask": "npm qt-qml watch"
+      "preLaunchTask": "npm qt-qml watch",
+      "env": {
+        "QT_SUPPRESS_TELEMETRY": "1",
+        "QT_LOG_SUPPRESSED_TELEMETRY": "1"
+      }
     },
     {
       "name": "Run qt-ui",
@@ -44,7 +56,11 @@
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}/qt-python"],
       "outFiles": ["${workspaceFolder}/qt-python/out/**/*.js"],
-      "preLaunchTask": "npm qt-python watch"
+      "preLaunchTask": "npm qt-python watch",
+      "env": {
+        "QT_SUPPRESS_TELEMETRY": "1",
+        "QT_LOG_SUPPRESSED_TELEMETRY": "1"
+      }
     },
     {
       "name": "Run Extension Tests qt-core",
@@ -52,11 +68,15 @@
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "args": [
-              "--extensionDevelopmentPath=${workspaceFolder}/qt-core",
-              "--extensionTestsPath=${workspaceFolder}/qt-core/out/test/suite/index.js"
+        "--extensionDevelopmentPath=${workspaceFolder}/qt-core",
+        "--extensionTestsPath=${workspaceFolder}/qt-core/out/test/suite/index.js"
       ],
       "outFiles": ["${workspaceFolder}/qt-core/out/test/**/*.js"],
-      "preLaunchTask": "npm qt-core watch and test"
+      "preLaunchTask": "npm qt-core watch and test",
+      "env": {
+        "QT_SUPPRESS_TELEMETRY": "1",
+        "QT_LOG_SUPPRESSED_TELEMETRY": "1"
+      }
     },
     {
       "name": "Run Extension Tests qt-cpp",
@@ -64,11 +84,15 @@
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "args": [
-              "--extensionDevelopmentPath=${workspaceFolder}/qt-cpp",
-              "--extensionTestsPath=${workspaceFolder}/qt-cpp/out/test/suite/index"
+        "--extensionDevelopmentPath=${workspaceFolder}/qt-cpp",
+        "--extensionTestsPath=${workspaceFolder}/qt-cpp/out/test/suite/index"
       ],
       "outFiles": ["${workspaceFolder}/qt-cpp/out/test/**/*.js"],
-      "preLaunchTask": "npm qt-cpp watch and test"
+      "preLaunchTask": "npm qt-cpp watch and test",
+      "env": {
+        "QT_SUPPRESS_TELEMETRY": "1",
+        "QT_LOG_SUPPRESSED_TELEMETRY": "1"
+      }
     },
     {
       "name": "Run Extension Tests qt-python",
@@ -76,18 +100,24 @@
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "args": [
-              "--extensionDevelopmentPath=${workspaceFolder}/qt-python",
-              "--extensionTestsPath=${workspaceFolder}/qt-python/out/test/suite/index"
+        "--extensionDevelopmentPath=${workspaceFolder}/qt-python",
+        "--extensionTestsPath=${workspaceFolder}/qt-python/out/test/suite/index"
       ],
       "outFiles": ["${workspaceFolder}/qt-python/out/test/**/*.js"],
-      "preLaunchTask": "npm qt-python watch and test"
+      "preLaunchTask": "npm qt-python watch and test",
+      "env": {
+        "QT_SUPPRESS_TELEMETRY": "1",
+        "QT_LOG_SUPPRESSED_TELEMETRY": "1"
+      }
     },
     {
       "name": "Run Extension Tests qt-cpp build",
       "type": "extensionHost",
       "request": "launch",
       "env": {
-        "QT_TEST_QT_ROOT": "${config:qt-core.qtInstallationRoot}"
+        "QT_TEST_QT_ROOT": "${config:qt-core.qtInstallationRoot}",
+        "QT_SUPPRESS_TELEMETRY": "1",
+        "QT_LOG_SUPPRESSED_TELEMETRY": "1"
       },
       "runtimeExecutable": "${execPath}",
       "args": [
@@ -107,6 +137,8 @@
       "request": "launch",
       "env": {
         "QT_TEST_QT_ROOT": "${config:qt-core.qtInstallationRoot}",
+        "QT_SUPPRESS_TELEMETRY": "1",
+        "QT_LOG_SUPPRESSED_TELEMETRY": "1"
       },
       "runtimeExecutable": "${execPath}",
       "args": [
@@ -132,7 +164,9 @@
       "outputCapture": "std",
       "console": "integratedTerminal",
       "env": {
-        "QT_TEST_QT_ROOT": "${config:qt-core.qtInstallationRoot}"
+        "QT_TEST_QT_ROOT": "${config:qt-core.qtInstallationRoot}",
+        "QT_SUPPRESS_TELEMETRY": "1",
+        "QT_LOG_SUPPRESSED_TELEMETRY": "1"
       }
     },
     {
@@ -141,11 +175,15 @@
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "args": [
-              "--extensionDevelopmentPath=${workspaceFolder}/qt-qml",
-              "--extensionTestsPath=${workspaceFolder}/qt-qml/out/test/suite/index"
+        "--extensionDevelopmentPath=${workspaceFolder}/qt-qml",
+        "--extensionTestsPath=${workspaceFolder}/qt-qml/out/test/suite/index"
       ],
       "outFiles": ["${workspaceFolder}/qt-qml/out/test/**/*.js"],
-      "preLaunchTask": "npm qt-qml watch and test"
+      "preLaunchTask": "npm qt-qml watch and test",
+      "env": {
+        "QT_SUPPRESS_TELEMETRY": "1",
+        "QT_LOG_SUPPRESSED_TELEMETRY": "1"
+      }
     },
     {
       "name": "Run Extension Tests qt-ui",
@@ -153,14 +191,16 @@
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "args": [
-              "--extensionDevelopmentPath=${workspaceFolder}/qt-ui",
-              "--extensionTestsPath=${workspaceFolder}/qt-ui/out/test/suite/index"
+        "--extensionDevelopmentPath=${workspaceFolder}/qt-ui",
+        "--extensionTestsPath=${workspaceFolder}/qt-ui/out/test/suite/index"
       ],
       "env": {
-        "QT_TESTING": "1"
+        "QT_TESTING": "1",
+        "QT_SUPPRESS_TELEMETRY": "1",
+        "QT_LOG_SUPPRESSED_TELEMETRY": "1"
       },
       "outFiles": ["${workspaceFolder}/qt-ui/out/test/**/*.js"],
-      "preLaunchTask": "npm qt-ui watch and test"
+      "preLaunchTask": "npm qt-ui watch and test",
     }
   ]
 }

--- a/qt-lib/src/telemetry.ts
+++ b/qt-lib/src/telemetry.ts
@@ -2,152 +2,118 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only
 
 import * as vscode from 'vscode';
+import * as process from 'process';
 import {
-  TelemetryEventMeasurements,
+  TelemetryReporter,
   TelemetryEventProperties,
-  TelemetryReporter
+  TelemetryEventMeasurements
 } from '@vscode/extension-telemetry';
 
-export type { TelemetryEventProperties };
-export { TelemetryReporter };
+type Props = TelemetryEventProperties;
+type Measures = TelemetryEventMeasurements;
 
 const globalConnectionString =
   'InstrumentationKey=09d5f9a1-0532-4146-b158-a653220b28b6;IngestionEndpoint=https://germanywestcentral-1.in.applicationinsights.azure.com/;LiveEndpoint=https://germanywestcentral.livediagnostics.monitor.azure.com/;ApplicationId=8758b8d8-22d0-459d-b1b4-1689a3a350d5';
-export let reporter: TelemetryReporter;
-
-enum EventTypes {
-  event = 'event',
-  rawEvent = 'rawEvent',
-  dangerousEvent = 'dangerousEvent',
-  errorEvent = 'error',
-  dangerousErrorEvent = 'dangerousError'
-}
 
 class Telemetry {
-  reporter: TelemetryReporter | undefined;
-  activate(context: vscode.ExtensionContext, connectionString?: string) {
-    this.reporter = new TelemetryReporter(
+  private _reporter: TelemetryReporter | undefined;
+  private _context: vscode.ExtensionContext | undefined;
+
+  public activate(context: vscode.ExtensionContext, connectionString?: string) {
+    this._reporter = new TelemetryReporter(
       connectionString ?? globalConnectionString,
       undefined,
       { ignoreUnhandledErrors: true }
     );
-    context.subscriptions.push(this.reporter);
+
+    this._context = context;
+    this._context.subscriptions.push(this._reporter);
   }
-  sendAction(
-    actionName: string,
-    properties?: TelemetryEventProperties,
-    measurements?: TelemetryEventMeasurements
-  ) {
-    this.send(
-      EventTypes.event,
-      `action.${actionName}.triggered`,
-      properties,
-      measurements
-    );
+
+  public dispose() {
+    if (this._reporter) {
+      void this._reporter.dispose();
+    }
   }
-  sendConfig(
-    configName: string,
-    properties?: TelemetryEventProperties,
-    measurements?: TelemetryEventMeasurements
-  ) {
-    this.send(
-      EventTypes.event,
-      `config.${configName}.triggered`,
-      properties,
-      measurements
-    );
+
+  public sendAction(actionName: string, p?: Props, m?: Measures) {
+    const name = `action.${actionName}.triggered`;
+    this._report('event', name, p, m);
   }
-  sendEvent(
-    eventName: string,
-    properties?: TelemetryEventProperties,
-    measurements?: TelemetryEventMeasurements
-  ) {
-    this.send(EventTypes.event, eventName, properties, measurements);
+
+  public sendConfig(configName: string, p?: Props, m?: Measures) {
+    const name = `config.${configName}.triggered`;
+    this._report('event', name, p, m);
   }
-  sendRawEvent(
-    eventName: string,
-    properties?: TelemetryEventProperties,
-    measurements?: TelemetryEventMeasurements
-  ) {
-    this.send(EventTypes.rawEvent, eventName, properties, measurements);
+
+  public sendEvent(name: string, p?: Props, m?: Measures) {
+    this._report('event', name, p, m);
   }
-  sendDangerousEvent(
-    eventName: string,
-    properties?: TelemetryEventProperties,
-    measurements?: TelemetryEventMeasurements
-  ) {
-    this.send(EventTypes.dangerousEvent, eventName, properties, measurements);
+
+  public sendRawEvent(name: string, p?: Props, m?: Measures) {
+    this._report('raw', name, p, m);
   }
-  sendErrorEvent(
-    eventName: string,
-    properties?: TelemetryEventProperties,
-    measurements?: TelemetryEventMeasurements
-  ) {
-    this.send(EventTypes.errorEvent, eventName, properties, measurements);
+
+  public sendDangerousEvent(name: string, p?: Props, m?: Measures) {
+    this._report('dangerous', name, p, m);
   }
-  sendDangerousErrorEvent(
-    eventName: string,
-    properties?: TelemetryEventProperties,
-    measurements?: TelemetryEventMeasurements
-  ) {
-    this.send(
-      EventTypes.dangerousErrorEvent,
-      eventName,
-      properties,
-      measurements
-    );
+
+  public sendDangerousErrorEvent(name: string, p?: Props, m?: Measures) {
+    this._report('dangerousError', name, p, m);
   }
-  private send(
-    eventType: EventTypes,
-    eventName: string,
-    properties?: TelemetryEventProperties,
-    measurements?: TelemetryEventMeasurements
+
+  private _report(
+    kind: 'event' | 'raw' | 'error' | 'dangerous' | 'dangerousError',
+    name: string,
+    props?: Props,
+    measures?: Measures
   ) {
-    if (!this.reporter) {
+    // Note:
+    // we ignore telemetry when the environment says so.
+    // This is useful when running tests or developing locally,
+    // to avoid tainting telemetry data with fake values.
+    if (process.env.QT_SUPPRESS_TELEMETRY === '1') {
+      if (process.env.QT_LOG_SUPPRESSED_TELEMETRY === '1') {
+        console.log(
+          'Telemetry suppressed:',
+          [
+            `extension = '${this._context?.extension.id ?? ''}'`,
+            `name = '${name}'`,
+            `kind = '${kind}'`
+          ].join(', ')
+        );
+      }
+      return;
+    }
+
+    if (!this._reporter) {
       throw new Error('Telemetry reporter not initialized');
     }
 
-    switch (eventType) {
-      case EventTypes.event:
-        this.reporter.sendTelemetryEvent(eventName, properties, measurements);
+    switch (kind) {
+      case 'event':
+        this._reporter.sendTelemetryEvent(name, props, measures);
         break;
-      case EventTypes.rawEvent:
-        this.reporter.sendRawTelemetryEvent(
-          eventName,
-          properties,
-          measurements
-        );
+
+      case 'raw':
+        this._reporter.sendRawTelemetryEvent(name, props, measures);
         break;
-      case EventTypes.dangerousEvent:
-        this.reporter.sendDangerousTelemetryEvent(
-          eventName,
-          properties,
-          measurements
-        );
+
+      case 'error':
+        this._reporter.sendTelemetryErrorEvent(name, props, measures);
         break;
-      case EventTypes.errorEvent:
-        this.reporter.sendTelemetryErrorEvent(
-          eventName,
-          properties,
-          measurements
-        );
+
+      case 'dangerous':
+        this._reporter.sendDangerousTelemetryEvent(name, props, measures);
         break;
-      case EventTypes.dangerousErrorEvent:
-        this.reporter.sendDangerousTelemetryErrorEvent(
-          eventName,
-          properties,
-          measurements
-        );
+
+      case 'dangerousError':
+        this._reporter.sendDangerousTelemetryErrorEvent(name, props, measures);
         break;
-      default:
-        throw new Error('Invalid event type');
-    }
-  }
-  dispose() {
-    if (this.reporter) {
-      void this.reporter.dispose();
     }
   }
 }
 
-export const telemetry = new Telemetry();
+const telemetry = new Telemetry();
+
+export { telemetry, type TelemetryEventProperties };


### PR DESCRIPTION
[qt-lib: Introduce QT_SUPPRESS_TELEMETRY and QT_LOG_SUPPRESSED_TELEMETRY](https://github.com/qt-labs/vscodeext/pull/578/changes/de17f0db5fe7c3118fbafd8545ca7fad81893969)
[Keep telemetry data unaffected by testing and development](https://github.com/qt-labs/vscodeext/pull/578/changes/3854bf177f15f2ffcfb04332c880b18571317f7d)